### PR TITLE
[mediaserver] Acceder desde fuera de la red local

### DIFF
--- a/python/version-mediaserver/platformcode/controllers/fileserver.py
+++ b/python/version-mediaserver/platformcode/controllers/fileserver.py
@@ -21,7 +21,7 @@ class fileserver(Controller):
         self.handler.send_header('Content-type', 'text/html')
         self.handler.end_headers()
         respuesta = f.read()
-        respuesta = respuesta.replace("{$host}","ws://"+config.get_local_ip() + ":"+config.get_setting("websocket.port")+"/")
+        respuesta = respuesta.replace("{$WSPORT}", config.get_setting("websocket.port"))
         self.handler.wfile.write(respuesta)
         f.close()
         

--- a/python/version-mediaserver/platformcode/template/page.html
+++ b/python/version-mediaserver/platformcode/template/page.html
@@ -165,5 +165,5 @@
   </body>
 </html>
 <script>
-    WebSocketHost = 'ws://' + window.location.hostname + '{$WSPORT}/'
+    WebSocketHost = 'ws://' + window.location.hostname + ':{$WSPORT}'
 </script>

--- a/python/version-mediaserver/platformcode/template/page.html
+++ b/python/version-mediaserver/platformcode/template/page.html
@@ -165,5 +165,5 @@
   </body>
 </html>
 <script>
-    WebSocketHost = '{$host}'
+    WebSocketHost = 'ws://' + window.location.hostname + '{$WSPORT}/'
 </script>


### PR DESCRIPTION
Cambio para poder usar pelisalacarta desde fuera de la red local.

El hosthane lo podemos sacar en la propia web vía javascript, con ello ya se puede conectar desde fuera (obviamente, siempre que estén rederigidos los puertos que sean)