### PR TITLE
Mejoras updater.py

### DIFF
--- a/python/main-classic/channelselector.py
+++ b/python/main-classic/channelselector.py
@@ -40,30 +40,9 @@ def getmainlist(preferred_thumb=""):
 # TODO: (3.1) Pasar el código específico de XBMC al laucher
 def mainlist(params,url,category):
     logger.info("channelselector.mainlist")
-
-    # Verifica actualizaciones solo en el primer nivel
-    if config.get_platform()!="boxee":
-
-        try:
-            from core import updater
-        except ImportError:
-            logger.info("channelselector.mainlist No disponible modulo actualizaciones")
-        else:
-            if config.get_setting("updatecheck2") == "true":
-                logger.info("channelselector.mainlist Verificar actualizaciones activado")
-                try:
-                    updater.checkforupdates()
-                except:
-                    import xbmcgui
-                    dialog = xbmcgui.Dialog()
-                    dialog.ok("No se puede conectar","No ha sido posible comprobar","si hay actualizaciones")
-                    logger.info("channelselector.mainlist Fallo al verificar la actualización")
-                    pass
-            else:
-                logger.info("channelselector.mainlist Verificar actualizaciones desactivado")
-
+    
     itemlist = getmainlist()
-	#Se devuelve el itemlist para que xbmctools se encarge de mostrarlo
+    #Se devuelve el itemlist para que xbmctools se encarge de mostrarlo
     return itemlist
 
 def getchanneltypes(preferred_thumb=""):

--- a/python/main-classic/core/updater.py
+++ b/python/main-classic/core/updater.py
@@ -13,17 +13,6 @@ import time
 import config
 import logger
 
-# FIXME: Esto está repetido en el channelselector, debería ir a config
-thumbnail_type = config.get_setting("thumbnail_type")
-if thumbnail_type=="":
-    thumbnail_type="2"
-logger.info("thumbnail_type="+thumbnail_type)
-if thumbnail_type=="0":
-    IMAGES_PATH = 'http://media.tvalacarta.info/pelisalacarta/posters/'
-elif thumbnail_type=="1":
-    IMAGES_PATH = 'http://media.tvalacarta.info/pelisalacarta/banners/'
-elif thumbnail_type=="2":
-    IMAGES_PATH = 'http://media.tvalacarta.info/pelisalacarta/squares/'
 
 ROOT_DIR = config.get_runtime_path()
 
@@ -31,52 +20,20 @@ REMOTE_VERSION_FILE = "http://descargas.tvalacarta.info/"+config.PLUGIN_NAME+"-v
 LOCAL_VERSION_FILE = os.path.join( ROOT_DIR , "version.xml" )
 LOCAL_FILE = os.path.join( ROOT_DIR , config.PLUGIN_NAME+"-" )
 
