### PR TITLE
Añade soporte para cuentas premium de filesmonster, mejoras en el canal Filesmonster Catalogue y cambios en el canal "cine tema gay"

### DIFF
--- a/python/main-classic/channels/cinetemagay.py
+++ b/python/main-classic/channels/cinetemagay.py
@@ -37,7 +37,7 @@ def mainlist(item):
     itemlist = []     
     itemlist.append( Item(channel=__channel__, action="lista"  , title="Cine gay latinoamericano" , url="http://cinegaylatinoamericano.blogspot.com.es/feeds/posts/default/?max-results=100&start-index=1",thumbnail="http://www.americaeconomia.com/sites/default/files/imagecache/foto_nota/homosexual1.jpg"))       
     itemlist.append( Item(channel=__channel__, action="lista"  , title="Cine y cortos gay" , url="http://cineycortosgay.blogspot.com.es/feeds/posts/default/?max-results=100&start-index=1",thumbnail="http://www.elmolar.org/wp-content/uploads/2015/05/cortometraje.jpg"))    
-    itemlist.append( Item(channel=__channel__, action="lista"  , title="Cine gay online (MÃ©xico)" , url="http://cinegayonlinemexico.blogspot.com.es/feeds/posts/default/?max-results=100&start-index=1",thumbnail="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTmmqL6tS2Ced1VoxlGQT0q-ibPEz1DCV3E1waHFDI5KT0pg1lJ"))                           
+    itemlist.append( Item(channel=__channel__, action="lista"  , title="Cine gay online (México)" , url="http://cinegayonlinemexico.blogspot.com.es/feeds/posts/default/?max-results=100&start-index=1",thumbnail="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTmmqL6tS2Ced1VoxlGQT0q-ibPEz1DCV3E1waHFDI5KT0pg1lJ"))                           
     itemlist.append( Item(channel=__channel__, action="lista"  , title="Sentido gay" , url="http://www.sentidogay.blogspot.com.es//feeds/posts/default/?max-results=100&start-index=1",thumbnail="http://1.bp.blogspot.com/-epOPgDD_MQw/VPGZGQOou1I/AAAAAAAAAkI/lC25GrukDuo/s1048/SentidoGay.jpg"))               
     itemlist.append( Item(channel=__channel__, action="lista"  , title="PGPA" , url="http://pgpa.blogspot.com.es/feeds/posts/default/?max-results=100&start-index=1",thumbnail="http://themes.googleusercontent.com/image?id=0BwVBOzw_-hbMNTRlZjk2YWMtYTVlMC00ZjZjLWI3OWEtMWEzZDEzYWVjZmQ4"))               
          
@@ -103,7 +103,7 @@ def lista(item):
     variable=str(variable)
     variable_url = item.url.split("index=")[0]
     url_nueva=variable_url+"index="+variable
-    itemlist.append( Item(channel=__channel__, action="lista", title="Ir a la pÃ¡gina siguiente (desde "+variable+")" , url=url_nueva , thumbnail="" , plot="Pasar a la pÃ¡gina siguiente (en grupos de 100)\n\n"+url_nueva) )
+    itemlist.append( Item(channel=__channel__, action="lista", title="Ir a la página siguiente (desde "+variable+")" , url=url_nueva , thumbnail="" , plot="Pasar a la pÃ¡gina siguiente (en grupos de 100)\n\n"+url_nueva) )
    
     return itemlist
 

--- a/python/main-classic/channels/cinetemagay.py
+++ b/python/main-classic/channels/cinetemagay.py
@@ -34,12 +34,11 @@ def isGeneric():
 def mainlist(item):
     logger.info("[cinetemagay.py] mainlist")
 
