### PR TITLE
Cambios cuando se reproduce desde strm o desde la librería

### DIFF
--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -201,18 +201,24 @@ def run():
 
                     logger.info("item.server=#"+item.server+"#")
                     # Ejecuta find_videos, del canal o común
-                    try:
-                        itemlist = channel.findvideos(item)
-
-                        if config.get_setting('filter_servers') == 'true':
-                            itemlist = filtered_servers(itemlist, server_white_list, server_black_list) 
-
-                    except:
-                        from servers import servertools
-                        itemlist = servertools.find_video_items(item)
-
-                        if config.get_setting('filter_servers') == 'true':
-                            itemlist = filtered_servers(itemlist, server_white_list, server_black_list) 
+                    if item.server != "":
+                        try:
+                            from servers import servertools
+                            videourls = servertools.resolve_video_urls_for_playing(server=item.server, url=item.url, video_password=item.video_password)
+                            return videourls
+                        except:
+                            itemlist = []
+                            pass						
+                    else:
+                        try:
+                            itemlist = channel.findvideos(item)
+                            if config.get_setting('filter_servers') == 'true':
+                                itemlist = filtered_servers(itemlist, server_white_list, server_black_list) 
+                        except:
+                            from servers import servertools
+                            itemlist = servertools.find_video_items(item)
+                            if config.get_setting('filter_servers') == 'true':
+                                itemlist = filtered_servers(itemlist, server_white_list, server_black_list)
 
                     if len(itemlist)>0:
                         #for item2 in itemlist:


### PR DESCRIPTION
Propuesta a raíz de este [tema](http://www.mimediacenter.info/foro/viewtopic.php?f=22&t=7382) para modificar el launcher.py cuando el action es strm_detail o play_from_library. Se cambia el orden, en lugar de buscar primero en el findvideos del canal, se pasa a servertools el server y la url del vídeo y si no los tuviera los buscaría por medio del canal.

