### PR TITLE
Error al iniciar en versión 4.0.4

### DIFF
--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -7,6 +7,7 @@
 
 import urllib, urllib2
 import os,sys
+import re
 
 from core import logger
 from core import config


### PR DESCRIPTION
la versión 4.0.4 la acabo de actualizar por el propio plugin, me da error al no encontrar la referencia de "re", se usa para el añadido de filtrar por servidores, la he añadido y ya tira el plugin.