-    itemlist = []
-    itemlist.append( Item(channel=__channel__, action="lista"  , title="New latin queer channel" , url="http://newlatinqueerchannel.blogspot.com.es/feeds/posts/default/?max-results=100&start-index=1",thumbnail="http://2.bp.blogspot.com/-UmC0SWRlQbk/Uuc7G66FmMI/AAAAAAAADbg/fc2MIkJJBlw/s1600/banner%2Bnewlqch.png"))         
-    itemlist.append( Item(channel=__channel__, action="lista"  , title="Modo gay" , url="http://www.modogay.com/feeds/posts/default/?max-results=100&start-index=1",thumbnail="http://4.bp.blogspot.com/--oGFfDhcJg8/T4iGRMsNFOI/AAAAAAAABV4/oXKs9PMbrYU/s1600/mgbanner2.jpg"))         
-    itemlist.append( Item(channel=__channel__, action="lista"  , title="Cine gay online (México)" , url="http://cinegayonlinemexico.blogspot.com.es/feeds/posts/default/?max-results=100&start-index=1",thumbnail="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTmmqL6tS2Ced1VoxlGQT0q-ibPEz1DCV3E1waHFDI5KT0pg1lJ"))               
-    itemlist.append( Item(channel=__channel__, action="lista"  , title="Myquerchannel" , url="http://myqueerchannel.blogspot.com.es//feeds/posts/default/?max-results=100&start-index=1",thumbnail="http://1.bp.blogspot.com/-FKkBi7VyE-U/Tz7Le9vtQ5I/AAAAAAAAAd4/OXjxaycEPb8/s1600/myqueer.jpg"))               
-    itemlist.append( Item(channel=__channel__, action="lista"  , title="La videotecagay" , url="http://lavideotecagay.blogspot.com.es/feeds/posts/default/?max-results=100&start-index=1",thumbnail="https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcSqnVLvoiVXfrHAlvo6n9b-sokU35qDWQTn4IVVqS0lpTneSWIK"))               
+    itemlist = []     
+    itemlist.append( Item(channel=__channel__, action="lista"  , title="Cine gay latinoamericano" , url="http://cinegaylatinoamericano.blogspot.com.es/feeds/posts/default/?max-results=100&start-index=1",thumbnail="http://www.americaeconomia.com/sites/default/files/imagecache/foto_nota/homosexual1.jpg"))       
+    itemlist.append( Item(channel=__channel__, action="lista"  , title="Cine y cortos gay" , url="http://cineycortosgay.blogspot.com.es/feeds/posts/default/?max-results=100&start-index=1",thumbnail="http://www.elmolar.org/wp-content/uploads/2015/05/cortometraje.jpg"))    
+    itemlist.append( Item(channel=__channel__, action="lista"  , title="Cine gay online (MÃ©xico)" , url="http://cinegayonlinemexico.blogspot.com.es/feeds/posts/default/?max-results=100&start-index=1",thumbnail="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTmmqL6tS2Ced1VoxlGQT0q-ibPEz1DCV3E1waHFDI5KT0pg1lJ"))                           
+    itemlist.append( Item(channel=__channel__, action="lista"  , title="Sentido gay" , url="http://www.sentidogay.blogspot.com.es//feeds/posts/default/?max-results=100&start-index=1",thumbnail="http://1.bp.blogspot.com/-epOPgDD_MQw/VPGZGQOou1I/AAAAAAAAAkI/lC25GrukDuo/s1048/SentidoGay.jpg"))               
     itemlist.append( Item(channel=__channel__, action="lista"  , title="PGPA" , url="http://pgpa.blogspot.com.es/feeds/posts/default/?max-results=100&start-index=1",thumbnail="http://themes.googleusercontent.com/image?id=0BwVBOzw_-hbMNTRlZjk2YWMtYTVlMC00ZjZjLWI3OWEtMWEzZDEzYWVjZmQ4"))               
          
     return itemlist
@@ -79,6 +78,8 @@ def lista(item):
         scrapedtitle = match[3]
         scrapedtitle = scrapedtitle.replace("&apos;","'")
         scrapedtitle = scrapedtitle.replace("&quot;","'")
+        scrapedtitle = scrapedtitle.replace("&amp;amp;","'")
+        scrapedtitle = scrapedtitle.replace("&amp;#39;","'")
         scrapedurl = match[2]
         scrapedthumbnail = match[0]
         imagen = ""
@@ -93,7 +94,7 @@ def lista(item):
         scrapedplot = scrapedplot.replace("&amp;","")
         scrapedplot = scrapedplot.replace("nbsp;","")
         scrapedplot=strip_tags(scrapedplot)
