### PR TITLE
[configuración por canales] - Varias correcciones

### DIFF
--- a/python/main-classic/core/channeltools.py
+++ b/python/main-classic/core/channeltools.py
@@ -166,7 +166,7 @@ def get_channel_setting(name, channel):
         except EnvironmentError:
             logger.info("ERROR al leer el archivo: {0}".format(file_settings))
 
-    if len(dict_settings) == 0 or dict_settings.has_key(name):
+    if len(dict_settings) == 0 or not dict_settings.has_key(name):
         # Obtenemos controles del archivo ../channels/channel.xml
         from core import channeltools
         try:

--- a/python/main-classic/platformcode/platformtools.py
+++ b/python/main-classic/platformcode/platformtools.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #------------------------------------------------------------
 # pelisalacarta - XBMC Plugin
 # platformtools
@@ -81,4 +81,4 @@ def show_channel_settings(list_controls=None, dict_values=None, caption="", call
     Parametros: ver descripcion en xbmc_config_menu.SettingsWindow
     '''
     from xbmc_config_menu import SettingsWindow
-    return SettingsWindow("ChannelSettings.xml", config.get_runtime_path()).Start(list_controls=list_controls, values=dict_values, title=caption, callback=callback, item=item)
+    return SettingsWindow("ChannelSettings.xml", config.get_runtime_path()).Start(list_controls=list_controls, dict_values=dict_values, title=caption, callback=callback, item=item)

--- a/python/main-classic/platformcode/xbmc_config_menu.py
+++ b/python/main-classic/platformcode/xbmc_config_menu.py
@@ -130,7 +130,7 @@ class SettingsWindow(xbmcgui.WindowXMLDialog):
             Así abre la ventana con los controles pasados y los valores de dict_values, si no se pasa dict_values, carga los valores por defecto de los controles,
             cuando le das a aceptar, llama a la función 'cb' del canal desde donde se ha llamado, pasando como parámetros, el ítem y el dict_values
     '''
-    def Start(self, list_controls=None, values=None, title="Opciones", callback=None, item = None):
+    def Start(self, list_controls=None, dict_values=None, title="Opciones", callback=None, item = None):
         logger.info("[xbmc_config_menu] start")
 
         #Ruta para las imagenes de la ventana
@@ -138,7 +138,7 @@ class SettingsWindow(xbmcgui.WindowXMLDialog):
 
         #Capturamos los parametros
         self.list_controls = list_controls
-        self.values = values
+        self.values = dict_values
         self.title = title
         self.callback = callback
         self.item = item
@@ -384,7 +384,7 @@ class SettingsWindow(xbmcgui.WindowXMLDialog):
                     self.values[id] = default
 
                 value = self.values[id]
-                logger.info(str(type(config.get_setting(id,self.channel))))
+                
             if ctype == "bool":
                 c["default"] = bool(c["default"])
                 self.values[id] = bool(self.values[id])
@@ -486,6 +486,9 @@ class SettingsWindow(xbmcgui.WindowXMLDialog):
         #Ponemos el foco en el primer control
         self.setFocus(self.controls[0]["control"])
         self.evaluate_conditions()
+        self.check_default()
+        self.check_ok(self.values)
+        
 
 
     def MoveUp(self):
@@ -625,7 +628,27 @@ class SettingsWindow(xbmcgui.WindowXMLDialog):
         self.getControl(10009).setPosition(self.getControl(10008).getX(), scrollbar_y)
         self.getControl(10009).setHeight(scrollbar_height)
         self.evaluate_conditions()
+    
+    def check_ok(self, dict_values=None):
+      if not self.callback:
+        if dict_values: 
+          self.init_values = dict_values.copy()
+          self.getControl(10004).setEnabled(False)
+          
+        else:
+          if self.init_values == self.values:
+            self.getControl(10004).setEnabled(False)
+          else:
+            self.getControl(10004).setEnabled(True)
+        
+    def check_default(self):
+      def_values = dict([[c["id"], c["default"]] for c in self.controls])
 
+      if def_values == self.values:
+        self.getControl(10006).setEnabled(False)
+      else:
+        self.getControl(10006).setEnabled(True)
+        
     def onClick(self, id):
         #Valores por defecto
         if id == 10006:
@@ -637,8 +660,12 @@ class SettingsWindow(xbmcgui.WindowXMLDialog):
                     c["control"].setSelected(c["default"])
                     self.values[c["id"]] = c["default"]
                 if c["type"] == "list":
-                    c["label"].setLabel(c["default"])
+                    c["label"].setLabel(c["lvalues"][c["default"]])
                     self.values[c["id"]] = c["default"]
+                    
+            self.evaluate_conditions()
+            self.check_default()
+            self.check_ok()
 
         #Boton Cancelar y [X]
         if id == 10003 or id == 10005:
@@ -652,7 +679,13 @@ class SettingsWindow(xbmcgui.WindowXMLDialog):
               self.close()
             else:
               self.close()
-              exec "from channels import " + self.channel + " as cb_channel"
+              try:
+                exec "from channels import " + self.channel + " as cb_channel"
+              except:
+                  try:
+                    exec "from core import " + self.channel + " as cb_channel"
+                  except:
+                      logger.error ('Imposible importar %s' % self.channel )
               exec "self.return_value =  cb_channel." + self.callback + "(self.item,self.values)"
 
 
@@ -688,7 +721,9 @@ class SettingsWindow(xbmcgui.WindowXMLDialog):
             #Si esl control es un "text", guardamos el nuevo valor
             if cont["type"] == "text" and cont["control"] == control: self.values[cont["id"]] = cont["control"].getText()
 
-            self.evaluate_conditions()
+        self.evaluate_conditions()
+        self.check_default()
+        self.check_ok()
 
     def onAction(self, action):
             #Accion 1: Flecha derecha


### PR DESCRIPTION
Detectados los siguientes errores:
- [x] Cuando le damos al botón Por defecto da un error en los controles tipo 'list'.
- [x] Cuando le damos al botón Por defecto no evalúa correctamente visible/enabled.
- [x] Cuando pulsamos sobre un control se llama a evaluate_conditions() una vez por cada control de la lista, cuando solo es necesario llamarlo una vez. 
- [x] Se cambia el nombre del parámetro values por dict_values, para ser coherentes con la documentación.
- [x] El canal solo puede estar en la carpeta channels. Solución permitir tb canales q estén el la carpeta core
- [x] El botón Aceptar está activo aunque no hayamos modificado ningún valor. Solución: activar el botón solo si el valor de algún control ha cambiado desde que se abrió la ventana
- [x] El botón Por Defecto está activo aunque los valores actuales sean los de por defecto. Solución: activar el botón solo si el valor de algún control es diferente a los valores por defecto
- [x] Añadir parámetro "byindex" en controles list, su valor por defecto es True, si se cambia a False, el valor default debe ser un string con una de las opciones de lvalues, y cuando le demos a Aceptar, el valor retornado será el valor seleccionado y no el indice

gracias a @superberny70 por la detección de los fallos y sus correcciones.
