### PR TITLE
Fix #306 Import libsmb en linux

### DIFF
--- a/python/main-classic/platformcode/library.py
+++ b/python/main-classic/platformcode/library.py
@@ -47,7 +47,7 @@ try:
 except ImportError:
     librerias = xbmc.translatePath(os.path.join(config.get_runtime_path(), 'lib'))
     sys.path.append(librerias)
-    from samba import libsmb as samba
+    from lib.samba import libsmb as samba
 
 import urllib2
 


### PR DESCRIPTION
Se soluciona el error que no permitía iniciar pelisalacarta en linux debido a que no localizaba la librería libsmb al hacer el import en library.py