### PR TITLE
Hotfix_openload

### DIFF
--- a/python/main-classic/core/downloadtools.py
+++ b/python/main-classic/core/downloadtools.py
@@ -463,7 +463,7 @@ def downloadbest(video_urls,title,continuar=False):
     for elemento in invertida:
         videotitle = elemento[0]
         url = elemento[1]
-        logger.info("pelisalacarta.core.downloadtools Descargando opción "+title+" "+url)
+        logger.info("pelisalacarta.core.downloadtools Descargando opción "+title+" "+url.encode('ascii','ignore'))
         
         # Calcula el fichero donde debe grabar
         try:
@@ -558,7 +558,7 @@ def downloadfile(url,nombrefichero,headers=[],silent=False,continuar=False):
         # Crea el diálogo de progreso
         if not silent:
             progreso = xbmcgui.DialogProgress()
-            progreso.create( "plugin" , "Descargando..." , url , nombrefichero )
+            progreso.create( "plugin" , "Descargando..." , url.split("|")[0] , nombrefichero )
             #progreso.create( "plugin" , "Descargando..." , os.path.basename(nombrefichero)+" desde "+urlparse.urlparse(url).hostname )
         else:
             progreso = ""

--- a/python/main-classic/servers/openload.py
+++ b/python/main-classic/servers/openload.py
@@ -5,124 +5,88 @@
 # http://blog.tvalacarta.info/plugin-xbmc/pelisalacarta/
 # ------------------------------------------------------------
 
-import re, urllib2, cookielib, os
+import re
 from core import scrapertools
 from core import logger
 from core import config
 
            
-headers = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11',
-       'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-       'Accept-Charset': 'ISO-8859-1,utf-8;q=0.7,*;q=0.3',
-       'Accept-Encoding': 'none',
-       'Accept-Language': 'en-US,en;q=0.8',
-       'Connection': 'keep-alive'}
-
-ficherocookies = os.path.join( config.get_data_path(), 'cookies.dat' )
-cj = cookielib.MozillaCookieJar()
-urlopen = urllib2.urlopen
-Request = urllib2.Request
-
-
-if cj != None:
-    if os.path.isfile(ficherocookies):
-        cj.load(ficherocookies)
-    opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
-else:
-    opener = urllib2.build_opener()
-
-urllib2.install_opener(opener)
+headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:22.0) Gecko/20100101 Firefox/22.0',
+       'Accept-Encoding': 'none'}
 
 
 def test_video_exists(page_url):
     logger.info("[openload.py] test_video_exists(page_url='%s')" % page_url)
 
-    req = Request(page_url, '', headers)
-    response = urlopen(req, timeout=60)
-    data = response.read()
+    data = scrapertools.downloadpageWithoutCookies(page_url)
 
     if 'We are sorry!' in data:
         return False, 'File Not Found or Removed.'
 
     return True, ""
 
+def get_video_url(page_url, premium=False, user="", password="", video_password=""):
+    logger.info("[openload.py] url=" + page_url)
+    video_urls = []
 
-def decodeOpenLoad(html, video=True):
-    if video == True:
-        aastring = re.search(r"<video(?:.|\s)*?<script\s[^>]*?>((?:.|\s)*?)</script", html, re.DOTALL | re.IGNORECASE).group(1)
+    data = scrapertools.downloadpageWithoutCookies(page_url)
+
+    if "videocontainer" not in data:
+        url = page_url.replace("/embed/","/f/")
+        data = scrapertools.downloadpageWithoutCookies(url)
+        url, extension = decode(data, video=False)
+        video_urls.append([str(extension) + " [Openload]", url])          
     else:
