### PR TITLE
Reparado conector realdebrid

### DIFF
--- a/python/main-classic/servers/realdebrid.py
+++ b/python/main-classic/servers/realdebrid.py
@@ -15,6 +15,7 @@ from core import jsontools
 from core import logger
 from core import scrapertools
 
+DEBUG = config.get_setting("debug")
 
 headers = {'User-Agent' : 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:47.0) Gecko/20100101 Firefox/47.0',
            'Accept' : 'application/json, text/javascript, */*; q=0.01',
@@ -57,7 +58,11 @@ def get_video_url( page_url , premium = False , user="" , password="", video_pas
     if matchjs != "":
         while not re.search(r'var tokenBearer', matchjs, re.DOTALL):
             matchjs = unpack(matchjs)
-        token_auth = scrapertools.find_single_match(matchjs, "tokenBearer='([^']+)'")
+            if DEBUG: logger.info("Script token:\n" + matchjs)
+        matches = scrapertools.find_multiple_matches(matchjs, "tokenBearer(?:=|\+=)'([^']+)'")
+        token_auth = ""
+        for token in matches:
+            token_auth += token
     
     headers.pop('Cookie', None)
     headers['Authorization'] = "Bearer %s" % token_auth

--- a/python/main-classic/servers/realdebrid.py
+++ b/python/main-classic/servers/realdebrid.py
@@ -6,95 +6,62 @@
 #------------------------------------------------------------
 
 import re
+import requests
+import time
 import urllib
-import urllib2
 
+from core import config
+from core import jsontools
 from core import logger
 from core import scrapertools
 
 
+headers = {'User-Agent' : 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:47.0) Gecko/20100101 Firefox/47.0',
+           'Accept' : 'application/json, text/javascript, */*; q=0.01',
+           'Accept-Language' : 'es-ES,es;q=0.8,en-US;q=0.5,en;q=0.3',
+           'Accept-Encoding' : 'gzip, deflate, br',
+           'Connection' : 'keep-alive',
+           'Referer' : 'https://real-debrid.com/',
+           'Cookie' : 'cookie_accept=y; https=1; lang=es;',
+           'X-Requested-With' : 'XMLHttpRequest'}
+
 # Returns an array of possible video url's from the page_url
 def get_video_url( page_url , premium = False , user="" , password="", video_password="" ):
-    logger.info("pelisalacarta.servers.realdebrid get_video_url( page_url='%s' , user='%s' , password='%s', video_password=%s)" % (page_url , user , "**************************"[0:len(password)] , video_password) )
-    page_url = correct_url(page_url)
+    logger.info("pelisalacarta.servers.realdebrid get_video_url( page_url='%s' , user='%s' , password='%s', video_password=%s)"
+                % (page_url , user , "**************************"[0:len(password)] , video_password))
+
     # Hace el login y consigue la cookie
-    post = urllib.urlencode({'user' : user, 'pass' : password})
-    login_url = 'https://real-debrid.com/ajax/login.php?'+post
+    params = urllib.urlencode([('user', user), ('pass', password), ('pin_challenge', ''),
+                               ('pin_answer', 'PIN: 0000'), ('time', int(time.time())) ])
+    login_url = 'https://real-debrid.com/ajax/login.php?%s' % params
     
-    data = scrapertools.cache_page(url=login_url)
-    if data is None or not re.search('expiration', data) or not re.search(user, data):
-        
-        # Hace el login y consigue la cookie
-        post = urllib.urlencode({'user' : user, 'pass' : password})
-        login_url = 'https://real-debrid.com/ajax/login.php?'+post
-    
-        data = scrapertools.cache_page(url=login_url)
-        if re.search('OK', data):
-            logger.info("Se ha logueado correctamente en Real-Debrid ")
-        else:
-            patron = 'message":"(.+?)"'
-            matches = re.compile(patron).findall(data)
-            if len(matches)>0:
-                server_error = "REAL-DEBRID: "+urllib.unquote_plus(matches[-1].replace("\\u00","%"))
-            else:
-                server_error = "REAL-DEBRID: Ha ocurrido un error con tu login"
-            return server_error
+    data = requests.get(login_url, headers=headers).text
+    data = jsontools.load_json(data)
+    if 'error' in data and data['error'] == 0:
+        logger.info("pelisalacarta.servers.realdebrid Se ha logueado correctamente")
+        cookie_auth = data['cookie']
     else:
