### PR TITLE
Renovado real-debrid para usar la api por completo

### DIFF
--- a/python/main-classic/core/servertools.py
+++ b/python/main-classic/core/servertools.py
@@ -239,8 +239,16 @@ def resolve_video_urls_for_playing(server,url,video_password="",muestra_dialogo=
                 if muestra_dialogo:
                   progreso.update((100 / len(opciones)) * opciones.index(premium)  , "Conectando con "+premium)
                 exec "from servers import "+premium+" as premium_conector"
-                video_urls.extend(premium_conector.get_video_url( page_url=url , premium=True , user=config.get_setting(premium+"user") , password=config.get_setting(premium+"password"), video_password=video_password ))
-
+                if premium == "realdebrid":
+                    if config.is_xbmc() or config.get_platform() == "mediaserver":
+                        debrid_urls = [premium_conector.get_video_url( page_url=url , premium=True , video_password=video_password )]
+                        if not "REAL-DEBRID:" in debrid_urls[0][0]:
+                            video_urls.extend(debrid_urls)
+                        else:
+                            if len(video_urls) == 0:
+                                return video_urls, False, debrid_urls[0][0]
+                else:
+                    video_urls.extend(premium_conector.get_video_url( page_url=url , premium=True , user=config.get_setting(premium+"user") , password=config.get_setting(premium+"password"), video_password=video_password ))
 
             if muestra_dialogo:
                 progreso.update( 100 , "Proceso finalizado")

--- a/python/main-classic/resources/settings.xml
+++ b/python/main-classic/resources/settings.xml
@@ -27,9 +27,6 @@
 
         <setting type="sep"/>
         <setting id="realdebridpremium" type="bool" label="Real-Debrid" default="false"/>
-        <setting id="realdebriduser" type="text" label="30014" enable="eq(-1,true)" default=""/>
-        <setting id="realdebridpassword" type="text" option="hidden" label="30015" enable="!eq(-1,)+eq(-2,true)"
-                 default=""/>
 
         <setting type="sep"/>
         <setting id="alldebridpremium" type="bool" label="Alldebrid" default="false"/>

--- a/python/version-mediaserver/resources/settings.xml
+++ b/python/version-mediaserver/resources/settings.xml
@@ -28,8 +28,6 @@
 
     <setting type="sep" />
     <setting id="realdebridpremium" type="bool" label="Real-Debrid" default="false"/>
-    <setting id="realdebriduser" type="text" label="30014"  enable="eq(-1,true)" default=""/>
-    <setting id="realdebridpassword" type="text" option="hidden" label="30015" enable="!eq(-1,)+eq(-2,true)" default=""/>
 
     <setting type="sep" />
     <setting id="alldebridpremium" type="bool" label="Alldebrid" default="false"/>

--- a/python/version-plex/DefaultPrefs.json
+++ b/python/version-plex/DefaultPrefs.json
@@ -12,26 +12,6 @@
     "default": "true"
   },
   {
-    "id": "realdebridpremium",
-    "label": "Cuenta premium Real Debrid",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "realdebriduser",
-    "label": "Usuario",
-    "type": "text",
-    "default": ""
-  },
-  {
-    "id": "realdebridpassword",
-    "label": "Password",
-    "type": "text",
-    "option": "hidden",
-    "default": "",
-    "secure": "true"
-  },
-  {
     "id": "alldebridpremium",
     "label": "Cuenta premium All Debrid",
     "type": "bool",

--- a/python/version-xbmc-09-plugin/resources/settings.xml
+++ b/python/version-xbmc-09-plugin/resources/settings.xml
@@ -19,8 +19,6 @@
 
     <setting type="sep" />
     <setting id="realdebridpremium" type="bool" label="Real-Debrid" default="false"/>
-    <setting id="realdebriduser" type="text" label="30014"  enable="eq(-1,true)" default=""/>
-    <setting id="realdebridpassword" type="text" option="hidden" label="30015" enable="!eq(-1,)+eq(-2,true)" default=""/>
 
     <setting type="sep" />
     <setting id="alldebridpremium" type="bool" label="Alldebrid" default="false"/>


### PR DESCRIPTION
- Ahora real-debrid devuelve varios enlaces de diferente en los servidores que lo soportan.

- Las credenciales que genera la api se guardan en un json como si fueran un setting de un canal dentro del userdata en la carpeta settings_channels.

- En servertools, se añade una comprobación para no usar real-debrid en otras plataformas distintas a Kodi/Xbmc y mediaserver, además del método antiguo para mostrar mensajes de error que devuelva la api.

- Eliminados de los settings.xml los apartados para usuario y contraseña de real-debrid, y por completo en plex.