-        itemlist.append( Item(channel=__channel__, action="detail", title=scrapedtitle , url=scrapedurl , thumbnail=scrapedthumbnail , plot=scrapedplot , folder=True) )
+        itemlist.append( Item(channel=__channel__, action="detail", title=scrapedtitle , url=scrapedurl , thumbnail=scrapedthumbnail , plot=scrapedurl+scrapedplot , folder=True) )
    
 
     variable = item.url.split("index=")[1]
@@ -102,7 +103,7 @@ def lista(item):
     variable=str(variable)
     variable_url = item.url.split("index=")[0]
     url_nueva=variable_url+"index="+variable
-    itemlist.append( Item(channel=__channel__, action="lista", title="Ir a la página siguiente (desde "+variable+")" , url=url_nueva , thumbnail="" , plot="Pasar a la página siguiente (en grupos de 100)\n\n"+url_nueva) )
+    itemlist.append( Item(channel=__channel__, action="lista", title="Ir a la pÃ¡gina siguiente (desde "+variable+")" , url=url_nueva , thumbnail="" , plot="Pasar a la pÃ¡gina siguiente (en grupos de 100)\n\n"+url_nueva) )
    
     return itemlist
 
@@ -110,67 +111,6 @@ def lista(item):
 
 
 
-
-
-
-
-def lista_2(item):
-    logger.info("[cinetemagay.py] lista")
-    itemlist = []
-
-   
-  
-         
-    # Descarga la pagina
-    data = scrapertools.cache_page(item.url)
-    #logger.info(data)
-
-
-
-    # Extrae las entradas (carpetas)
-   
-    patronvideos ='img.*?src="([^"]+)".*?' 
-    patronvideos += "<link rel='replies' type='text/html' href='([^']+)' title='([^']+)'/><link"
-
-    matches = re.compile(patronvideos,re.DOTALL).findall(data)
-
-
-    for match in matches:
-        scrapedtitle = "ver película"
-        scrapedtitle = scrapedtitle.replace("&apos;","'")
-        scrapedtitle = scrapedtitle.replace("@","a")
-		
-        scrapedtitle = scrapedtitle.replace("&quot;","'")
-        scrapedtitle = scrapedtitle.replace("&lt;h1&gt;","")
-        scrapedtitle = scrapedtitle.replace("&lt;/h1&gt;","")
-    
-        
-        scrapedurl = match[1]
-        scrapedthumbnail = match[0]
-        imagen = ""
-        scrapedplot = match[1]  
-        tipo = match[0]
-        if (DEBUG): logger.info("title=["+scrapedtitle+"], url=["+scrapedurl+"], thumbnail=["+scrapedthumbnail+"]")
-        scrapedplot = "<"+scrapedplot     
-        scrapedplot = scrapedplot.replace("&gt;",">")
-        scrapedplot = scrapedplot.replace("&lt;","<")
-        scrapedplot = scrapedplot.replace("</div>","\n")
-        scrapedplot = scrapedplot.replace("<br />","\n")
-        scrapedplot = scrapedplot.replace("&amp;","")
-        scrapedplot = scrapedplot.replace("nbsp;","")
-        scrapedplot=strip_tags(scrapedplot)
-        itemlist.append( Item(channel=__channel__, action="detail", title=scrapedtitle , url=scrapedurl , thumbnail=scrapedthumbnail , plot=scrapedplot , folder=True) )
-   
-
-    variable = item.url.split("index=")[1]
-    variable=int(variable)
-    variable+=100
-    variable=str(variable)
-    variable_url = item.url.split("index=")[0]
-    url_nueva=variable_url+"index="+variable
-    itemlist.append( Item(channel=__channel__, action="lista", title="Ir a la página siguiente (desde "+variable+")" , url=url_nueva , thumbnail="" , plot="Pasar a la página siguiente (en grupos de 100)\n\n"+url_nueva) )
-   
-    return itemlist
 
 
 
@@ -181,6 +121,13 @@ def detail(item):
 
     # Descarga la pagina
     data = scrapertools.cachePage(item.url)
