### PR TITLE
Subtítulos embebidos en servidores

### DIFF
--- a/python/main-classic/platformcode/xbmctools.py
+++ b/python/main-classic/platformcode/xbmctools.py
@@ -362,7 +362,10 @@ def play_video(channel="",server="",url="",category="",title="", thumbnail="",pl
     # Ha elegido uno de los vídeos
     elif seleccion < len(video_urls):
         mediaurl = video_urls[seleccion][1]
-        if len(video_urls[seleccion])>2:
+        if len(video_urls[seleccion])>3:
+            wait_time = video_urls[seleccion][2]
+            subtitle = video_urls[seleccion][3]
+        elif len(video_urls[seleccion])>3:
             wait_time = video_urls[seleccion][2]
         else:
             wait_time = 0

--- a/python/main-classic/platformcode/xbmctools.py
+++ b/python/main-classic/platformcode/xbmctools.py
@@ -490,7 +490,7 @@ def play_video(channel="",server="",url="",category="",title="", thumbnail="",pl
         titulo = fulltitle
         if fulltitle=="":
             titulo = title
-        library.savelibrary(titulo,url,thumbnail,server,plot,canal=channel,category=category,Serie=Serie)
+        library.savelibrary(titulo,url,thumbnail,server,plot,canal=channel,category=category,Serie=Serie,subtitle=subtitle)
         advertencia = xbmcgui.Dialog()
         resultado = advertencia.ok(config.get_localized_string(30101) , fulltitle , config.get_localized_string(30135)) # 'se ha añadido a la lista de descargas'
         return

--- a/python/main-classic/platformcode/xbmctools.py
+++ b/python/main-classic/platformcode/xbmctools.py
@@ -365,7 +365,7 @@ def play_video(channel="",server="",url="",category="",title="", thumbnail="",pl
         if len(video_urls[seleccion])>3:
             wait_time = video_urls[seleccion][2]
             subtitle = video_urls[seleccion][3]
-        elif len(video_urls[seleccion])>3:
+        elif len(video_urls[seleccion])>2:
             wait_time = video_urls[seleccion][2]
         else:
             wait_time = 0

--- a/python/main-classic/platformcode/xbmctools.py
+++ b/python/main-classic/platformcode/xbmctools.py
@@ -569,7 +569,7 @@ def play_video(channel="",server="",url="",category="",title="", thumbnail="",pl
 
     # Lanza el reproductor
         # Lanza el reproductor
-    if strmfile:  # Si es un fichero strm no hace falta el play
+    if strmfile and server != "torrent": #Si es un fichero strm no hace falta el play
         logger.info("b6")
         import sys
         xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, xlistitem)

--- a/python/main-classic/servers/openload.py
+++ b/python/main-classic/servers/openload.py
@@ -42,6 +42,7 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
         text_encode = scrapertools.get_match(data,"<video[^<]+<script[^>]+>(.*?)</script>")
         text_decode = decode(data)
 
+    subtitle = scrapertools.find_single_match(data, '<track kind="captions" src="([^"]+)" srclang="es"')
     #Header para la descarga
     header_down = "|User-Agent="+headers['User-Agent']+"|"
     if video == True:
@@ -49,7 +50,7 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
         videourl = scrapertools.get_header_from_response(videourl,header_to_get="location")
         videourl = videourl.replace("https://","http://").replace("?mime=true","")
         extension = videourl[-4:]
-        video_urls.append([ extension + " [Openload]", videourl+header_down+extension])
+        video_urls.append([ extension + " [Openload]", videourl+header_down+extension, 0, subtitle])
     else:
         videourl = scrapertools.find_single_match(text_decode, '"href",(?:\s|)\'([^\']+)\'')
         videourl = videourl.replace("https://","http://")


### PR DESCRIPTION
A raíz de ver que en el canal pelispedia creado por SeiTaN hay muchos enlaces de openload con subtítulos embebidos en su reproductor, he modificado el conector de openload y xbmctools para añadir esa opción y  se pueda utilizar en otros conectores si se da el caso.