### PR TITLE
Filtrado de servidores en la configuración

### DIFF
--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -522,7 +522,7 @@ def set_server_list():
     if server2 == 'Accept File':
         server_white_list.append('powvideo')
 
-    logger.info("set_server_list list %s" % server_white_list)
+    logger.info("set_server_list whiteList %s" % server_white_list)
 
     # denied servers
     if server1 == 'Block File':
@@ -530,7 +530,7 @@ def set_server_list():
     if server2 == 'Block File':
         server_black_list.append('powvideo')
 
-    logger.info("set_server_list list %s" % server_black_list)
+    logger.info("set_server_list blackList %s" % server_black_list)
     logger.info("pelisalacarta.platformcode.launcher.set_server_list end")
     return server_white_list, server_black_list
 

--- a/python/main-classic/resources/settings.conf
+++ b/python/main-classic/resources/settings.conf
@@ -163,3 +163,6 @@ personalchannelurl5=http://pelisalacarta.mimediacenter.info/personalchannel/samp
 personalchannelname5=Ejemplo de canal personal
 personalchannellogo5=http://pelisalacarta.mimediacenter.info/personalchannel/sample.png
 personalchannelpage5=100
+
+server1='Accept File'
+server2='Accept File'

--- a/python/main-classic/resources/settings.xml
+++ b/python/main-classic/resources/settings.xml
@@ -174,5 +174,14 @@
     <setting id="librarypath" type="text" label="30067" default=""/>
     <setting id="saved_searches_limit" type="enum" values="10|20|30|40" label="30024" default="0"/>
   </category>
+  
+  <category label="Server Filters">
+    <!--<setting label="Advance Setup (for 'AND' use space, for 'OR' use comma)" type="lsep"/>
+    <setting label="Accept File with:" type="text" id="movie_key_allowed" default=""/>
+    <setting label="Block File with:" type="text" id="movie_key_denied" default=""/>
+    <setting label="Easy Setup Keywords after the query" type="lsep"/>-->
+    <setting label="streamcloud" type="labelenum" id="server1" values="Accept File|Block File|Filter Off" default="Filter Off"/>
+    <setting label="powvideo" type="labelenum" id="server2" values="Accept File|Block File|Filter Off" default="Filter Off"/>
+  </category>
 
 </settings>


### PR DESCRIPTION
añadida funcionalidad en la configuración.
- en los enlaces, los servidores se filtraran tanto por listaBlanca, mostrando sólo los servidores válidos, como por listaNegra, no mostrando los que se encuentren en esta lista

Futuras mejoras:
- añadir los servidores de manera dinamica en la configuración obteniendolos de la carpeta "plugin.video.pelisalacarta\servers"
- añadir un campo de texto para añadir todo el filtro que queramos sin tener que realizar de uno en uno.
- obtener los nombres de los servidores de un array y recorrer los elementos en un bucle para formar la listaBlanca y la listaNegra.