+
+
+    data =data.replace("%3A", ":")
+    data =data.replace("%2F", "/")
+    data =data.replace("%3D", "=")   
+    data =data.replace("%3", "?")   
+    data =data.replace("%26", "&")
     descripcion = ""
     plot = ""
     patrondescrip = 'SINOPSIS:(.*?)'
@@ -199,28 +146,29 @@ def detail(item):
         except:
             plot = descripcion
 
+
+   
+        
     # Busca los enlaces a los videos de  servidores
     video_itemlist = servertools.find_video_items(data=data)
     for video_item in video_itemlist:
-        itemlist.append( Item(channel=__channel__ , action="play" , server=video_item.server, title=item.title+video_item.title,url=video_item.url, thumbnail=item.thumbnail, plot=item.plot, folder=False))
 
-    # Extrae los enlaces a los videos (Directo)
-    patronvideos = "file: '([^']+)'"
-    matches = re.compile(patronvideos,re.DOTALL).findall(data)
-    if len(matches)>0:
-        if not "www.youtube" in matches[0]:
-            itemlist.append( Item(channel=__channel__ , action="play" , server="Directo", title=item.title+" [directo]",url=matches[0], thumbnail=item.thumbnail, plot=item.plot))
+        itemlist.append( Item(channel=__channel__ , action="play" , server=video_item.server, title=item.title+"  "+video_item.title,url=video_item.url, thumbnail=item.thumbnail, plot=video_item.url, folder=False))
+
+
 
     return itemlist
 
 
-# Verificación automática de canales: Esta función debe devolver "True" si está ok el canal.
+
+
+# VerificaciÃ³n automÃ¡tica de canales: Esta funciÃ³n debe devolver "True" si estÃ¡ ok el canal.
 def test():
     from servers import servertools
     
     # mainlist
     mainlist_items = mainlist(Item())
-    # Da por bueno el canal si alguno de los vídeos de "Novedades" devuelve mirrors
+    # Da por bueno el canal si alguno de los vÃ­deos de "Novedades" devuelve mirrors
     onesite_items = lista(mainlist_items[0])
     bien = False
     for onesite_item in onesite_items:

--- a/python/main-classic/channels/filesmonster_catalogue.py
+++ b/python/main-classic/channels/filesmonster_catalogue.py
@@ -7,6 +7,8 @@
 import urlparse,urllib2,urllib,re
 import os,sys
 
+
+
 from core import logger
 from core import config
 from core import scrapertools
@@ -442,6 +444,7 @@ def detail_1(item):
 
 
 def detail(item):
+
     logger.info("[filesmonster_catalogue.py] detail")
     itemlist = []
 
@@ -449,13 +452,25 @@ def detail(item):
     data=scrapertools.downloadpageGzip(item.url)
     # descubre la url
     
-    
+    titulo=item.title.replace(" [abrir carpeta en filesmonster ]","")
+    contador=0
     patronvideos2  = 'http://filesmonster.com/download.php(.*?)".(.*?)'
     matches2 = re.compile(patronvideos2,re.DOTALL).findall(data)
     for match2 in matches2:
         scrapedurl2 ="http://filesmonster.com/download.php"+match2[0] 
+        contador=contador+1
+        contador_t=str(contador)
+       
+        itemlist.append( Item(channel=__channel__ , action="play" ,  plot=data ,  server="filesmonster", title="CONTENIDO "+contador_t+": "+titulo+" [ver en filesmonster]" ,url=scrapedurl2, thumbnail=item.thumbnail, folder=False))
+
+
+
+    patronvideos2  = 'http://filesmonster.com/folders.php(.*?)".(.*?)'
+    matches2 = re.compile(patronvideos2,re.DOTALL).findall(data)
+    for match2 in matches2:
+        scrapedurl2 ="http://filesmonster.com/folders.php"+match2[0] 
         
-        itemlist.append( Item(channel=__channel__ , action="play" ,  plot=data ,  server="filesmonster", title=item.title+" [ver en filesmonster]" ,url=scrapedurl2, thumbnail=item.thumbnail, folder=False))
+        itemlist.append( Item(channel=__channel__ , action="detail" ,  plot=data ,  title=item.title+" [abrir carpeta en filesmonster ]" ,url=scrapedurl2, thumbnail=item.thumbnail, folder=True))
 
 
     return itemlist
