### PR TITLE
Soluciona diferentes fallos con el canal filesmonster catalogue y el servidor filesmonster

### DIFF
--- a/python/main-classic/channels/filesmonster_catalogue.py
+++ b/python/main-classic/channels/filesmonster_catalogue.py
@@ -156,7 +156,7 @@ def detail(item):
 
     for url in matches:
         title = "Archivo %d: %s [filesmonster]" %(len(itemlist)+1, item.fulltitle)
-        itemlist.append( Item(channel=item.channel , action="play" ,  server="filesmonster", title=item.url, fulltitle= item.fulltitle ,url=url, thumbnail=item.thumbnail, folder=False))
+        itemlist.append( Item(channel=item.channel , action="play" ,  server="filesmonster", title=title, fulltitle= item.fulltitle ,url=url, thumbnail=item.thumbnail, folder=False))
 
 
 

--- a/python/main-classic/channels/filesmonster_catalogue.py
+++ b/python/main-classic/channels/filesmonster_catalogue.py
@@ -133,7 +133,7 @@ def videos_2(item):
       matches = re.compile(patronvideos,re.DOTALL).findall(data)
 
       for url, title, thumbnail in matches:
-          itemlist.append( Item(channel=item.channel, action="detail", title=title, fulltitle = title , url=url, thumbnail=thumbnail)) 
+          itemlist.append( Item(channel=item.channel, action="detail_2", title=title, fulltitle = title , url=url, thumbnail=thumbnail)) 
 
       url =  scrapertools.find_single_match(data, '<link rel="next" href="([^"]+)" />').replace("&amp;","&")
 
@@ -144,6 +144,8 @@ def videos_2(item):
     return itemlist
     
 
+
+
 def detail(item):
     logger.info("[filesmonster_catalogue.py] detail")
     itemlist = []
@@ -153,6 +155,39 @@ def detail(item):
     matches = re.compile(patronvideos,re.DOTALL).findall(data)
 
     for url in matches:
+        title = "Archivo %d: %s [filesmonster]" %(len(itemlist)+1, item.fulltitle)
+        itemlist.append( Item(channel=item.channel , action="play" ,  server="filesmonster", title=item.url, fulltitle= item.fulltitle ,url=url, thumbnail=item.thumbnail, folder=False))
+
+
+
+    patronvideos  = '["|\'](http\://filesmonster.com/folders.php\?[^"\']+)["|\']'
+    matches = re.compile(patronvideos,re.DOTALL).findall(data)
+    for url in matches: 
+      if not url == item.url:
+        logger.info(url)
+        logger.info(item.url)
+        title = "Carpeta %d: %s [filesmonster]" %(len(itemlist)+1, item.fulltitle)
+        itemlist.append( Item(channel=item.channel , action="detail" ,  title=title, fulltitle= item.fulltitle ,url=url, thumbnail=item.thumbnail, folder=True))
+
+
+    return itemlist
+
+
+
+
+def detail_2(item):
+    logger.info("[filesmonster_catalogue.py] detail")
+    itemlist = []
+
+	 # descarga la pagina
+    data=scrapertools.downloadpageGzip(item.url)
+    data=data.split('<span class="filesmonsterdlbutton">Download from Filesmonster</span>')
+    data=data[0]
+    # descubre la url
+    patronvideos  = 'href="http://filesmonster.com/download.php(.*?)".(.*?)'
+    matches = re.compile(patronvideos,re.DOTALL).findall(data)    
+    for match2 in matches:
+    	url ="http://filesmonster.com/download.php"+match2[0] 
         title = "Archivo %d: %s [filesmonster]" %(len(itemlist)+1, item.fulltitle)
         itemlist.append( Item(channel=item.channel , action="play" ,  server="filesmonster", title=title, fulltitle= item.fulltitle ,url=url, thumbnail=item.thumbnail, folder=False))
 

--- a/python/main-classic/channels/filesmonster_catalogue.py
+++ b/python/main-classic/channels/filesmonster_catalogue.py
@@ -21,9 +21,8 @@ def mainlist(item):
     logger.info("[filesmonster_catalogue.py] mainlist")
 
     itemlist = []
+    itemlist.append( Item(channel=item.channel, action="unusualporn" , title="Canal unusualporn.net"         , thumbnail="http://filesmonster.biz/img/logo.png"))    
     itemlist.append( Item(channel=item.channel, action="filesmonster", title="Canal filesmonster.filesdl.net", thumbnail="http://filesmonster.biz/img/logo.png"))    
-    itemlist.append( Item(channel=item.channel, action="unusualporn" , title="Canal unusualporn.net"         , thumbnail="http://filesmonster.biz/img/logo.png"))        
-    itemlist.append( Item(channel=item.channel, action="search", title="Búsqueda global"               , url="http://filesmonster.filesdl.net/posts/search?q=%s"))
     return itemlist
 
 
@@ -32,7 +31,8 @@ def filesmonster(item):
 
     itemlist = []
     itemlist.append( Item(channel=item.channel, action="videos"    , title="Ultimos vídeos" , thumbnail="http://photosex.biz/imager/w_400/h_400/9f869c6cb63e12f61b58ffac2da822c9.jpg", url="http://filesmonster.filesdl.net"))         