-try:
-    # Añadida a la opcion : si plataforma xbmcdharma es "True", no debe ser con la plataforma de la xbox
-    # porque seria un falso "True", ya que el xbmc en las xbox no son dharma por lo tanto no existen los addons
-    logger.info("pelisalacarta.core.updater get_platform="+config.get_platform())
-    logger.info("pelisalacarta.core.updater get_system_platform="+config.get_system_platform())
-    if config.get_platform()=="kodi-jarvis":
-        import xbmc
-        REMOTE_FILE = "http://descargas.tvalacarta.info/"+config.PLUGIN_NAME+"-kodi-jarvis-"
-        DESTINATION_FOLDER = xbmc.translatePath( "special://home/addons")
-    elif config.get_platform()=="kodi-isengard":
-        import xbmc
-        REMOTE_FILE = "http://descargas.tvalacarta.info/"+config.PLUGIN_NAME+"-kodi-isengard-"
-        DESTINATION_FOLDER = xbmc.translatePath( "special://home/addons")
-    elif config.get_platform()=="kodi-helix":
-        import xbmc
-        REMOTE_FILE = "http://descargas.tvalacarta.info/"+config.PLUGIN_NAME+"-kodi-helix-"
-        DESTINATION_FOLDER = xbmc.translatePath( "special://home/addons")
-    elif config.get_platform()=="xbmc-eden":
-        import xbmc
-        REMOTE_FILE = "http://descargas.tvalacarta.info/"+config.PLUGIN_NAME+"-xbmc-eden-"
-        DESTINATION_FOLDER = xbmc.translatePath( "special://home/addons")
-    elif config.get_platform()=="xbmc-frodo":
-        import xbmc
-        REMOTE_FILE = "http://descargas.tvalacarta.info/"+config.PLUGIN_NAME+"-xbmc-frodo-"
-        DESTINATION_FOLDER = xbmc.translatePath( "special://home/addons")
-    elif config.get_platform()=="xbmc-gotham":
-        import xbmc
-        REMOTE_FILE = "http://descargas.tvalacarta.info/"+config.PLUGIN_NAME+"-xbmc-gotham-"
-        DESTINATION_FOLDER = xbmc.translatePath( "special://home/addons")
-    elif config.get_platform()=="xbmc":
-        import xbmc
-        REMOTE_FILE = "http://descargas.tvalacarta.info/"+config.PLUGIN_NAME+"-xbmc-plugin-"
-        DESTINATION_FOLDER = xbmc.translatePath( "special://home/plugins/video")
-    elif config.get_platform()=="wiimc":
-        REMOTE_FILE = "http://descargas.tvalacarta.info/"+config.PLUGIN_NAME+"-wiimc-"
-        DESTINATION_FOLDER = os.path.join(config.get_runtime_path(),"..")
-    elif config.get_platform()=="rss":
-        REMOTE_FILE = "http://descargas.tvalacarta.info/"+config.PLUGIN_NAME+"-rss-"
-        DESTINATION_FOLDER = os.path.join(config.get_runtime_path(),"..")
+#DESTINATION_FOLDER sera siempre el lugar donde este la carpeta del plugin,
+#No hace falta "xbmc.translatePath", get_runtime_path() ya tiene que devolver la ruta correcta
+DESTINATION_FOLDER = os.path.join(config.get_runtime_path(),"..")
 
-except:
-    import xbmc
-    REMOTE_FILE = "http://descargas.tvalacarta.info/"+config.PLUGIN_NAME+"-xbmc-plugin-"
-    DESTINATION_FOLDER = xbmc.translatePath( os.path.join( ROOT_DIR , ".." ) )
+#Todas las plataformas son "pelisalacarta-nombre-plataforma-version.zip" excepto para xbmc que es "pelisalacarta-xbmc-plugin-version.zip"
+if config.get_platform()=="xbmc":
+  REMOTE_FILE = "http://descargas.tvalacarta.info/%s-%s-" % ("xbmc-plugin", config.get_platform())
 
-def checkforupdates(plugin_mode=True):
+else:
+  REMOTE_FILE = "http://descargas.tvalacarta.info/%s-%s-" % (config.PLUGIN_NAME, config.get_platform())
+  
+
+
+def checkforupdates():
     logger.info("pelisalacarta.core.updater checkforupdates")
 
     # Descarga el fichero con la versión en la web
@@ -84,31 +41,17 @@ def checkforupdates(plugin_mode=True):
     logger.info("pelisalacarta.core.updater Version remota: "+REMOTE_VERSION_FILE)
     data = scrapertools.cachePage( REMOTE_VERSION_FILE )
 
-    '''    
-    <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-    <version>
-            <name>pelisalacarta</name>
-            <tag>4.0     </tag>
-            <version>4000</tag>
-            <date>20/03/2015</date>
-            <changes>New release</changes>
-    </version>
-    '''
-
     version_publicada = scrapertools.find_single_match(data,"<version>([^<]+)</version>").strip()
     tag_publicada = scrapertools.find_single_match(data,"<tag>([^<]+)</tag>").strip()
     logger.info("pelisalacarta.core.updater version remota="+tag_publicada+" "+version_publicada)
     
     # Lee el fichero con la versión instalada
-    localFileName = LOCAL_VERSION_FILE
-    logger.info("pelisalacarta.core.updater fichero local version: "+localFileName)
-    infile = open( localFileName )
-    data = infile.read()
-    infile.close();
-    #logger.info("xml local="+data)
+    logger.info("pelisalacarta.core.updater fichero local version: "+LOCAL_VERSION_FILE)
+    data = open(LOCAL_VERSION_FILE).read()
 
     version_local = scrapertools.find_single_match(data,"<version>([^<]+)</version>").strip()
     tag_local = scrapertools.find_single_match(data,"<tag>([^<]+)</tag>").strip()
+    
     logger.info("pelisalacarta.core.updater version local="+tag_local+" "+version_local)
 
     try:
@@ -117,90 +60,32 @@ def checkforupdates(plugin_mode=True):
     except:
         import traceback
         logger.info(traceback.format_exc())
