### PR TITLE
Mejoras en el control parental (modo adulto)

### DIFF
--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -43,7 +43,10 @@ def run():
                 except:
                     pass
             '''
-
+            # Control parental: Desactivar Modo Adulto
+            config.set_setting("enableadultmode","false")
+            config.set_setting("adultpassword_introducida","")
+                
             import channelselector as plugin
             plugin.mainlist(params, url, category)
 
@@ -61,7 +64,7 @@ def run():
                 import xbmc
                 xbmc.executebuiltin( "Container.Refresh" )
 
-        elif (action=="channeltypes"):
+        elif (action=="channeltypes"):      
             import channelselector as plugin
             plugin.channeltypes(params,url,category)
 

--- a/python/main-classic/resources/settings.xml
+++ b/python/main-classic/resources/settings.xml
@@ -2,16 +2,21 @@
 <settings>
   <category label="General">
     <setting id="player_type" type="enum" values="Auto|MPlayer|DVDPlayer" label="30000" default="2"/>
-    <setting id="updatecheck2" type="bool" label="30001" default="true"/>
-    <setting id="updatechannels" type="bool" label="30004" default="true"/>
-    <setting id="updatelibrary" type="bool" label="30201" default="true"/>
-    <setting id="enableadultmode" type="bool" label="30002" default="false"/>
-    <setting id="debug" type="bool" label="30003" default="false"/>
+    <setting id="player_mode" type="enum" values="Direct|SetResolvedUrl|Built-In|Download and Play" label="30044" default="0"/>
     <setting id="default_action" type="enum" lvalues="30006|30007|30008|30009" label="30005" default="0"/>
     <setting id="thumbnail_type" type="enum" lvalues="30011|30012|30200" label="30010" default="2"/>
     <setting id="languagefilter" type="enum" lvalues="30025|30026|30027|30028|30029|30046|30016|30023|30036|30037" values="0|1|2|3|4" label="30019" default="0"/>
     <setting id="forceview" type="bool" label ="30043" default="false"/>
-    <setting id="player_mode" type="enum" values="Direct|SetResolvedUrl|Built-In|Download and Play" label="30044" default="0"/>
+    <setting id="debug" type="bool" label="30003" default="false"/>
+	<setting type="sep" />
+	<setting label="Modo Adulto" type="lsep" />
+	<setting id="adultpassword_introducida" type="text" label="Introduzca la contraseña" default=""/>
+	<setting id="enableadultmode" type="bool" label="30002" default="true" enable="eq(-1,1234)" subsetting="true"/>
+	<setting type="sep" />
+	<setting label="Actualizaciones" type="lsep" />
+	<setting id="updatecheck2" type="bool" label="30001" default="true"/>
+    <setting id="updatechannels" type="bool" label="30004" default="true"/>
+    <setting id="updatelibrary" type="bool" label="30201" default="true"/>
   </category>
   
   <!-- Login -->


### PR DESCRIPTION
Sin llegar a la funcionalidad que implemente en la version 3.9 (mas info en: http://www.mimediacenter.info/foro/viewtopic.php?f=14&t=6693#p24305), he añadido un poco mas de proteccion para nuestros menores.

El funcionamiento es el siguiente:
- Para Activar el Modo Adulto, ahora se ha de introducir antes una contraseña (por defecto 1234).
- Al salir de Kodi y volver a entrar por el Modo Adulto se desactiva automaticamente.

Para cambiar la contraseña podeis editar en el archivo resources/settings.xml la linea 14:
```<setting id="enableadultmode" type="bool" label="30002" default="true" enable="eq(-1,1234)" subsetting="true"/>```