@@ -687,6 +702,15 @@ def detail_2(item):
 		
 
         itemlist.append( Item(channel=__channel__ , action="play" ,  plot=scrapedplot ,  server="filesmonster", title=item.title+" [ver en filesmonster]" ,url=scrapedurl2, thumbnail=scrapedthumbnail,  folder=False))
+
+
+
+    patronvideos2  = 'http://filesmonster.com/folders.php(.*?)".(.*?)'
+    matches2 = re.compile(patronvideos2,re.DOTALL).findall(data)
+    for match2 in matches2:
+        scrapedurl2 ="http://filesmonster.com/folders.php"+match2[0] 
+        
+        itemlist.append( Item(channel=__channel__ , action="detail" ,  plot=data ,  title=item.title+" [abrir carpeta en filesmonster ]" ,url=scrapedurl2, thumbnail=item.thumbnail, folder=True))
 
 
     return itemlist

--- a/python/main-classic/channels/filesmonster_catalogue.py
+++ b/python/main-classic/channels/filesmonster_catalogue.py
@@ -53,9 +53,9 @@ def menu_1(item):
 
     itemlist = []
     itemlist.append( Item(channel=__channel__, action="hetero"  ,  title="Categorías porno hetero" , thumbnail="http://photosex.biz/imager/w_400/h_500/e48337cd95bbb6c2c372ffa6e71441ac.jpg"))    
-    itemlist.append( Item(channel=__channel__, action="gay"  ,  title="Categorí­as porno gay y lesbian" , thumbnail="http://photosex.biz/imager/w_400/h_500/93df13c85224d428c195ea6581e7cdb3.jpg"))   
+    itemlist.append( Item(channel=__channel__, action="gay"  ,  title="Categorías porno gay y lesbian" , thumbnail="http://photosex.biz/imager/w_400/h_500/93df13c85224d428c195ea6581e7cdb3.jpg"))   
     itemlist.append( Item(channel=__channel__, action="bisex"  , title="Categorías porno bisex, trans y otras" , thumbnail="http://photosex.biz/imager/w_400/9dbaf07ad77788fd3d1f2f533bb25544.jpg"))     
-    itemlist.append( Item(channel=__channel__, action="lista_categoria"  ,  title="Listado global (todas las categorí­as)" ,  url="http://filesmonster.filesdl.net/posts/index/",  thumbnail="http://photosex.biz/imager/w_400/h_400/9f869c6cb63e12f61b58ffac2da822c9.jpg"))         
+    itemlist.append( Item(channel=__channel__, action="lista_categoria"  ,  title="Listado global (todas las categorías)" ,  url="http://filesmonster.filesdl.net/posts/index/",  thumbnail="http://photosex.biz/imager/w_400/h_400/9f869c6cb63e12f61b58ffac2da822c9.jpg"))         
     itemlist.append( Item(channel=__channel__, title="Búsqueda global"     , action="search") )
     return itemlist
 
@@ -216,7 +216,7 @@ def lista_categoria(item):
     pagina_despues=str(pagina+4)
     pagina=str(pagina)
     videos=str(cuantos_videos)
-    if (cuantos_videos==25): itemlist.append( Item(channel=__channel__, action="lista_categoria", title=">> siguientes (pÃ¡ginas "+pagina +" a "+pagina_despues+")", url=item.url , thumbnail="", plot=pagina , folder=True) )
+    if (cuantos_videos==25): itemlist.append( Item(channel=__channel__, action="lista_categoria", title=">> siguientes (páginas "+pagina +" a "+pagina_despues+")", url=item.url , thumbnail="", plot=pagina , folder=True) )
     itemlist.append( Item(channel=__channel__, action="mainlist", title="<< volver al inicio",  folder=True) )
   
 
@@ -306,7 +306,7 @@ def lista_buscar(item):
     pagina=plot+5
     pagina_despues=str(pagina+4)
     pagina=str(pagina)