-        version_publicada = ""
-        version_local = ""
-
-    if version_publicada=="" or version_local=="":
-        arraydescargada = tag_publicada.split(".")
-        arraylocal = tag_local.split(".")
-
-        # local 2.8.0 - descargada 2.8.0 -> no descargar
-        # local 2.9.0 - descargada 2.8.0 -> no descargar
-        # local 2.8.0 - descargada 2.9.0 -> descargar
-        if len(arraylocal) == len(arraydescargada):
-            logger.info("caso 1")
-            hayqueactualizar = False
-            for i in range(0, len(arraylocal)):
-                print arraylocal[i], arraydescargada[i], int(arraydescargada[i]) > int(arraylocal[i])
-                if int(arraydescargada[i]) > int(arraylocal[i]):
-                    hayqueactualizar = True
-        # local 2.8.0 - descargada 2.8 -> no descargar
-        # local 2.9.0 - descargada 2.8 -> no descargar
-        # local 2.8.0 - descargada 2.9 -> descargar
-        if len(arraylocal) > len(arraydescargada):
-            logger.info("caso 2")
-            hayqueactualizar = False
-            for i in range(0, len(arraydescargada)):
-                #print arraylocal[i], arraydescargada[i], int(arraydescargada[i]) > int(arraylocal[i])
-                if int(arraydescargada[i]) > int(arraylocal[i]):
-                    hayqueactualizar = True
-        # local 2.8 - descargada 2.8.8 -> descargar
-        # local 2.9 - descargada 2.8.8 -> no descargar
-        # local 2.10 - descargada 2.9.9 -> no descargar
-        # local 2.5 - descargada 3.0.0
-        if len(arraylocal) < len(arraydescargada):
-            logger.info("caso 3")
-            hayqueactualizar = True
-            for i in range(0, len(arraylocal)):
-                #print arraylocal[i], arraydescargada[i], int(arraylocal[i])>int(arraydescargada[i])
-                if int(arraylocal[i]) > int(arraydescargada[i]):
-                    hayqueactualizar =  False
-                elif int(arraylocal[i]) < int(arraydescargada[i]):
-                    hayqueactualizar =  True
-                    break
+        version_publicada = None
+        version_local = None
+    
+    hayqueactualizar = False
+    #Si no tenemos la versión, comprobamos el tag
+    if version_publicada is None or version_local is None:
+        logger.info("pelisalacarta.core.updater comprobando el tag")
+        from distutils.version import StrictVersion
+        hayqueactualizar = StrictVersion(tag_publicada) > StrictVersion(tag_local)
+        
     else:
-        hayqueactualizar = (numero_version_publicada > numero_version_local)
+        logger.info("pelisalacarta.core.updater comprobando la version")
+        hayqueactualizar = numero_version_publicada > numero_version_local
 
+    #Si hay actualización disponible, devuelve la Nueva versión para que cada plataforma se encargue de mostrar los avisos
     if hayqueactualizar:
-    
-        if plugin_mode:
-    
-            logger.info("pelisalacarta.core.updater actualizacion disponible")
-            
-            # Añade al listado de XBMC
-            import xbmcgui
-            thumbnail = IMAGES_PATH+"Crystal_Clear_action_info.png"
-            logger.info("thumbnail="+thumbnail)
-            listitem = xbmcgui.ListItem( "Descargar version "+tag_publicada, thumbnailImage=thumbnail )
-            itemurl = '%s?action=update&version=%s' % ( sys.argv[ 0 ] , tag_publicada )
-            import xbmcplugin
-            xbmcplugin.addDirectoryItem( handle = int(sys.argv[ 1 ]), url = itemurl , listitem=listitem, isFolder=True)
-            
-            # Avisa con un popup
-            dialog = xbmcgui.Dialog()
-            dialog.ok("Versión "+tag_publicada+" disponible","Ya puedes descargar la nueva versión del plugin\ndesde el listado principal")
+        return  tag_publicada
+    else:
+      return None
 
-        else:
 
-            import xbmcgui
-            yes_pressed = xbmcgui.Dialog().yesno( "Versión "+tag_publicada+" disponible" , "¿Quieres instalarla?" )
-
-            if yes_pressed:
-                params = {"version":tag_publicada}
-                update(params)
-
-    '''
-    except:
-        logger.info("No se han podido verificar actualizaciones...")
-        import sys
-        for line in sys.exc_info():
-            logger.error( "%s" % line )
-    '''
-def update(params):
+def update(item):
     # Descarga el ZIP
     logger.info("pelisalacarta.core.updater update")
