### PR TITLE
Arreglos en gamovideo, hdfull y cinefox

### DIFF
--- a/python/main-classic/channels/cinefox.py
+++ b/python/main-classic/channels/cinefox.py
@@ -230,7 +230,7 @@ def filtro(item):
         return filtrado(item, valores_guardados)
 
     list_controls.append({'id': 'espacio', 'label': '', 'enabled': False,
-                          'type': 'text', 'default': '', 'visible': True})
+                          'type': 'label', 'default': '', 'visible': True})
     list_controls.append({'id': 'save', 'label': 'Establecer como filtro por defecto', 'enabled': True,
                           'type': 'bool', 'default': False, 'visible': True})
     list_controls.append({'id': 'filtro_per', 'label': 'Guardar filtro en acceso directo...', 'enabled': True,

--- a/python/main-classic/channels/hdfull.py
+++ b/python/main-classic/channels/hdfull.py
@@ -626,6 +626,8 @@ def play(item):
     if "aHR0c" in item.url:
         import base64
         item.url = base64.decodestring(item.url.split("/")[-1])
+        if "VideoMega" in item.title and not "videomega" in item.url:
+            item.url = "http://videomega.tv/cdn.php?" + item.url
 
     itemlist = servertools.find_video_items(data=item.url)
 

--- a/python/main-classic/servers/gamovideo.py
+++ b/python/main-classic/servers/gamovideo.py
@@ -11,7 +11,7 @@ from core import jsunpack
 from core import logger
 from core import scrapertools
 
-headers = [["User-Agent","Mozilla/5.0 (Windows NT 10.0; WOW64; rv:45.0) Gecko/20100101 Firefox/45.0"]]
+headers = [["User-Agent","Mozilla/5.0"]]
 
 def test_video_exists( page_url ):
     logger.info("pelisalacarta.servers.gamovideo test_video_exists(page_url='%s')" % page_url)
@@ -25,7 +25,7 @@ def test_video_exists( page_url ):
 def get_video_url( page_url , premium = False , user="" , password="", video_password="" ):
     logger.info("pelisalacarta.servers.gamovideo get_video_url(page_url='%s')" % page_url)
 
-    data = scrapertools.cache_page(page_url,headers=headers)
+    data = scrapertools.cache_page(page_url, headers=headers)
     packer = scrapertools.find_single_match(data,"<script type='text/javascript'>(eval.function.p,a,c,k,e,d..*?)</script>")
     unpacker = jsunpack.unpack(data) if packer != "" else ""
     if unpacker != "": data = unpacker
@@ -62,7 +62,7 @@ def find_videos(data):
 
     for match in matches:
         titulo = "[gamovideo]"
-        url = "http://gamovideo.com//embed-%s.html" % match
+        url = "http://gamovideo.com/embed-%s.html" % match
         if url not in encontrados:
             logger.info("  url="+url)
             devuelve.append( [ titulo , url , 'gamovideo' ] )


### PR DESCRIPTION
- Gamovideo daba error debido al user-agent.
- Reparados en hdfull los enlaces a videomega que es el único servidor que fallaba aparentemente.
- En cinefox la ventana de filtro no permitía recorrer todas las opciones con el teclado.