### PR TITLE
Fix por error en launcher

### DIFF
--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -230,7 +230,8 @@ def run():
                 if 'infoLabels' in item:
                     
                     # All but title
-                    item.infoLabels.pop('title')
+                    if 'title' in item.infoLabels:
+                        item.infoLabels.pop('title')
                     new_itemlist = itemlist[:]
                     itemlist = []
                     


### PR DESCRIPTION
Se ha reportado en el foro que en algún canal como divxatope da error en la función de findvideos. El motivo es que se intenta descartar el parámetro "title" de infoLabels pero éste no existe y salta este error:

```
plugin.video.pelisalacarta\platformcode\launcher.py", line 233, in run
item.infoLabels.pop('title')
KeyError: 'title'
```
Solucionado añadiendo una comprobación de si existe.