-    if (cuantos_videos==25 ) : itemlist.append( Item(channel=__channel__, action="lista_buscar", title=">> siguientes resultados (pÃ¡ginas "+pagina +" a "+pagina_despues+")", url=texto , thumbnail="", plot=pagina , folder=True) )
+    if (cuantos_videos==25 ) : itemlist.append( Item(channel=__channel__, action="lista_buscar", title=">> siguientes resultados (páginas "+pagina +" a "+pagina_despues+")", url=texto , thumbnail="", plot=pagina , folder=True) )
     itemlist.append( Item(channel=__channel__, action="mainlist", title="<< volver al inicio",  folder=True) )
   
   
@@ -393,7 +393,7 @@ def search(item,texto):
     pagina=plot+5
     pagina_despues=str(pagina+4)
     pagina=str(pagina)
-    if (cuantos_videos==25 ) : itemlist.append( Item(channel=__channel__, action="lista_buscar", title=">> siguientes resultados (pÃ¡ginas "+pagina +" a "+pagina_despues+")", url=texto , thumbnail="", plot=pagina , folder=True) )
+    if (cuantos_videos==25 ) : itemlist.append( Item(channel=__channel__, action="lista_buscar", title=">> siguientes resultados (páginas "+pagina +" a "+pagina_despues+")", url=texto , thumbnail="", plot=pagina , folder=True) )
     itemlist.append( Item(channel=__channel__, action="mainlist", title="<< volver al inicio",  folder=True) )
   
   
@@ -487,7 +487,7 @@ def menu_2(item):
     itemlist = []
     itemlist.append( Item(channel=__channel__, action="categorias_2"  ,  url="hetero",  title="Categorías porno hetero" , thumbnail="http://photosex.biz/imager/w_400/h_500/e48337cd95bbb6c2c372ffa6e71441ac.jpg"))    
     itemlist.append( Item(channel=__channel__, action="categorias_2"  ,  url="gay",  title="Categorías porno gay, lesbian, bisexual" , thumbnail="http://photosex.biz/imager/w_400/h_500/93df13c85224d428c195ea6581e7cdb3.jpg"))        
-    itemlist.append( Item(channel=__channel__, action="categorias_2"  ,  url="", title="Todas las categorias" , thumbnail="http://photosex.biz/imager/w_400/9dbaf07ad77788fd3d1f2f533bb25544.jpg"))     
+    itemlist.append( Item(channel=__channel__, action="categorias_2"  ,  url="", title="Todas las categorÍas" , thumbnail="http://photosex.biz/imager/w_400/9dbaf07ad77788fd3d1f2f533bb25544.jpg"))     
     itemlist.append( Item(channel=__channel__, action="lista_categoria_2"  ,  title="Listado global (vídeos de todas las categorías)" ,  url="http://filesmonster.biz/index.php?page=1",  thumbnail="http://photosex.biz/imager/w_400/h_400/9f869c6cb63e12f61b58ffac2da822c9.jpg"))         
 
     return itemlist
@@ -663,7 +663,7 @@ def search_2(item,texto):
     pagina=str(pagina)
     pagina_inicial=str(pagina_inicial)
     url_siguiente=re.sub(pagina_inicial, pagina, url)
-    itemlist.append( Item(channel=__channel__, action="lista_categoria_2", title=">> siguientes [pagina "+pagina+"]",   url=url_siguiente, folder=True) )
+    itemlist.append( Item(channel=__channel__, action="lista_categoria_2", title=">> siguientes [página "+pagina+"]",   url=url_siguiente, folder=True) )
     itemlist.append( Item(channel=__channel__, action="mainlist_2", title="<< volver al inicio",  folder=True) )
     return itemlist
 

--- a/python/main-classic/resources/settings.xml
+++ b/python/main-classic/resources/settings.xml
@@ -41,6 +41,12 @@
     <setting id="alldebridpassword" type="text" option="hidden" label="30015" enable="!eq(-1,)+eq(-2,true)" default=""/>
 
     <setting type="sep" />