-    remotefilename = REMOTE_FILE+params.get("version")+".zip"
-    localfilename = LOCAL_FILE+params.get("version")+".zip"
+    remotefilename = REMOTE_FILE+item.version+".zip"
+    localfilename = LOCAL_FILE+item.version+".zip"
     logger.info("pelisalacarta.core.updater remotefilename=%s" % remotefilename)
     logger.info("pelisalacarta.core.updater localfilename=%s" % localfilename)
     logger.info("pelisalacarta.core.updater descarga fichero...")

--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -58,19 +58,36 @@ def run():
         if ( item.action=="selectchannel" ):
             import channelselector
             itemlist = channelselector.mainlist(params, item.url, item.category)
+            
+            # Verifica actualizaciones solo en el primer nivel
+            if config.get_setting("updatecheck2") == "true":
+              logger.info("channelselector.mainlist Verificar actualizaciones activado")
+              from core import updater
+              try:
+                version = updater.checkforupdates()
+                
+                if version:
+                  import xbmcgui
+                  advertencia = xbmcgui.Dialog()
+                  advertencia.ok("Versión "+version+" disponible","Ya puedes descargar la nueva versión del plugin\ndesde el listado principal")
+                  itemlist.insert(0,Item(title="Descargar version "+version, version=version, channel="updater", action="update", thumbnail=channelselector.get_thumbnail_path() + "Crystal_Clear_action_info.png"))
+              except:
+                import xbmcgui
+                advertencia = xbmcgui.Dialog()
+                advertencia.ok("No se puede conectar","No ha sido posible comprobar","si hay actualizaciones")
+                logger.info("channelselector.mainlist Fallo al verificar la actualización")
+
+            else:
+              logger.info("channelselector.mainlist Verificar actualizaciones desactivado")
+                
             from platformcode import xbmctools
             xbmctools.renderItems(itemlist, item)
 
         # Actualizar version
-        elif ( item.action=="update" ):
-            try:
-                from core import updater
-                updater.update(params)
-            except ImportError:
-                logger.info("pelisalacarta.platformcode.launcher Actualizacion automática desactivada")
-
-            #import channelselector as plugin
-            #plugin.listchannels(params, url, category)
+        elif (item.action=="update"):
+   
+            from core import updater
+            updater.update(item)
             if config.get_system_platform()!="xbox":
                 import xbmc
                 xbmc.executebuiltin( "Container.Refresh" )

--- a/python/main-ui/default.py
+++ b/python/main-ui/default.py
@@ -40,7 +40,27 @@ plugintools.log("pelisalacarta 4 ui begin")
 config.verify_directories_created()
 
 # Check for new updates
-updater.checkforupdates(plugin_mode=False)
+if config.get_setting("updatecheck2") == "true":
+  logger.info("Verificar actualizaciones activado")
+  from core import updater
+  try:
+    version = updater.checkforupdates()
+    
+    if version:
+      import xbmcgui
+      yes_pressed = xbmcgui.Dialog().yesno( "Versión "+version+" disponible" , "¿Quieres instalarla?" )
+
+      if yes_pressed:
+          item = Item(version=version)
+          updater.update(item)
+  except:
+    import xbmcgui
+    advertencia = xbmcgui.Dialog()
+    advertencia.ok("No se puede conectar","No ha sido posible comprobar","si hay actualizaciones")
+    logger.info("channelselector.mainlist Fallo al verificar la actualización")
+
+else:
+  logger.info("channelselector.mainlist Verificar actualizaciones desactivado")
 
 # Get items for main menu
 item = Item( channel="navigation", action="mainlist" )


### PR DESCRIPTION
He echo una serie de cambios para el updater.py, para que funcione en la versión mediaserver, que da error al comprobar actualizaciones ya que el updater actual esta pensado para kodi

Para que funcione en la versión mediaserver este PR hay que mergearlo en la rama develop y en la rama develop-mediaserver

luego en la rama develop-mediaserver hay que mergear otro PR que he creado que modifica el launcher especifico para mediaserver...

he quitado todo lo relacionado con Kodi del updater, solo comprueba la versión y si hay una versión nueva devuelve el numero de la nueva versión, luego, es cada plataforma que se encarga de mostrar el aviso a su manera, creo que así dará menos problemas