-        aastring = re.search(r"Click to start Download(?:.|\s).*?<script\s[^>]*?>((?:.|\s)*?)</script", html, re.DOTALL | re.IGNORECASE).group(1)
-    
-    aastring = aastring.replace("((ﾟｰﾟ) + (ﾟｰﾟ) + (ﾟΘﾟ))", "9")
-    aastring = aastring.replace("((ﾟｰﾟ) + (ﾟｰﾟ))","8")
-    aastring = aastring.replace("((ﾟｰﾟ) + (o^_^o))","7")
-    aastring = aastring.replace("((o^_^o) +(o^_^o))","6")
-    aastring = aastring.replace("((ﾟｰﾟ) + (ﾟΘﾟ))","5")
-    aastring = aastring.replace("(ﾟｰﾟ)","4")
-    aastring = aastring.replace("((o^_^o) - (ﾟΘﾟ))","2")
-    aastring = aastring.replace("(o^_^o)","3")
-    aastring = aastring.replace("(ﾟΘﾟ)","1")
-    aastring = aastring.replace("(c^_^o)","0")
-    aastring = aastring.replace("(ﾟДﾟ)[ﾟεﾟ]","\\")
-    aastring = aastring.replace("(3 +3 +0)","6")
-    aastring = aastring.replace("(3 - 1 +0)","2")
-    aastring = aastring.replace("(!+[]+!+[])","2")
-    aastring = aastring.replace("(-~-~2)","4")
-    aastring = aastring.replace("(-~-~1)","3")
-    aastring = aastring.replace("(+!+[])","1")
-    aastring = aastring.replace("(0+0)","0")
+        url, extension = decode(data)
+        video_urls.append([str(extension) + " [Openload]", url])
 
-    decodestring = re.search(r"\\\+([^(]+)", aastring, re.DOTALL | re.IGNORECASE).group(1)
-    decodestring = "\\+"+ decodestring
-    decodestring = decodestring.replace("+","")
-    decodestring = decodestring.replace(" ","")
+    return video_urls
+
+def decode(data, video=True):
+    if video == True:
+        text_encode = scrapertools.get_match(data,"<video[^<]+<script[^>]+>(.*?)</script>")
+    else:
+        text_encode = scrapertools.get_match(data,"Click to start Download.*?<script[^>]+>(.*?)</script")
     
-    decodestring = decode(decodestring)
-    decodestring = decodestring.replace("\\/","/")
+    text = re.sub(r"\s+", "", text_encode)
+    text = text \
+        .replace("(ﾟДﾟ)[ﾟoﾟ]","|") \
+        .replace("((ﾟｰﾟ)+(ﾟｰﾟ)+(ﾟΘﾟ))", "9") \
+        .replace("((ﾟｰﾟ)+(ﾟｰﾟ))", "8") \
+        .replace("((ﾟｰﾟ)+(o^_^o))", "7") \
+        .replace("((o^_^o)+(o^_^o))", "6") \
+        .replace("((ﾟｰﾟ)+(ﾟΘﾟ))", "5") \
+        .replace("(ﾟｰﾟ)", "4") \
+        .replace("((o^_^o)-(ﾟΘﾟ))", "2") \
+        .replace("(o^_^o)", "3") \
+        .replace("(ﾟΘﾟ)", "1") \
+        .replace("(c^_^o)", "0") \
+        .replace("(ﾟДﾟ)[ﾟεﾟ]", ",") \
+        .replace("(3+3+0)", "6") \
+        .replace("(3-1+0)", "2") \
+        .replace("(!+[]+!+[])", "2") \
+        .replace("(-~-~2)", "4") \
+        .replace("(-~-~1)", "3") \
+        .replace("(+!+[])", "1") \
+        .replace("(0+0)", "0")
+    text = re.sub(r"\+", "", text).split('|')[2]
+
+    for n in text[1:].split(','):
+        text = text.replace(',%s' % n, chr(int(n, 8)))
 
     #Header para la descarga
     header_down = "|User-Agent="+headers['User-Agent']+"|"
     if video == True:
-        videourl = re.search(r"vr='([^']+)'", decodestring, re.DOTALL | re.IGNORECASE).group(1)
+        videourl = scrapertools.find_single_match(text, "vr='([^']+)'")
         videourl = scrapertools.get_header_from_response(videourl,header_to_get="location")
         videourl = videourl.replace("https://","http://").replace("?mime=true","")
         extension = videourl[-4:]
         return videourl+header_down+extension, extension
     else:
-        videourl = re.search(r'"href", \'([^\']+)\'', decodestring, re.DOTALL | re.IGNORECASE).group(1)
+        videourl = scrapertools.find_single_match(text, '"href", \'([^\']+)\'')
         videourl = videourl.replace("https://","http://")
         extension = videourl[-4:]
         return videourl+header_down+extension, extension
