### PR TITLE
Update animeflv.py

### DIFF
--- a/python/main-classic/channels/animeflv.py
+++ b/python/main-classic/channels/animeflv.py
@@ -23,7 +23,6 @@ __type__ = "generic"
 __title__ = "Animeflv"
 __channel__ = "animeflv"
 __language__ = "ES"
-__creationdate__ = "20151024"
 
 host = "http://animeflv.net/"
 
@@ -72,9 +71,7 @@ animeflv.data.json
 '''
 
 
-# Cargar los datos con la librería 'requests'
 def get_page(url):
-
 
     response = requests.get(url)
     return response.status_code, response.content
@@ -510,42 +507,44 @@ def numbered_for_tratk(show, season, episode):
     :rtype: int, int
     """
     logger.info("pelisalacarta.channels.animeflv numbered_for_tratk")
+    show = show.lower()
 
     new_season = season
     new_episode = episode
     SERIES = {}
 
-    fname = os.path.join(config.get_runtime_path(), "channels", "animeflv.data.json")
+    name_file = os.path.splitext(os.path.basename(__file__))[0]
+    fname = os.path.join(config.get_data_path(), "channels", name_file + ".data.json")
+
     if os.path.isfile(fname):
         infile = open(fname, "rb")
         data = infile.read()
         infile.close()
-        # json_data = jsontools.loads(data)
         json_data = jsontools.load_json(data)
 
         if 'SERIES' in json_data:
             SERIES = json_data['SERIES']
 
-        # escapamos los caracteres raros si los hubiera en el key, ya que usamos el nombre de la serie como key
+        # ponemos en minusculas el key, ya que previamente hemos hecho lo mismo con show.
         for key in SERIES.keys():
-            new_key = re.escape(key)
+            new_key = key.lower()
             if new_key != key:
                 SERIES[new_key] = SERIES[key]
                 del SERIES[key]
 
-    if re.escape(show) in SERIES:
-        logger.info("ha encontrado algo: {0}".format(SERIES[re.escape(show)]))
+    if show in SERIES:
+        logger.info("ha encontrado algo: {0}".format(SERIES[show]))
 
-        if SERIES[re.escape(show)]['total_episode']:
-            for idx, valor in enumerate(SERIES[re.escape(show)]['total_episode']):
+        if SERIES[show]['total_episode']:
+            for idx, valor in enumerate(SERIES[show]['total_episode']):
 
                 if new_episode > valor:
                     new_episode -= valor
-                    new_season = SERIES[re.escape(show)]['season'][idx]
+                    new_season = SERIES[show]['season'][idx]
                     break
 
         else:
-            new_season = SERIES[re.escape(show)]['season']
+            new_season = SERIES[show]['season']
 
     logger.info("pelisalacarta.channels.animeflv numbered_for_tratk: {0}:{1}".format(new_season, new_episode))
     return new_season, new_episode

--- a/python/main-classic/channels/animeflv.xml
+++ b/python/main-classic/channels/animeflv.xml
@@ -6,10 +6,10 @@
 	<update_url></update_url>
 	<active>true</active>
 	<include_in_global_search>true</include_in_global_search>
-	<version>3</version>
+	<version>4</version>
 	<adult>false</adult>
-	<date>24/10/2015</date>
-    <changes>resueltos problemas utf, libreria requests, pep8 conventions, etc</changes>
+	<date>14/11/2015</date>
+    <changes>añadido mejoras para tratk.tv, si da error al mostrar los resultados, etc</changes>
 	<fanart></fanart>
 	<thumbnail></thumbnail>
 	<categories>


### PR DESCRIPTION
comento un poco por encima la necesidad de esta función, y luego explico su funcionamiento.

# PROBLEMA CONOCIDO
Si añadimos una serie de anime a la biblioteca y ponemos que nos coja la información del scraper `The TVDB`, tenemos un problema, ya que este sitio divide la misma serie en temporadas y en `animeflv` se usa el nombre completo.

Ejemplo: `Saint Seiya: Soul of Gold` es `Saint Seiya -> temporada 9`

Por lo que si queremos que usar el plugin de `tratk.tv` no se nos marcarían correctamente los episodios.

# SOLUCIÓN

Para ello he creado una función que gracias a un archivo de configuración `animeflv.data.json` (de momento es manual), renombre la temporada y episodio con los datos correctos para que posteriormente se marque de manera correcta el episodio en `tratk.tv`.

## EJEMPLO

Si vamos a la web `TheTVDB` y buscamos por ejemplo el anime [Fairy Tail](http://thetvdb.com/?tab=series&id=114801&lid=16), vemos que se compone de 6 temporadas, pero en `animeflv` está dividida en "dos series distintas" **Fairy Tail** y **Fairy Tail (2014)**

-  THETVDB
    - FAIRY TAIL:
        - SEASON 1: EPISODE 48 --> season 1: total_episode: 0
        - SEASON 2: EPISODE 48 --> season 2: total_episode: 48
        - SEASON 3: EPISODE 54 --> season 3: total_episode: 96 ( [48=season2] +[ 48=season1] )
        - SEASON 4: EPISODE 175 --> season 4: total_episode: 150 ( [54=season3] + [48=season2] + [48=season3] )
    
        *** LAS TEMPORADAS 5 Y 6 PERTENECEN A **FAIRY TAIL (2014)** { nombre que tiene en animeflv } ***
        - SEASON 5: EPISODE 51 --> season 5: total_episode: 0
        - SEASON 6: EPISODE xx --> season 6: total_episode: 51+xx ( [51=season5] )

El fichero `animeflv.data.json` tiene que estar dentro de `userdata`
Ejemplo: `C:\Users\NOMBRE_USUARIO\AppData\Roaming\Kodi\userdata\addon_data\plugin.video.pelisalacarta\channels`
Y la estructura sería de este modo:

```json
{
   "SERIES":{
      "Fairy Tail":{
         "season":[
            4,
            3,
            2,
            1
         ],
         "total_episode":[
            150,
            96,
            48,
            0
         ]
      },
      "Fairy Tail (2014)":{
         "season":[
            6,
            5
         ],
         "total_episode":[
            51,
            0
         ]
      }
   }
}
```

***Si hay varias temporadas en un mismo nombre de serie:***
 - season: debe ir en orden descendente
 - episode: la "temporada 1" siempre son "0 capitulos", la "temporada 2" es el "número de capitulos de la temporada 1", y así sucesivamente incrementando el número de episodios por las temporadas anteriores.


Me supongo que iran surgiendo dudas.