-        logger.info("Ya estas logueado en Real-Debrid")
+        error_message = data['message'].decode('utf-8','ignore')
+        if error_message != "":
+            server_error = "REAL-DEBRID: " + error_message
+        else:
+            server_error = "REAL-DEBRID: Ha ocurrido un error con tu login"
 
-    url = 'https://real-debrid.com/ajax/unrestrict.php?link=%s&password=%s' % (urllib.quote(page_url), video_password)
-    req = urllib2.Request(url)
-    req.add_header('Cookie',"cookie_accept=y; https=1; lang=es; auth="+scrapertools.find_single_match(data,'auth=(.*?);'))
-    response = urllib2.urlopen(req)
-    data=response.read()
-    response.close()
+        return server_error
 
-    data = data.replace('{"error":-1,"message":"Old API used, please upgrade: https:\/\/api.real-debrid.com"}',"")
-    listaDict=load_json(data)
-    if 'main_link' in listaDict :
-        return listaDict['main_link'].encode('utf-8')
-    else :
-        if 'message' in listaDict :
-            msg = listaDict['message'].decode('utf-8','ignore')
+    headers['Cookie'] = headers['Cookie'] + cookie_auth 
+    params = urllib.urlencode([('link', page_url), ('pass', video_password),
+                               ('remote', '0'), ('time', int(time.time())) ])
+    url = 'https://real-debrid.com/ajax/unrestrict.php?%s' % params
+    data = requests.get(url, headers=headers).text
+    data = jsontools.load_json(data)
+
+    if 'main_link' in data:
+        return data['main_link'].encode('utf-8')
+    else:
+        if 'message' in data:
+            msg = data['message'].decode('utf-8','ignore')
             server_error = "REAL-DEBRID: " + msg
             return server_error
-        else :
-            return "REAL-DEBRID: No generated_link and no main_link"
-    
-
-def correct_url(url):
-    if "userporn.com" in url:
-        url = url.replace("/e/","/video/")
-    
-    if "putlocker" in url:
-        url = url.replace("/embed/","/file/")
-    return url
-
-def load_json(data):
-    # callback to transform json string values to utf8
-    def to_utf8(dct):
-        
-        rdct = {}
-        for k, v in dct.items() :			
-            if isinstance(v, (str, unicode)):
-                rdct[k] = v.encode('utf8', 'ignore')
-            else :
-                rdct[k] = v
-        
-        return rdct
-
-    try:
-        import json
-    except:
-        try:
-            import simplejson as json
-        except:
-            from lib import simplejson as json
-
-    try :       
-        json_data = json.loads(data, object_hook=to_utf8)
-        return json_data
-    except:
-        import sys
-        for line in sys.exc_info():
-            logger.error( "%s" % line )
+        else:
+            return "REAL-DEBRID: No se ha generado ningún enlace"

--- a/python/main-classic/servers/realdebrid.xml
+++ b/python/main-classic/servers/realdebrid.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" ?>
 <server>
 	<active>false</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>Corregido al haberse desactivado la api que se usaba</changes>
+	<date>14/06/2016</date>
 	<free>false</free>
 	<id>realdebrid</id>
 	<name>Real-Debrid</name>
 	<premium></premium>
 	<thumbnail>http://media.tvalacarta.info/servers/server_realdebrid.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>


### PR DESCRIPTION
No funcionaba debido a que se ha desactivado la api que se utilizaba por una nueva. Me he estado informando del uso de la nueva api, pero para ello se necesita utilizar el token privado de la cuenta (lo cual no recomiendan) o pedirles acceso a la api como app, así que por ahora no se utiliza, simplemente se loguea y se genera el enlace tal y como se hace desde el navegador.