### PR TITLE
Fix okru

### DIFF
--- a/python/main-classic/servers/okru.py
+++ b/python/main-classic/servers/okru.py
@@ -27,13 +27,9 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
 
     data = scrapertools.cache_page(page_url.split('|')[0], headers=headers)
 
-    headers.append(['X-Requested-With', 'ShockwaveFlash/99.999.999.999'])
-    _headers = urllib.urlencode(dict(headers))
-
     # URL del vídeo
     for type, url in re.findall(r'\{"name":"([^"]+)","url":"([^"]+)"', data, re.DOTALL):
         url = url.replace("%3B", ";").replace(r"\u0026", "&")
-        url += '|' + _headers
         video_urls.append([type + " [okru]", url])
 
     return video_urls


### PR DESCRIPTION
Eliminada la variable _headers y su concatenación a la url.

No sé si ha habido algún cambio en el servidor, pero he probado varios vídeos de okru y ninguno me funcionaba con el conector actual. Al eliminar lo que comento ya los reproduce sin problemas en cualquier calidad, pero no sé si puede ser necesario en algún caso en particular. Lo subo a la espera de confirmarse si está correcto.