### PR TITLE
Fix cnubis

### DIFF
--- a/python/main-classic/servers/cnubis.py
+++ b/python/main-classic/servers/cnubis.py
@@ -22,7 +22,7 @@ def get_video_url( page_url , premium = False , user="" , password="", video_pas
     logger.info("media_url="+media_url[0])
 
     # URL del vídeo
-    video_urls.append( [ "."+ media_url[1] + " [cnubis]",media_url[0] ] )
+    video_urls.append( [ "."+ media_url[1] + " [cnubis]", media_url[0].replace("https","http") ] )
 
     for video_url in video_urls:
        logger.info("pelisalacarta.servers.cnubis %s - %s" % (video_url[0],video_url[1]))


### PR DESCRIPTION
Corregida la url que devuelve para evitar errores en versiones de Kodi 14.2 e inferiores debido a no poder conectarse a direcciones https. Gracias a @juanpintom por [comentarlo](https://github.com/tvalacarta/pelisalacarta/pull/128#issuecomment-181347799)