### PR TITLE
Referente a PR 163 por cambios en reproducción desde la librería

### DIFF
--- a/python/main-classic/core/item.py
+++ b/python/main-classic/core/item.py
@@ -46,7 +46,7 @@ class Item(object):
         kwargs.setdefault("password", "")           #Password del video
 
         kwargs.setdefault("folder", True)           #Carpeta o vídeo
-        kwargs.setdefault("server", "directo")      #Servidor que contiene el vídeo
+        kwargs.setdefault("server", "")      #Servidor que contiene el vídeo
         kwargs.setdefault("extra", "")              #Datos extra
         
         kwargs.setdefault("language", "")           #Idioma del contenido


### PR DESCRIPTION
Los cambios de ese PR se hicieron para que cuando se reprodujese desde la librería comprobase en un primer momento si el item.server tenía algún valor para así directamente buscar con servertools el enlace al vídeo. El problema es que actualmente el Item.py le da al parámetro server el valor por defecto de "directo" por lo que si se agrega una serie/película a la librería sin especificar el server, éste se guardará como directo en el .strm e intentará buscar el enlace con servertools cuando seguramente no debería.

La idea es cambiar el valor por defecto del server a cadena vacía. Esto no afectaría a la reproducción del vídeo ya que al comienzo de la función play_video de xbmctools, se comprueba si el server="" y en ese caso se le da el valor de directo.