-    itemlist.append( Item(channel=item.channel, action="categorias", title="Categorias"               , thumbnail="http://photosex.biz/imager/w_400/h_500/e48337cd95bbb6c2c372ffa6e71441ac.jpg", url="http://filesmonster.filesdl.net"))    
+    itemlist.append( Item(channel=item.channel, action="categorias", title="Categorias"               , thumbnail="http://photosex.biz/imager/w_400/h_500/e48337cd95bbb6c2c372ffa6e71441ac.jpg", url="http://filesmonster.filesdl.net"))   
+    itemlist.append( Item(channel=item.channel, action="search", title="Buscar en filesmonster.fliesdl.net"               , url="http://filesmonster.filesdl.net/posts/search?q=%s")) 
     return itemlist
 
 
@@ -41,7 +41,8 @@ def unusualporn(item):
 
     itemlist = []
     itemlist.append( Item(channel=item.channel, action="videos_2", title="Últimos vídeos", url="http://unusualporn.net/", thumbnail="http://photosex.biz/imager/w_400/h_500/e48337cd95bbb6c2c372ffa6e71441ac.jpg"))    
-    itemlist.append( Item(channel=item.channel, action="categorias", title="Categorías", url="http://unusualporn.net/", thumbnail="http://photosex.biz/imager/w_400/h_500/e48337cd95bbb6c2c372ffa6e71441ac.jpg"))    
+    itemlist.append( Item(channel=item.channel, action="categorias", title="Categorías", url="http://unusualporn.net/", thumbnail="http://photosex.biz/imager/w_400/h_500/e48337cd95bbb6c2c372ffa6e71441ac.jpg"))   
+    itemlist.append( Item(channel=item.channel, action="search", title="Buscar en unusualporn"               , url="http://unusualporn.net/search/%s"))  
     return itemlist
 
 def categorias(item):
@@ -77,18 +78,26 @@ def categorias_2(item):
 
     return itemlist
     
+    
+    
 def search(item,texto):
     logger.info("[filesmonster_catalogue.py] search:" + texto)
+    original=item.url
     item.url = item.url % texto
     try:
-        return videos(item)
+        if original=='http://filesmonster.filesdl.net/posts/search?q=%s':
+        	return videos(item)
+        if original=='http://unusualporn.net/search/%s':
+        	return videos_2(item)
     # Se captura la excepción, para no interrumpir al buscador global si un canal falla
     except:
         import sys
         for line in sys.exc_info():
             logger.error( "%s" % line )
         return []
-        
+
+
+
 
 def videos(item):
     logger.info("[filesmonster_catalogue.py] list")
@@ -108,7 +117,7 @@ def videos(item):
 
     #Enlace para la siguiente pagina  
     if url:
-      itemlist.append( Item(channel=item.channel, action="videos", title=">> Pagina Siguiente", url=url) )
+      itemlist.append( Item(channel=item.channel, action="videos", title=">> Página Siguiente", url=url) )
 
     return itemlist
 
@@ -130,7 +139,7 @@ def videos_2(item):
 
     #Enlace para la siguiente pagina  
     if url:
-      itemlist.append( Item(channel=item.channel, action="videos_2", title=">> Pagina Siguiente", url=url) )
+      itemlist.append( Item(channel=item.channel, action="videos_2", title=">> Página Siguiente", url=url) )
 
     return itemlist
     

--- a/python/main-classic/channels/filesmonster_catalogue.py
+++ b/python/main-classic/channels/filesmonster_catalogue.py
@@ -41,7 +41,7 @@ def unusualporn(item):
 
     itemlist = []
     itemlist.append( Item(channel=item.channel, action="videos_2", title="Últimos vídeos", url="http://unusualporn.net/", thumbnail="http://photosex.biz/imager/w_400/h_500/e48337cd95bbb6c2c372ffa6e71441ac.jpg"))    
-    itemlist.append( Item(channel=item.channel, action="categorias", title="Categorías", url="http://unusualporn.net/", thumbnail="http://photosex.biz/imager/w_400/h_500/e48337cd95bbb6c2c372ffa6e71441ac.jpg"))   
+    itemlist.append( Item(channel=item.channel, action="categorias_2", title="Categorías", url="http://unusualporn.net/", thumbnail="http://photosex.biz/imager/w_400/h_500/e48337cd95bbb6c2c372ffa6e71441ac.jpg"))   
     itemlist.append( Item(channel=item.channel, action="search", title="Buscar en unusualporn"               , url="http://unusualporn.net/search/%s"))  
     return itemlist
 

--- a/python/main-classic/servers/filesmonster.xml
+++ b/python/main-classic/servers/filesmonster.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
+	<changes>Version incial</changes>
 	<date>25/03/2016</date>
 	<free>false</free>
 	<id>filesmonster</id>
 	<name>filesmonster</name>
-	<premium>
-		<value>realdebrid</value>
-		<value>alldebrid</value>
-	</premium>
+	<premium>filesmonster</premium>
 	<thumbnail>http://media.tvalacarta.info/servers/server_filesmonster.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
 	<version>1</version>
 </server>
+


### PR DESCRIPTION
- Separado el buscador para cada una de las dos webs, ya que cada una tiene su patrón de búsqueda diferente.
- Solucionado el problema por el que no cargaban las categorías de unusualporn.
- Solucionado el problema por el que no cargaban los vídeos de unusualporn, al necesitar una comprobación previa para detectar la URL de descarga, a diferencia de la otra web.
- Convierte a filesmonster en un canal premium, y no de realdebrid y alldebrid (no soportado por ellos)