### PR TITLE
Reemplazar default.py

### DIFF
--- a/python/main-classic/platformcode/library.py
+++ b/python/main-classic/platformcode/library.py
@@ -404,7 +404,7 @@ def save_library_episodes(path, episodelist):
     t = float(100) / len(episodelist)
 
     addon_name = sys.argv[0].strip()
-    if not addon_name:
+    if not addon_name or addon_name.startswith("default.py"):
         addon_name = "plugin://plugin.video.pelisalacarta/"
 
     for i, e in enumerate(episodelist):

--- a/python/main-classic/platformcode/library.py
+++ b/python/main-classic/platformcode/library.py
@@ -265,7 +265,7 @@ def save_library_movie(item):
     logger.debug(filename)
     fullfilename = join_path(MOVIES_PATH, filename)
     addon_name = sys.argv[0].strip()
-    if not addon_name:
+    if not addon_name or addon_name.startswith("default.py"):
         addon_name = "plugin://plugin.video.pelisalacarta/"
 
     if path_exists(fullfilename):


### PR DESCRIPTION
Cuando llamo de forma externa (vía cron) a la actualización de addons, su nombre es "default.py", por lo que jode todos los strm (pone como addon default.py?URI)