### PR TITLE
Errata en xbmctools

### DIFF
--- a/python/main-classic/platformcode/xbmctools.py
+++ b/python/main-classic/platformcode/xbmctools.py
@@ -35,7 +35,7 @@ import xbmcplugin
 from core import config
 from core import logger
 from platformcode import library
-from channel import descargas
+from channels import descargas
 
 # Esto permite su ejecución en modo emulado
 try:


### PR DESCRIPTION
Pequeña errata en el import que me he encontrado al probar develop y da error nada más entrar al addon ;)

Aunque no sé si es mejor mantener ese import o no, ya que más abajo se repite...