### PR TITLE
Fix descargas seriesblanco

### DIFF
--- a/python/main-classic/channels/seriesblanco.json
+++ b/python/main-classic/channels/seriesblanco.json
@@ -6,8 +6,8 @@
             "serie", 
             "vos"
         ], 
-        "changes": "Arreglado el findVindeos, añadido strip() en el nombre de las series", 
-        "date": "02/03/2016", 
+        "changes": "Arreglado la sección descargas de findVideos de seriesblanco", 
+        "date": "18/03/2016", 
         "fanart": "", 
         "id": "seriesblanco", 
         "include_in_global_search": false, 
@@ -15,7 +15,7 @@
         "name": "Seriesblanco", 
         "thumbnail": "", 
         "update_url": "", 
-        "version": "8.1"
+        "version": "9.0"
     }, 
     "settings": {}
 }

--- a/python/main-classic/channels/seriesblanco.json
+++ b/python/main-classic/channels/seriesblanco.json
@@ -15,7 +15,7 @@
         "name": "Seriesblanco", 
         "thumbnail": "", 
         "update_url": "", 
-        "version": "8.0"
+        "version": "8.1"
     }, 
     "settings": {}
 }

--- a/python/main-classic/channels/seriesblanco.py
+++ b/python/main-classic/channels/seriesblanco.py
@@ -199,10 +199,23 @@ def episodios(item):
     return itemlist
 
 
+def parseVideos(item, typeStr, data):
+    itemlist = []
+    links = re.findall('<tr.+?<span>(.+?)</span>.*?banderas/([^\.]+).+?href="([^"]+).+?servidores/([^\.]+).*?</td>.*?<td>.*?<span>(.+?)</span>.*?<span>(.*?)</span>.*?</tr>', data, re.MULTILINE | re.DOTALL)
+
+    for date, language, link, server, uploader, quality in links:
+        if not quality:
+            quality = "SD"
+        title = "{0} en {1} [{2}] [{3}] ({4}: {5})".format(typeStr, server, IDIOMAS[language],
+                                                           quality, uploader, date)
+
+        itemlist.append(Item(channel=__channel__, title=title, url=urlparse.urljoin(HOST, link), action="play",
+                             show=item.show))
+    return itemlist
+
+
 def findvideos(item):
     logger.info("pelisalacarta.seriesblanco findvideos")
-
-    itemlist = []
 
     # Descarga la página
     data = scrapertools.cache_page(item.url)
@@ -213,28 +226,7 @@ def findvideos(item):
 
     online = re.findall('<table class="as_gridder_table">(.+?)</table>', data, re.MULTILINE | re.DOTALL)
 
-    links = re.findall('<tr.+?<span>(.+?)</span>.*?banderas/([^\.]+).+?href="([^"]+).+?servidores/([^\.]+).*?</td>.*?<td>.*?<span>(.+?)</span>.*?<span>(.*?)</span>.*?</tr>', online[0], re.MULTILINE | re.DOTALL)
-
-    for date, language, link, server, uploader, quality in links:
-        if not quality:
-            quality = "SD"
-        title = "{0} en {1} [{2}] [{3}] ({4}: {5})".format("Ver", server, IDIOMAS[language],
-                                                           quality, uploader, date)
-
-        itemlist.append(Item(channel=__channel__, title=title, url=urlparse.urljoin(HOST, link), action="play",
-                             show=item.show))
-
-    links = re.findall('<tr.+?<span>(.+?)</span>.*?banderas/([^\.]+).+?href="([^"]+).+?servidores/([^\.]+).*?</td>.*?<td>.*?<span>(.+?)</span>.*?<span>(.*?)</span>.*?</tr>', online[0], re.MULTILINE | re.DOTALL)
-
-    for date, language, link, server, uploader, quality in links:
-        if not quality:
-            quality = "SD"
-        title = "{0} en {1} [{2}] [{3}] ({4}: {5})".format("Descargar", server, IDIOMAS[language],
-                                                           quality, uploader, date)
-        itemlist.append(Item(channel=__channel__, title=title, url=urlparse.urljoin(HOST, link), action="play",
-                             show=item.show))
-
-    return itemlist
+    return parseVideos(item, "Ver", online[0]) + parseVideos(item, "Descargar", online[1])
 
 
 def play(item):

--- a/python/main-classic/channels/seriesblanco.xml
+++ b/python/main-classic/channels/seriesblanco.xml
@@ -12,9 +12,9 @@
 	<bannermenu>http://media.tvalacarta.info/pelisalacarta/bannermenu/seriesblanco.png</bannermenu>
 
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/channels/</update_url>
-	<version>8</version>
-	<date>02/03/2016</date>
-	<changes>- Arreglado el findVindeos, añadido strip() en el nombre de las series</changes>
+	<version>9</version>
+	<date>18/03/2016</date>
+	<changes>- Arreglado la sección descargas de findVideos de seriesblanco</changes>
 
 	<categories>
 		<category>serie</category>


### PR DESCRIPTION
Estaba mal puesto el parseo de las descargas (se usaba de nuevo los datos de los streams online, en vez de las descargas)