+    <setting id="filesmonsterpremium" type="bool" label="Filesmonster" default="false"/>
+    <setting id="filesmonsteruser" type="text" label="30014" enable="eq(-1,true)" default=""/>
+    <setting id="filesmonsterpassword" type="text" label="30015" option="hidden" enable="!eq(-1,)+eq(-2,true)" default=""/>
+
+
+    <setting type="sep" />
     <setting id="uploadedtopremium" type="bool" label="Uploaded.to" default="false"/>
     <setting id="uploadedtouser" type="text" label="30014"  enable="eq(-1,true)" default=""/>
     <setting id="uploadedtopassword" type="text" option="hidden" label="30015" enable="!eq(-1,)+eq(-2,true)" default=""/>

--- a/python/main-classic/servers/filesmonster.py
+++ b/python/main-classic/servers/filesmonster.py
@@ -14,7 +14,7 @@ from core import config
 
 
 def get_video_url( page_url , premium = False , user="" , password="", video_password="" ):
-    logger.info("[filesmonster.py] get_video_url( page_url='%s' , user='%s' , password='%s', video_password=%s)" )
+    logger.info("[filesmonster.py] get_video_url( page_url='%s')" )
     video_urls = []
     itemlist=[]
     data1=''

--- a/python/main-classic/servers/filesmonster.py
+++ b/python/main-classic/servers/filesmonster.py
@@ -1,26 +1,66 @@
 # -*- coding: utf-8 -*-
 #------------------------------------------------------------
 # pelisalacarta - XBMC Plugin
-# Conector para uploaz
+# Conector para filesmonster
 # http://blog.tvalacarta.info/plugin-xbmc/pelisalacarta/
 #------------------------------------------------------------
 
 import urlparse,urllib2,urllib,re
 import os
-
+import cookielib
 from core import scrapertools
 from core import logger
 from core import config
 
-def get_video_url( page_url , premium = False , user="" , password="", video_password="" ):
-    logger.info("[filesmonster.py] get_video_url(page_url='%s')" % page_url)
-    video_urls = []
-    return video_urls
 
-# Encuentra vídeos del servidor en el texto pasado
+def get_video_url( page_url , premium = False , user="" , password="", video_password="" ):
+    logger.info("[filesmonster.py] get_video_url( page_url='%s' , user='%s' , password='%s', video_password=%s)" )
+    video_urls = []
+    itemlist=[]
+    data1=''
+    data2=''
+    url=''
+    alerta='[filesmonster premium]'
+    enlace="no"
+    post2 = "username="+user+"&password="+password
+    login_url="http://filesmonster.com/api/public/login"
+    data1=scrapertools.cache_page(login_url, post=post2)
+    partes1=data1.split('"')
+    estado=partes1[3]
+    if estado!='success': alerta="[error de filesmonster premium]: "+estado
+    
+    id=page_url
+    id=id.replace("http://filesmonster.com/download.php","")
+    post=id.replace("?", "")
+    url = 'http://filesmonster.com/api/public/premiumDownload'
+    data2=scrapertools.cache_page(url, post=post)
+    
+    partes=data2.split('"')
+    url=partes[7]
+    if "http" not in url:alerta="[error de filesmonster premium]: "+url
+    
+    video_urls.append( [alerta ,url] )
+
+
+
+     
+		
+    return video_urls
+	
+
+    	
+	
+
+
+
+
+
+# Encuentra vÃ­deos del servidor en el texto pasado
 def find_videos(data):
     encontrados = set()
     devuelve = []
+
+
 
     # http://uploaz.com/file/
     patronvideos  = '"filesmonster.com/download(.*?)"'


### PR DESCRIPTION
Añade soporte para las cuentas premium de filesmonster para lo que se han modificado los archivos.

resources/setings.xml
servers/filesmonster.py

Usa la API pública de filesmonster para verificar si la cuenta es premium y para recuperar la dirección del vídeo en consecuencia. 

Si el login es incorrecto o la cuenta no es premium aparece el texto correspondiente, devuelto del jsonp de la API en la propia línea de para descargar (no he sabido hacer que aparezca un menú emergente jeje)

- Mejorado el canal Filesmonster catalogue, ahora permite mostar el contenido de carpetas con varios archivos en su interior

channels/filesmonster_calaogue.py

- Mejoras en el canal "cine tema gay", se eliminaron las fuentes no operativas y se añaden nuevas fuentes

channesl/cinetemagay.py