-
-def decode(encoded):
-    for octc in (c for c in re.findall(r'\\(\d{2,3})', encoded)):
-        encoded = encoded.replace(r'\%s' % octc, chr(int(octc, 8)))
-    return encoded.decode('utf8')
-
-
-def get_video_url(page_url, premium=False, user="", password="", video_password=""):
-    logger.info("[openload.py] url=" + page_url)
-    video_urls = []
-    req = Request(page_url, '', headers)
-    response = urlopen(req, timeout=60)
-    data = response.read()
-    if "videocontainer" not in data:
-        url = page_url.replace("/embed/","/f/")
-        req = Request(url, '', headers)
-        response = urlopen(req, timeout=60)
-        data = response.read()
-        cj.save(ficherocookies)
-        response.close()
-        url, extension = decodeOpenLoad(data, video=False)
-        video_urls.append([str(extension) + " [Openload]", url])          
-    else:
-        cj.save(ficherocookies)
-        response.close()
-        url, extension = decodeOpenLoad(data)
-        video_urls.append([str(extension) + " [Openload]", url])
-
-    return video_urls
-
 
 # Encuentra vídeos del servidor en el texto pasado
 def find_videos(text):

--- a/python/main-classic/servers/openload.py
+++ b/python/main-classic/servers/openload.py
@@ -37,7 +37,9 @@ urllib2.install_opener(opener)
 def test_video_exists(page_url):
     logger.info("[openload.py] test_video_exists(page_url='%s')" % page_url)
 
-    data = scrapertools.cache_page(page_url, headers=headers)
+    req = Request(page_url, '', headers)
+    response = urlopen(req, timeout=60)
+    data = response.read()
 
     if 'We are sorry!' in data:
         return False, 'File Not Found or Removed.'
@@ -64,8 +66,11 @@ def decodeOpenLoad(html, video=True):
     aastring = aastring.replace("(ﾟДﾟ)[ﾟεﾟ]","\\")
     aastring = aastring.replace("(3 +3 +0)","6")
     aastring = aastring.replace("(3 - 1 +0)","2")
-    aastring = aastring.replace("(1 -0)","1")
-    aastring = aastring.replace("(4 -0)","4")
+    aastring = aastring.replace("(!+[]+!+[])","2")
+    aastring = aastring.replace("(-~-~2)","4")
+    aastring = aastring.replace("(-~-~1)","3")
+    aastring = aastring.replace("(+!+[])","1")
+    aastring = aastring.replace("(0+0)","0")
 
     decodestring = re.search(r"\\\+([^(]+)", aastring, re.DOTALL | re.IGNORECASE).group(1)
     decodestring = "\\+"+ decodestring
@@ -76,14 +81,16 @@ def decodeOpenLoad(html, video=True):
     decodestring = decodestring.replace("\\/","/")
 
     #Header para la descarga
-    header_down = "|User-Agent=Mozilla/5.0 (Windows NT 10.0; WOW64; rv:43.0) Gecko/20100101 Firefox/43.0|"
+    header_down = "|User-Agent="+headers['User-Agent']+"|"
     if video == True:
-        videourl = re.search(r'vr ="([^"]+)"', decodestring, re.DOTALL | re.IGNORECASE).group(1)
-        extension = re.search(r'vt ="([^"]+)"', decodestring, re.DOTALL | re.IGNORECASE).group(1)
+        videourl = re.search(r"vr='([^']+)'", decodestring, re.DOTALL | re.IGNORECASE).group(1)
         videourl = scrapertools.get_header_from_response(videourl,header_to_get="location")
+        videourl = videourl.replace("https://","http://").replace("?mime=true","")
+        extension = videourl[-4:]
         return videourl+header_down+extension, extension
     else:
-        videourl = re.search(r'\'href\',"([^"]+)"', decodestring, re.DOTALL | re.IGNORECASE).group(1)
+        videourl = re.search(r'"href", \'([^\']+)\'', decodestring, re.DOTALL | re.IGNORECASE).group(1)
+        videourl = videourl.replace("https://","http://")
         extension = videourl[-4:]
         return videourl+header_down+extension, extension
 


### PR DESCRIPTION
-Corregido openload por cambios en la página. (solución gracias al addon Ultimate Whitecream)

-Cambios menores en downloadtools para que no se produzca un error de encode en el logger y para que en el diálogo de descarga solo aparezca la url y no las cabeceras adicionales, ya que impiden leerlo por completo.