### PR TITLE
Modificados metodos logger.error y logger.debug.

### DIFF
--- a/python/main-classic/core/logger.py
+++ b/python/main-classic/core/logger.py
@@ -32,6 +32,13 @@ def info(texto):
 def debug(texto):
     if loggeractive:
         try:
+            import inspect
+            import os
+            last=inspect.stack()[1]
+            modulo= os.path.basename(os.path.splitext(last[1])[0])
+            funcion= last [3]
+            texto= "    [" + modulo + "." + funcion + "] " + texto
+            xbmc.log("######## DEBUG #########")
             xbmc.log(texto)
         except:
             validchars = " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!#$%&'()-@[]^_`{}~."
@@ -41,6 +48,13 @@ def debug(texto):
 def error(texto):
     if loggeractive:
         try:
+            import inspect
+            import os
+            last=inspect.stack()[1]
+            modulo= os.path.basename(os.path.splitext(last[1])[0])
+            funcion= last [3]
+            texto= "    [" + modulo + "." + funcion + "] " + texto
+            xbmc.log("######## ERROR #########")
             xbmc.log(texto)
         except:
             validchars = " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!#$%&'()-@[]^_`{}~."


### PR DESCRIPTION
Al llamar a uno de estos metodos automaticamente insertan en el archivo log las siguientes lineas:
######## ERROR ######## o ######## DEBUG ########
    [MODULO.FUNCION] MENSAJE pasado como parametro

Donde MODULO y FUNCION son el modulo (archivo py)  y la funcion o procedimiento desde el que se invoca a logger

El metodo logger.info queda como siempre.
En principio solo es para Kodi, pero si se acepta esta modificacion se podria pasar al resto de plataformas.