### PR TITLE
Correccion de errores varios en la creacion y gestion de infolabels

### DIFF
--- a/python/main-classic/core/item.py
+++ b/python/main-classic/core/item.py
@@ -43,6 +43,10 @@ class Item(object):
             self.set_parent_content(kwargs["parentContent"])
             del kwargs["parentContent"]
 
+        # Creamos el atributo infoLabels si no existe
+        if not type(self.__dict__.get("infoLabels", "")) == dict:
+            self.__dict__["infoLabels"] = {}
+
         self.__dict__.update(kwargs)
         self.__dict__ = self.toutf8(self.__dict__)
 
@@ -64,55 +68,31 @@ class Item(object):
         # Descodificamos los HTML entities
         if name in ["title", "plot", "fulltitle", "contentPlot", "contentTitle"]: value = self.decode_html(value)
 
-        # Al modificar cualquiera de estos atributos que empiecen por content..., marcamos hasContentDetails como "true"
-        if name.startswith("content"): self.__dict__["hasContentDetails"] = "true"
+       # Al modificar cualquiera de estos atributos content...
+        if name in ["contentTitle", "contentPlot", "contentSerieName", "contentType", "contentEpisodeTitle",
+                    "contentSeason", "contentEpisodeNumber", "contentThumbnail"]:
+            #... marcamos hasContentDetails como "true"...
+            self.__dict__["hasContentDetails"] = "true"
+            #...y actualizamos infoLables
+            if name == "contentTitle":
+                self.__dict__["infoLabels"]["title"] = value
+            elif name == "contentPlot":
+                self.__dict__["infoLabels"]["plot"] = value
+            elif name == "contentSerieName":
+                self.__dict__["infoLabels"]["tvshowtitle"] = value
+            elif name == "contentType":
+                self.__dict__["infoLabels"]["mediatype"] = value
+            elif name == "contentEpisodeTitle":
+                self.__dict__["infoLabels"]["episodeName"] = value
+            elif name == "contentSeason":
+                self.__dict__["infoLabels"]["season"] = value
+            elif name == "contentEpisodeNumber":
+                self.__dict__["infoLabels"]["episode"] = value
+            elif name == "contentThumbnail":
+                self.__dict__["infoLabels"]["thumbnail"] = value
 
-        # Intercambiamos los atributos contentDetails <-> infoLabels
-        self.set_infolabels(name, value)
-        self.setcontentDetails(name, value)
-
-        super(Item, self).__setattr__(name, value)
-
-    def setcontentDetails(self, name, value):
-        '''
-        Rellena los campos contentDetails con la información de infoLabels
-        '''
-        if not type(value) == dict or not name == "infoLabels":
-            return
-
-        if value.get("title", "") <> "": super(Item, self).__setattr__("contentTitle", value["title"])
-        if value.get("plot", "") <> "": super(Item, self).__setattr__("contentPlot", value["plot"])
-        if value.get("overview", "") <> "": super(Item, self).__setattr__("contentPlot", value["overview"])
-        if value.get("tvshowtitle", "") <> "": super(Item, self).__setattr__("contentSerieName", value["tvshowtitle"])
-        if value.get("mediatype", "") <> "": super(Item, self).__setattr__("contentType", value["mediatype"])
-        if value.get("season", "") <> "": super(Item, self).__setattr__("contentSeason", value["season"])
-        if value.get("episode", "") <> "": super(Item, self).__setattr__("contentEpisodeNumber", value["episode"])
-        if value.get("thumbnail", "") <> "": super(Item, self).__setattr__("contentThumbnail", value["thumbnail"])
-        if value.get("fanart", "") <> "": super(Item, self).__setattr__("fanart", value["fanart"])
-
-
-    def set_infolabels(self, name, value):
-        '''
-        Rellena infoLabels con la informacionde contentDetails
-        '''
-        # Creamos el atributo infoLabels si no existe
-        if name.startswith("content"):
-            if not type(self.__dict__.get("infoLabels", "")) == dict: self.__dict__["infoLabels"] = {}
-
-            if name == "contentTitle": self.__dict__["infoLabels"]["title"] = value
-            if name == "contentPlot": self.__dict__["infoLabels"]["plot"] = value
-            if name == "contentSerieName": self.__dict__["infoLabels"]["tvshowtitle"] = value
-            if name == "contentType": self.__dict__["infoLabels"]["mediatype"] = value
-            if name == "contentSeason": self.__dict__["infoLabels"]["season"] = value
-            if name == "contentEpisodeNumber": self.__dict__["infoLabels"]["episode"] = value
-            if name == "contentThumbnail": self.__dict__["infoLabels"]["thumbnail"] = value
-
-    def __getattribute__(self, name):
-        if name.startswith("content") or name == "__dict__":
-            infoLabels = Item.__getattribute__(self, "infoLabels")
-            Item.setcontentDetails(self, "infoLabels", infoLabels)
-
-        return super(Item, self).__getattribute__(name)
+        else:
+            super(Item, self).__setattr__(name, value)
 
     def __getattr__(self, name):
         '''
@@ -131,6 +111,25 @@ class Item(object):
         # Valor por defecto para hasContentDetails
         elif name == "hasContentDetails":
             return "false"
+
+        elif name in ["contentTitle", "contentPlot", "contentSerieName", "contentType", "contentEpisodeTitle",
+                    "contentSeason", "contentEpisodeNumber", "contentThumbnail"]:
+            if name == "contentTitle":
+                return self.__dict__["infoLabels"].get("title","")
+            elif name == "contentPlot":
+                return self.__dict__["infoLabels"].get("plot","")
+            elif name == "contentSerieName":
+                return self.__dict__["infoLabels"].get("tvshowtitle","")
+            elif name == "contentType":
+                return self.__dict__["infoLabels"].get("mediatype","")
+            elif name == "contentEpisodeTitle":
+                return self.__dict__["infoLabels"].get("episodeName", "")
+            elif name == "contentSeason":
+                return self.__dict__["infoLabels"].get("season","")
+            elif name == "contentEpisodeNumber":
+                return self.__dict__["infoLabels"].get("episode","")
+            elif name == "contentThumbnail":
+                return self.__dict__["infoLabels"].get("thumbnail","")
 
         # valor por defecto para el resto de atributos
         else:
@@ -154,7 +153,15 @@ class Item(object):
         Genera una cadena de texto con los datos del item para el log
         Uso: logger.info(item.tostring())
         '''
-        return separator.join([var + "=[" + str(self.__dict__[var]) + "]" for var in sorted(self.__dict__)])
+        dic= self.__dict__.copy()
+
+        # Añadimos los campos content... si tienen algun valor
+        for key in ["contentTitle", "contentPlot", "contentSerieName", "contentType",
+                    "contentSeason", "contentEpisodeNumber", "contentThumbnail"]:
+            value = self.__getattr__(key)
+            if value: dic[key]= value
+
+        return separator.join([var + "=[" + str(dic[var]) + "]" for var in sorted(dic)])
 
     def tourl(self):
         '''

--- a/python/main-classic/core/tmdb.py
+++ b/python/main-classic/core/tmdb.py
@@ -111,7 +111,6 @@ def find_and_set_infoLabels_tmdb(item, ask_video=True):
 
     tmdb_result = None
     while not tmdb_result:
-
         if not item.infoLabels.get("tmdb_id"):
             otmdb_global = Tmdb(texto_buscado=title, tipo=video_type, year=year)
         elif not otmdb_global or otmdb_global.result.get("id") != item.infoLabels['tmdb_id']:
@@ -127,14 +126,23 @@ def find_and_set_infoLabels_tmdb(item, ask_video=True):
         elif len(results) > 0:
             tmdb_result = results[0]
 
-        else:
-            # Pregunta el titulo
-            it = platformtools.dialog_input(title, "No se ha encontrado la {0}, introduzca el nombre correcto".
-                                            format("serie" if video_type == "tv" else "pelicula"))
-            if it is not None:
-                title = it
+
+        if tmdb_result is None:
+            if platformtools.dialog_yesno("{0} no encontrada".
+                                          format("Serie" if video_type == "tv" else "Pelicula") ,
+                                          "No se ha encontrado la {0}:".
+                                          format("serie" if video_type == "tv" else "pelicula"),
+                                          title,
+                                          '¿Desea introducir otro nombre?'):
+                # Pregunta el titulo
+                it = platformtools.dialog_input(title, "Introduzca el nombre de la {0} a buscar".
+                                                format("serie" if video_type == "tv" else "pelicula"))
+                if it is not None:
+                    title = it
+                else:
+                    logger.debug("he pulsado 'cancelar' en la ventana 'introduzca el nombre correcto'")
+                    break
             else:
-                logger.debug("he pulsado 'cancelar' en la ventana 'introduzca el nombre correcto'")
                 break
 
 
@@ -142,7 +150,7 @@ def find_and_set_infoLabels_tmdb(item, ask_video=True):
 
     if not tmdb_result:
         item.infoLabels = infoLabels
-        return
+        return False
 
     infoLabels = otmdb_global.get_infoLabels(infoLabels, tmdb_result)
     infoLabels["mediatype"] = contentType
@@ -165,6 +173,7 @@ def find_and_set_infoLabels_tmdb(item, ask_video=True):
                     infoLabels['thumbnail'] = episodio['episodio_imagen']
 
     item.infoLabels = infoLabels
+    return True
 
 
 def set_infoLabels_item(item, seekTmdb=True, idioma_busqueda='es', lock=None):

--- a/python/main-classic/core/tmdb.py
+++ b/python/main-classic/core/tmdb.py
@@ -32,6 +32,7 @@ import copy
 from core import jsontools
 from core import logger
 from core import scrapertools
+from platformcode import platformtools
 
 # -----------------------------------------------------------------------------------------------------------
 # Conjunto de funciones relacionadas con las infoLabels.

--- a/python/main-classic/core/tmdb.py
+++ b/python/main-classic/core/tmdb.py
@@ -23,13 +23,15 @@
 # along with pelisalacarta 4.  If not, see <http://www.gnu.org/licenses/>.
 # --------------------------------------------------------------------------------
 
-import re
 import time
+import traceback
+import urllib2
+import re
+import copy
 
 from core import jsontools
 from core import logger
 from core import scrapertools
-from platformcode import platformtools
 
 # -----------------------------------------------------------------------------------------------------------
 # Conjunto de funciones relacionadas con las infoLabels.
@@ -97,9 +99,6 @@ def cb_select_from_tmdb(item, tmdb_result):
 def find_and_set_infoLabels_tmdb(item, ask_video=True):
     global otmdb_global
 
-    if not item.infoLabels:
-        item.infoLabels = {}
-
     contentType = item.contentType if item.contentType else ("movie" if not item.contentSerieName else "tvshow")
     title = item.contentSerieName if contentType == "tvshow" else item.contentTitle
     season = int(item.contentSeason) if item.contentSeason else ""
@@ -152,83 +151,7 @@ def find_and_set_infoLabels_tmdb(item, ask_video=True):
         item.infoLabels = infoLabels
         return
 
-    for k, v in result.items():
-        if v == '':
-            continue
-        elif k == 'videos':
-            if len(v) > 0:
-                if v[0]["site"] == "YouTube":
-                    infoLabels['trailer'] = "https://www.youtube.com/watch?v=" + v[0]["key"]
-        elif k == 'number_of_episodes':
-            infoLabels['totalepisodes'] = int(v)
-        elif k == 'number_of_seasons':
-            infoLabels['totalseasons'] = int(v)
-        elif k == 'overview':
-            infoLabels['plot'] = otmdb_global.get_sinopsis()
-        elif k == 'runtime':
-            infoLabels['duration'] = int(v)*60
-        elif k == 'release_date':
-            infoLabels['year'] = int(v[:4])
-        elif k == 'first_air_date':
-            infoLabels['year'] = int(v[:4])
-            infoLabels['aired'] = v
-            infoLabels['premiered'] = v
-        elif k == 'original_title':
-            infoLabels['originaltitle'] = v
-        elif k == 'vote_average':
-            infoLabels['rating'] = float(v)
-        elif k == 'vote_count':
-            infoLabels['votes'] = v
-        elif k == 'poster_path':
-            infoLabels['thumbnail'] = 'http://image.tmdb.org/t/p/original' + v
-        elif k == 'backdrop_path':
-            infoLabels['fanart'] = 'http://image.tmdb.org/t/p/original' + v
-        elif k == 'id':
-            infoLabels['tmdb_id'] = v
-        elif k == 'imdb_id':
-            infoLabels['imdb_id'] = v
-            infoLabels['IMDBNumber'] = v
-            infoLabels['code'] = v
-        elif k == 'genres':
-            infoLabels['genre'] = otmdb_global.get_generos()
-        elif k == 'name':
-            infoLabels['title'] = v
-            if contentType in ["episode", "tvshow"]:
-                infoLabels['tvshowname'] = v
-        elif k == 'production_companies':
-            infoLabels['studio'] = ", ".join(i['name'] for i in v)
-        elif k == 'production_countries' or k == 'origin_country':
-            if 'country' not in infoLabels:
-                infoLabels['country'] = ", ".join(i if type(i) == str else i['name'] for i in v)
-            else:
-                infoLabels['country'] = ", " + ", ".join(i if type(i) == str else i['name'] for i in v)
-        elif k == 'credits_cast':
-            infoLabels['castandrole'] = []
-            for c in sorted(v, key=lambda c: c.get("order")):
-                infoLabels['castandrole'].append((c['name'], c['character']))
-        elif k == 'credits_crew':
-            l_director = []
-            l_writer = []
-            for crew in v:
-                if crew['job'].lower() == 'director':
-                    l_director.append(crew['name'])
-                elif crew['job'].lower() in ('screenplay', 'writer'):
-                    l_writer.append(crew['name'])
-            if l_director:
-                infoLabels['director'] = ", ".join(l_director)
-            if l_writer:
-                if 'writer' not in infoLabels:
-                    infoLabels['writer'] = ", ".join(l_writer)
-                else:
-                    infoLabels['writer'] += "," + (",".join(l_writer))
-        elif k == 'created_by':
-            l_writer = []
-            for cr in v:
-                l_writer.append(cr['name'])
-            if 'writer' not in infoLabels:
-                infoLabels['writer'] = ",".join(l_writer)
-            else:
-                infoLabels['writer'] += "," + (",".join(l_writer))
+    infoLabels = otmdb_global.get_infoLabels(infoLabels)
 
     if infoLabels["mediatype"] == "episode":
         try:
@@ -250,7 +173,7 @@ def find_and_set_infoLabels_tmdb(item, ask_video=True):
     item.infoLabels = infoLabels
 
 
-def set_infoLabels_item(item, seekTmdb=False, idioma_busqueda='es', lock=None):
+def set_infoLabels_item(item, seekTmdb=True, idioma_busqueda='es', lock=None):
     # -----------------------------------------------------------------------------------------------------------
     # Obtiene y fija (item.infoLabels) los datos extras de una serie, capitulo o pelicula.
     #
@@ -295,28 +218,27 @@ def set_infoLabels_item(item, seekTmdb=False, idioma_busqueda='es', lock=None):
 
     def obtener_datos_item():
         if item.contentSeason != '':
-            item.infoLabels['season'] = int(item.contentSeason)
             item.infoLabels['mediatype'] = 'season'
-        if item.contentEpisodeNumber != '':
-            item.infoLabels['episode'] = int(item.contentEpisodeNumber)
-            item.infoLabels['mediatype'] = 'episode'
-        if item.contentEpisodeTitle != '':
-            item.infoLabels['episodeName'] = item.contentEpisodeTitle
+        if item.contentEpisodeNumber != '' or item.contentEpisodeTitle != '':
             item.infoLabels['mediatype'] = 'episode'
         if item.contentTitle == '':
             item.contentTitle = item.title
         return -1 * len(item.infoLabels)
 
-    def __leer_datos(otmdb_global):
-        item.infoLabels = otmdb_global.get_infoLabels(item.infoLabels)
-        logger.debug(infoLabels_tostring(item))
+    def __leer_datos(otmdb_aux):
+        item.infoLabels = otmdb_aux.get_infoLabels(item.infoLabels)
         if 'thumbnail' in item.infoLabels:
             item.thumbnail = item.infoLabels['thumbnail']
         if 'fanart' in item.infoLabels:
             item.fanart = item.infoLabels['fanart']
 
     if seekTmdb:
-        if not 'infoLabels' in item: item.infoLabels = {}
+        # Comprobamos q tipo de contenido es...
+        if 'mediatype' not in item.infoLabels:
+            item.infoLabels['tvshowtitle'] = item.show if item.show != '' else item.contentSerieName
+            item.infoLabels['mediatype'] = 'movie' if item.infoLabels['tvshowtitle'] == '' else 'tvshow'
+        tipo = 'movie' if item.infoLabels['mediatype'] == 'movie' else 'tv'
+
         if 'season' in item.infoLabels and 'tmdb_id' in item.infoLabels:
             try:
                 numtemporada = int(item.infoLabels['season'])
@@ -324,40 +246,44 @@ def set_infoLabels_item(item, seekTmdb=False, idioma_busqueda='es', lock=None):
                 logger.debug("El numero de temporada no es valido")
                 return obtener_datos_item()
 
-            if 'mediatype' not in item.infoLabels:
-                item.infoLabels['tvshowtitle'] = item.show if item.show != '' else item.contentSerieName
-                item.infoLabels['mediatype'] = 'movie' if item.infoLabels['tvshowtitle'] == '' else 'tvshow'
-
-            tipo = 'movie' if item.infoLabels['mediatype'] == 'movie' else 'tv'
-
             if lock:
                 lock.acquire()
             if not otmdb_global:
                 otmdb_global = Tmdb(id_Tmdb=item.infoLabels['tmdb_id'], tipo=tipo, idioma_busqueda=idioma_busqueda)
                 __leer_datos(otmdb_global)
+                temporada = otmdb_global.get_temporada(numtemporada)
             if lock:
                 lock.release()
 
             if 'episode' in item.infoLabels:
                 try:
-                    # logger.debug(infoLabels_tostring(item))
                     episode = int(item.infoLabels['episode'])
                 except ValueError:
-                    logger.debug("El número de episodio (%s) no es valido" % repr(item.infoLabels('episode')))
+                    logger.debug("El número de episodio (%s) no es valido" % repr(item.infoLabels['episode']))
                     return obtener_datos_item()
 
                 # Tenemos numero de temporada y numero de episodio validos...
                 # ... buscar datos episodio
                 item.infoLabels['mediatype'] = 'episode'
                 episodio = otmdb_global.get_episodio(numtemporada, episode)
+
                 if episodio:
                     # Actualizar datos
+                    __leer_datos(otmdb_global)
                     item.infoLabels['title'] = episodio['episodio_titulo']
                     if episodio['episodio_sinopsis']:
                         item.infoLabels['plot'] = episodio['episodio_sinopsis']
                     if episodio['episodio_imagen']:
                         item.infoLabels['poster_path'] = episodio['episodio_imagen']
                         item.thumbnail = item.infoLabels['poster_path']
+                    if episodio['episodio_air_date']:
+                        item.infoLabels['aired'] = episodio['episodio_air_date']
+                    if episodio['episodio_vote_average']:
+                        item.infoLabels['rating'] = episodio['episodio_vote_average']
+                        item.infoLabels['votes'] = episodio['episodio_vote_count']
+
+                    return len(item.infoLabels)
+
 
             else:
                 # Tenemos numero de temporada valido pero no numero de episodio...
@@ -366,23 +292,28 @@ def set_infoLabels_item(item, seekTmdb=False, idioma_busqueda='es', lock=None):
                 temporada = otmdb_global.get_temporada(numtemporada)
                 if temporada:
                     # Actualizar datos
+                    __leer_datos(otmdb_global)
+                    logger.debug(str(item.infoLabels))
+                    logger.debug(str(temporada))
                     item.infoLabels['title'] = temporada['name']
                     if temporada['overview']:
                         item.infoLabels['plot'] = temporada['overview']
+                    if temporada['air_date']:
+                        item.infoLabels['aired'] = temporada['air_date']
                     if temporada['poster_path']:
                         item.infoLabels['poster_path'] = 'http://image.tmdb.org/t/p/original' + temporada['poster_path']
                         item.thumbnail = item.infoLabels['poster_path']
+                    return len(item.infoLabels)
 
-            return len(item.infoLabels)
-
-        else:  # BUSCAR...
+        # Buscar...
+        else:
             __inicializar()
-            tipo = 'movie' if item.infoLabels['mediatype'] == 'movie' else 'tv'
-            otmdb_global = None
+            otmdb = copy.copy(otmdb_global)
+
             # Busquedas por ID...
             if 'tmdb_id' in item.infoLabels and item.infoLabels['tmdb_id']:
                 # ...Busqueda por tmdb_id
-                otmdb_global = Tmdb(id_Tmdb=item.infoLabels['tmdb_id'], tipo=tipo, idioma_busqueda=idioma_busqueda)
+                otmdb = Tmdb(id_Tmdb=item.infoLabels['tmdb_id'], tipo=tipo, idioma_busqueda=idioma_busqueda)
 
             elif item.infoLabels['IMDBNumber'] or item.infoLabels['code'] or item.infoLabels['imdb_id']:
                 if item.infoLabels['IMDBNumber']:
@@ -395,53 +326,52 @@ def set_infoLabels_item(item, seekTmdb=False, idioma_busqueda='es', lock=None):
                     item.infoLabels['code'] == item.infoLabels['imdb_id']
                     item.infoLabels['IMDBNumber'] == item.infoLabels['imdb_id']
                 # ...Busqueda por imdb code
-                otmdb_global = Tmdb(external_id=item.infoLabels['imdb_id'], external_source="imdb_id", tipo=tipo,
-                                    idioma_busqueda=idioma_busqueda)
+                otmdb = Tmdb(external_id=item.infoLabels['imdb_id'], external_source="imdb_id", tipo=tipo,
+                             idioma_busqueda=idioma_busqueda)
 
             elif tipo == 'tv':  # buscar con otros codigos
                 if 'tvdb_id' in item.infoLabels and item.infoLabels['tvdb_id']:
                     # ...Busqueda por tvdb_id
-                    otmdb_global = Tmdb(external_id=item.infoLabels['tvdb_id'], external_source="tvdb_id", tipo=tipo,
-                                        idioma_busqueda=idioma_busqueda)
+                    otmdb = Tmdb(external_id=item.infoLabels['tvdb_id'], external_source="tvdb_id", tipo=tipo,
+                                 idioma_busqueda=idioma_busqueda)
                 elif 'freebase_mid' in item.infoLabels and item.infoLabels['freebase_mid']:
                     # ...Busqueda por freebase_mid
-                    otmdb_global = Tmdb(external_id=item.infoLabels['freebase_mid'], external_source="freebase_mid",
-                                        tipo=tipo, idioma_busqueda=idioma_busqueda)
+                    otmdb = Tmdb(external_id=item.infoLabels['freebase_mid'], external_source="freebase_mid",
+                                 tipo=tipo, idioma_busqueda=idioma_busqueda)
                 elif 'freebase_id' in item.infoLabels and item.infoLabels['freebase_id']:
                     # ...Busqueda por freebase_id
-                    otmdb_global = Tmdb(external_id=item.infoLabels['freebase_id'], external_source="freebase_id",
-                                        tipo=tipo, idioma_busqueda=idioma_busqueda)
+                    otmdb = Tmdb(external_id=item.infoLabels['freebase_id'], external_source="freebase_id",
+                                 tipo=tipo, idioma_busqueda=idioma_busqueda)
                 elif 'tvrage_id' in item.infoLabels and item.infoLabels['tvrage_id']:
                     # ...Busqueda por tvrage_id
-                    otmdb_global = Tmdb(external_id=item.infoLabels['tvrage_id'], external_source="tvrage_id",
-                                        tipo=tipo, idioma_busqueda=idioma_busqueda)
+                    otmdb = Tmdb(external_id=item.infoLabels['tvrage_id'], external_source="tvrage_id",
+                                 tipo=tipo, idioma_busqueda=idioma_busqueda)
 
-            if otmdb_global is None:
+            if otmdb is None:
                 # No se ha podido buscar por ID...
                 # hacerlo por titulo
                 if item.infoLabels['title'] != '':
                     if tipo == 'tv':
                         # Busqueda de serie por titulo y filtrando sus resultados si es necesario
-                        otmdb_global = Tmdb(texto_buscado=item.infoLabels['tvshowtitle'], tipo=tipo,
-                                            idioma_busqueda=idioma_busqueda, filtro=item.infoLabels.get('filtro', {}),
-                                            year=str(item.infoLabels.get('year', '')))
+                        otmdb = Tmdb(texto_buscado=item.infoLabels['tvshowtitle'], tipo=tipo,
+                                     idioma_busqueda=idioma_busqueda, filtro=item.infoLabels.get('filtro', {}),
+                                     year=str(item.infoLabels.get('year', '')))
                     else:
                         # Busqueda de pelicula por titulo...
                         if item.infoLabels['year'] or 'filtro' in item.infoLabels:
                             # ...y año o filtro
-                            titulo_buscado = item.fulltitle if item.fulltitle != '' else \
-                                (item.contentTitle if item.contentTitle != '' else item.infoLabels['title'])
-                            otmdb_global = Tmdb(texto_buscado=titulo_buscado, tipo=tipo,
-                                                idioma_busqueda=idioma_busqueda,
-                                                filtro=item.infoLabels.get('filtro', {}),
-                                                year=str(item.infoLabels.get('year', '')))
+                            titulo_buscado = item.fulltitle if item.fulltitle != '' else item.contentTitle
+                            otmdb = Tmdb(texto_buscado=titulo_buscado, tipo=tipo,
+                                         idioma_busqueda=idioma_busqueda,
+                                         filtro=item.infoLabels.get('filtro', {}),
+                                         year=str(item.infoLabels.get('year', '')))
 
-            if otmdb_global is None or not otmdb_global.get_id():
+            if otmdb is None or not otmdb.get_id():
                 # La busqueda no ha dado resultado
                 return obtener_datos_item()
             else:
                 # La busqueda ha encontrado un resultado valido
-                __leer_datos(otmdb_global)
+                __leer_datos(otmdb)
                 return len(item.infoLabels)
 
     else:
@@ -451,11 +381,10 @@ def set_infoLabels_item(item, seekTmdb=False, idioma_busqueda='es', lock=None):
 
 def set_infoLabels_itemlist(item_list, seekTmdb=False, idioma_busqueda='es'):
     """
-    De manera concurrente y respetando los limites de la API, obtiene los datos de los items incluidos en la lista
-    item_list.
+    De manera concurrente, obtiene los datos de los items incluidos en la lista item_list.
 
-    Si la lista sobrepasa los 30 items (limite de peticiones en 10'') solo los primeros 30 se buscaran en
-    www.themoviedb.org, el resto se hara dentro del propio Item independientemente del parametros seekTmdb.
+    La API tiene un limite de 40 peticiones por IP cada 10'' y por eso la lista no deberia tener mas de 30 items
+    para asegurar un buen funcionamiento de esta funcion.
 
     :param item_list: listado de objetos Item que representan peliculas, series o capitulos. El diccionario
         item.infoLabels de cada objeto Item sera modificado incluyendo los datos extras localizados.
@@ -482,12 +411,11 @@ def set_infoLabels_itemlist(item_list, seekTmdb=False, idioma_busqueda='es'):
     def sub_get(item, _i, _seekTmdb):
         semaforo.acquire()
         ret = set_infoLabels_item(item, _seekTmdb, idioma_busqueda, lock)
+        # logger.debug(str(ret) + "item: " + item.tostring())
         semaforo.release()
         r_list.append((_i, item, ret))
 
     for item in item_list:
-        if i > 29:
-            seekTmdb = False
         t = threading.Thread(target=sub_get, args=(item, i, seekTmdb))
         t.start()
         i += 1
@@ -641,11 +569,11 @@ class Tmdb(object):
             url += '&year=' + str(self.busqueda["year"])
 
         buscando = self.busqueda["texto"].capitalize()
-        logger.debug("Buscando %s en pagina %s:\n%s" % (buscando, page, url))
+        logger.info("[Tmdb.py] Buscando %s en pagina %s:\n%s" % (buscando, page, url))
 
         response_dic = {}
         try:
-            response_dic = jsontools.load_json(scrapertools.downloadpage(url))
+            response_dic = jsontools.load_json(scrapertools.downloadpageWithoutCookies(url))
             self.total_results = response_dic["total_results"]
             self.total_pages = response_dic["total_pages"]
         except:
@@ -658,6 +586,7 @@ class Tmdb(object):
             if self.busqueda['filtro']:
                 # TODO documentar esta parte
                 for key, value in dict(self.busqueda['filtro']).items():
+
                     for r in self.results[:]:
                         '''  # Opcion mas permisiva
                         if r.has_key(k) and r[k] != v:
@@ -672,11 +601,11 @@ class Tmdb(object):
             if index_resultado < len(self.results):
                 self.__leer_resultado(self.results[index_resultado])
             else:
-                logger.error("La busqueda de {0} no dio {1} resultados para la pagina {2}"
+                logger.error("La busqueda de '{0}' no dio {1} resultados para la pagina {2}"
                              .format(buscando, index_resultado + 1, page))
         else:
             # No hay resultados de la busqueda
-            logger.error("La busqueda de %s no dio resultados para la pagina %s" % (buscando, page))
+            logger.error("La busqueda de '%s' no dio resultados para la pagina %s" % (buscando, page))
 
     def __by_id(self, source="tmdb"):
 
@@ -696,16 +625,19 @@ class Tmdb(object):
                    '&language=%s' % (self.busqueda["id"], source, self.busqueda["idioma"]))
             buscando = source.capitalize() + ": " + self.busqueda["id"]
 
-        logger.debug("Buscando %s:\n%s" % (buscando, url))
-        resultado = jsontools.load_json(scrapertools.downloadpage(url))
+        logger.info("[Tmdb.py] Buscando %s:\n%s" % (buscando, url))
+        try:
+            resultado = jsontools.load_json(scrapertools.downloadpageWithoutCookies(url))
 
-        if source != "tmdb":
-            if self.busqueda["tipo"] == "movie":
-                resultado = resultado["movie_results"]
-            else:
-                resultado = resultado["tv_results"]
-            if len(resultado) > 0:
-                resultado = resultado[0]
+            if source != "tmdb":
+                if self.busqueda["tipo"] == "movie":
+                    resultado = resultado["movie_results"]
+                else:
+                    resultado = resultado["tv_results"]
+                if len(resultado) > 0:
+                    resultado = resultado[0]
+        except:
+            resultado = {}
 
         if len(resultado) > 0:
             self.result = resultado
@@ -713,12 +645,11 @@ class Tmdb(object):
                 self.results.append(resultado)
                 self.total_results = 1
                 self.total_pages = 1
-            # print resultado
+
             self.__leer_resultado(resultado)
 
         else:  # No hay resultados de la busqueda
             logger.debug("La busqueda de %s no dio resultados." % buscando)
-
 
     def __inicializar(self):
         # Inicializamos las colecciones de resultados, fanart y temporada
@@ -792,7 +723,10 @@ class Tmdb(object):
                 Tmdb.dic_generos[self.busqueda["idioma"]][self.busqueda["tipo"]] = {}
             url = ('http://api.themoviedb.org/3/genre/%s/list?api_key=f7f51775877e0bb6703520952b3c7840&language=%s'
                    % (self.busqueda["tipo"], self.busqueda["idioma"]))
-            lista_generos = jsontools.load_json(scrapertools.downloadpage(url))["genres"]
+            try:
+                lista_generos = jsontools.load_json(scrapertools.downloadpageWithoutCookies(url))["genres"]
+            except:
+                pass
             for i in lista_generos:
                 Tmdb.dic_generos[self.busqueda["idioma"]][self.busqueda["tipo"]][str(i["id"])] = i["name"]
 
@@ -954,7 +888,11 @@ class Tmdb(object):
                     self.busqueda["idioma"] = self.result['original_language']
                 url = ('http://api.themoviedb.org/3/%s/%s?api_key=f7f51775877e0bb6703520952b3c7840&language=%s' %
                        (self.busqueda["tipo"], self.busqueda["id"], self.busqueda["idioma"]))
-                resultado = jsontools.load_json(scrapertools.downloadpage(url))
+                try:
+                    resultado = jsontools.load_json(scrapertools.downloadpageWithoutCookies(url))
+                except:
+                    pass
+
                 if resultado:
                     if 'overview' in resultado:
                         self.result['overview'] = resultado['overview']
@@ -1105,7 +1043,7 @@ class Tmdb(object):
                 # 'person' No soportado
                 return None
 
-            fanarttv = jsontools.load_json(scrapertools.downloadpage(url))
+            fanarttv = jsontools.load_json(scrapertools.downloadpageWithoutCookies(url))
             if fanarttv is None:  # Si el item buscado no esta en Fanart.tv devolvemos una lista vacia
                 return []
 
@@ -1165,7 +1103,8 @@ class Tmdb(object):
         #   Return: (dic)
         #       Devuelve un dicionario con los siguientes elementos:
         #           "temporada_nombre", "temporada_sinopsis", "temporada_poster", "temporada_num_episodios"(int),
-        #           "episodio_titulo", "episodio_sinopsis" y  "episodio_imagen"
+        #           "episodio_titulo", "episodio_sinopsis", "episodio_imagen", "episodio_air_date", "episodio_air_date",
+        #           "episodio_crew", "episodio_guest_stars", "episodio_vote_count" y "episodio_vote_average"
         # --------------------------------------------------------------------------------------------------------------------------------------------
         if self.result["id"] == "" or self.busqueda["tipo"] != "tv":
             return {}
@@ -1195,7 +1134,11 @@ class Tmdb(object):
         ret_dic["episodio_sinopsis"] = episodio["overview"]
         ret_dic["episodio_imagen"] = ('http://image.tmdb.org/t/p/original' + episodio["still_path"]) if episodio[
             "still_path"] else ""
-
+        ret_dic["episodio_air_date"] = episodio["air_date"]
+        ret_dic["episodio_crew"] = episodio["crew"]
+        ret_dic["episodio_guest_stars"] = episodio["guest_stars"]
+        ret_dic["episodio_vote_count"] = episodio["vote_count"]
+        ret_dic["episodio_vote_average"] = episodio["vote_average"]
         return ret_dic
 
     def get_temporada(self, numtemporada=1):
@@ -1216,7 +1159,8 @@ class Tmdb(object):
             numtemporada = 1
 
         # if not self.temporada.has_key("season_number") or self.temporada["season_number"] != numtemporada:
-        if numtemporada > len(self.temporada) or self.temporada.get(numtemporada) is None:
+        # if numtemporada > len(self.temporada) or self.temporada[numtemporada] is None:
+        if not self.temporada.has_key(numtemporada) or not self.temporada[numtemporada]:
             # Si no hay datos sobre la temporada solicitada, consultar en la web
 
             # http://api.themoviedb.org/3/tv/1407/season/1?api_key=f7f51775877e0bb6703520952b3c7840&language=es&
@@ -1224,10 +1168,12 @@ class Tmdb(object):
             url = "http://api.themoviedb.org/3/tv/%s/season/%s?api_key=f7f51775877e0bb6703520952b3c7840&language=%s" \
                   "&append_to_response=credits" % (self.result["id"], numtemporada, self.busqueda["idioma"])
 
-            buscando = "id_Tmdb: " + str(self.result["id"]) + " temporada: " + str(numtemporada)
+            buscando = "id_Tmdb: " + str(self.result["id"]) + " temporada: " + str(numtemporada) + "\nURL: " + url
             logger.info("[Tmdb.py] Buscando " + buscando)
-
-            self.temporada[numtemporada] = jsontools.load_json(scrapertools.downloadpage(url))
+            try:
+                self.temporada[numtemporada] = jsontools.load_json(scrapertools.downloadpageWithoutCookies(url))
+            except:
+                self.temporada[numtemporada] = ["status_code"]
 
             if "status_code" in self.temporada[numtemporada]:
                 # Se ha producido un error
@@ -1249,7 +1195,11 @@ class Tmdb(object):
                 # Primera búsqueda de videos en el idioma de busqueda
                 url = "http://api.themoviedb.org/3/%s/%s/videos?api_key=f7f51775877e0bb6703520952b3c7840&language=%s" \
                       % (self.busqueda['tipo'], self.result['id'], self.busqueda["idioma"])
-                dict_videos = jsontools.load_json(scrapertools.downloadpage(url))
+                try:
+                    dict_videos = jsontools.load_json(scrapertools.downloadpageWithoutCookies(url))
+                except:
+                    pass
+
                 if dict_videos['results']:
                     dict_videos['results'] = sorted(dict_videos['results'], key=lambda x: (x['type'], x['size']))
                     self.result["videos"] = dict_videos['results']
@@ -1258,7 +1208,11 @@ class Tmdb(object):
             if self.busqueda["idioma"] != 'en':
                 url = "http://api.themoviedb.org/3/%s/%s/videos?api_key=f7f51775877e0bb6703520952b3c7840" \
                       % (self.busqueda['tipo'], self.result['id'])
-                dict_videos = jsontools.load_json(scrapertools.downloadpage(url))
+                try:
+                    dict_videos = jsontools.load_json(scrapertools.downloadpageWithoutCookies(url))
+                except:
+                    pass
+
                 if dict_videos['results']:
                     dict_videos['results'] = sorted(dict_videos['results'], key=lambda x: (x['type'], x['size']))
                     self.result["videos"].extend(dict_videos['results'])
@@ -1282,7 +1236,8 @@ class Tmdb(object):
         devuelto sera el leido como parametro debidamente actualizado.
         :rtype: Dict
         """
-        ret_infoLabels = infoLabels if infoLabels else {}
+        ret_infoLabels = copy.copy(infoLabels) if infoLabels else {}
+
         for k, v in self.result.items():
             if v == '':
                 continue
@@ -1290,7 +1245,7 @@ class Tmdb(object):
                 v = re.sub(r"\n|\r|\t", "", v)
 
             if k == 'overview':
-                ret_infoLabels['plot'] = otmdb_global.get_sinopsis()
+                ret_infoLabels['plot'] = self.get_sinopsis()
             elif k == 'runtime':
                 ret_infoLabels['duration'] = v
             elif k == 'release_date':
@@ -1316,7 +1271,7 @@ class Tmdb(object):
                 ret_infoLabels['IMDBNumber'] = v
                 ret_infoLabels['code'] = v
             elif k == 'genres':
-                ret_infoLabels['genre'] = otmdb_global.get_generos()
+                ret_infoLabels['genre'] = self.get_generos()
             elif k == 'name':
                 ret_infoLabels['title'] = v
             elif k == 'production_companies':
@@ -1353,6 +1308,9 @@ class Tmdb(object):
                     ret_infoLabels['writer'] = ",".join(l_writer)
                 else:
                     ret_infoLabels['writer'] += "," + (",".join(l_writer))
+            elif k == 'videos' and len(v) > 0:
+                if v[0]["site"] == "YouTube":
+                    ret_infoLabels['trailer'] = "https://www.youtube.com/watch?v=" + v[0]["key"]
             elif type(v) == str:
                 ret_infoLabels[k] = v
                 # logger.debug(k +'= '+ v)

--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -216,18 +216,6 @@ def run():
                 if config.get_setting('filter_servers') == 'true':
                     itemlist = filtered_servers(itemlist, server_white_list, server_black_list)
 
-                # Copy infolabels from parent item
-                if 'infoLabels' in item:
-
-                    # All but title
-                    if 'title' in item.infoLabels:
-                        item.infoLabels.pop('title')
-                    new_itemlist = itemlist[:]
-                    itemlist = []
-
-                    for i in new_itemlist:
-                        itemlist.append(i.clone(infoLabels=item.infoLabels))
-
 
                 from platformcode import subtitletools
                 subtitletools.saveSubtitleName(item)

--- a/python/main-classic/platformcode/xbmc_info_window.py
+++ b/python/main-classic/platformcode/xbmc_info_window.py
@@ -287,6 +287,7 @@ class InfoWindow(xbmcgui.WindowXMLDialog):
         self.item = item
         self.indexList = -1
         self.listData = None
+        self.return_value = None
 
         # Obtenemos el canal desde donde se ha echo la llamada y cargamos los settings disponibles para ese canal
         channelpath = inspect.currentframe().f_back.f_back.f_code.co_filename
@@ -301,7 +302,7 @@ class InfoWindow(xbmcgui.WindowXMLDialog):
 
         # Muestra la ventana
         self.doModal()
-        return
+        return self.return_value
 
     def onInit(self):
         # Ponemos el foco en el boton de cerrar [X]

--- a/python/main-classic/platformcode/xbmctools.py
+++ b/python/main-classic/platformcode/xbmctools.py
@@ -46,7 +46,7 @@ except:
 DEBUG = config.get_setting("debug")
 
 def add_new_folder(item, totalItems=0):
-    logger.info('pelisalacarta.platformcode.xbmctools add_new_folder item='+item.tostring())
+    #logger.info('pelisalacarta.platformcode.xbmctools add_new_folder item='+item.tostring())
 
     if item.fulltitle=="":
         item.fulltitle=item.title
@@ -65,7 +65,7 @@ def add_new_folder(item, totalItems=0):
     listitem = xbmcgui.ListItem( item.title, iconImage="DefaultFolder.png", thumbnailImage=item.thumbnail )
 
     if item.action !="":
-        set_infoLabels(listitem,item) # Modificacion introducida por super_berny para añadir infoLabels al ListItem
+        set_infoLabels(listitem,item)
     
     if item.fanart!="":
         listitem.setProperty('fanart_image',item.fanart) 
@@ -77,7 +77,7 @@ def add_new_folder(item, totalItems=0):
         pass
     
     itemurl = '%s?%s' % ( sys.argv[ 0 ] , item.tourl())
-    logger.info("pelisalacarta.platformcode.xbmctools add_new_folder itemurl="+itemurl)
+    #logger.info("pelisalacarta.platformcode.xbmctools add_new_folder itemurl="+itemurl)
 
     #if item.show != "": #Añadimos opción contextual para Añadir la serie completa a la biblioteca
     #    addSerieCommand = "XBMC.RunPlugin(%s?%s)" % ( sys.argv[ 0 ] , item.clone(action="addlist2Library").tourl())
@@ -124,7 +124,7 @@ def add_new_folder(item, totalItems=0):
     return ok
 
 def add_new_video(item, IsPlayable='false', totalItems = 0):
-    logger.info('pelisalacarta.platformcode.xbmctools add_new_video item='+item.tostring())
+    #logger.info('pelisalacarta.platformcode.xbmctools add_new_video item='+item.tostring())
 
     # TODO: Posible error en trailertools.py
     contextCommands = []
@@ -145,7 +145,7 @@ def add_new_video(item, IsPlayable='false', totalItems = 0):
     listitem = xbmcgui.ListItem( item.title, iconImage="DefaultVideo.png", thumbnailImage=item.thumbnail )
 
     if item.action !="":
-        set_infoLabels(listitem,item) # Modificacion introducida por super_berny para añadir infoLabels al ListItem
+        set_infoLabels(listitem,item)
    
     if item.fanart!="":
         #logger.info("item.fanart :%s" %item.fanart)
@@ -168,7 +168,7 @@ def add_new_video(item, IsPlayable='false', totalItems = 0):
         pass
 
     itemurl = '%s?%s' % ( sys.argv[ 0 ] , item.tourl())
-    logger.info("pelisalacarta.platformcode.xbmctools add_new_video itemurl="+itemurl)
+    #logger.info("pelisalacarta.platformcode.xbmctools add_new_video itemurl="+itemurl)
 
     if item.totalItems == 0:
         ok = xbmcplugin.addDirectoryItem( handle = pluginhandle, url=itemurl, listitem=listitem, isFolder=False)
@@ -982,36 +982,18 @@ def alert_no_puedes_ver_video(server,url,motivo):
         resultado = advertencia.ok( "No puedes ver ese vídeo porque...","El servidor donde está alojado no está","soportado en pelisalacarta todavía",url)
 
 def set_infoLabels(listitem,item):
-    '''
-    Metodo para añadir informacion extra al listitem.
-    Se mantiene por retocompatibilidad, pero deberia despreciarse en futuras versiones.
-    '''
-    if item.plot.startswith("{'infoLabels'"):
-        # Esta forma de pasar la informacion al listitem es obsoleta y deberia despreciarse
-        # plot tiene que ser un str con el siguiente formato:
-        #   plot="{'infoLabels':{dicionario con los pares de clave/valor descritos en
-        #               http://mirrors.xbmc.org/docs/python-docs/14.x-helix/xbmcgui.html#ListItem-setInfo}}"
+    """
+    Metodo para pasar la informacion al listitem (ver tmdb.set_InfoLabels() )
+    item.infoLabels es un dicionario con los pares de clave/valor descritos en:
+    http://mirrors.xbmc.org/docs/python-docs/14.x-helix/xbmcgui.html#ListItem-setInfo
+    :param listitem: objeto xbmcgui.ListItem
+    :param item: objeto Item que representa a una pelicula, serie o capitulo
+    :return: None
+    """
+    if item.plot and item.infoLabels.get("plot","") == "":
+        item.infoLabels['plot'] = item.plot
 
-        try:
-            import ast
-            infodict=ast.literal_eval(item.plot)['infoLabels']
+    it = item.clone()
+    it.infoLabels['title'] = it.title
 
-            #if not infodict.has_key('title'): 
-            #    infodict['title'] = item.title
-            infodict['title'] = item.title
-            
-            listitem.setInfo( "video", infodict)
-        except:
-            pass
-
-    elif len(item.infoLabels) >0:
-        # Nuevo modelo para pasar la informacion al listitem (ver tmdb.set_InfoLabels() )
-        # item.infoLabels es un dicionario con los pares de clave/valor descritos en:
-        # http://mirrors.xbmc.org/docs/python-docs/14.x-helix/xbmcgui.html#ListItem-setInfo
-        item.infoLabels['title'] = item.title
-        listitem.setInfo( "video", item.infoLabels)
-
-    elif item.plot !='':
-        # Retrocompatibilidad con canales q no utilizan infoLabels de ningun tipo
-        listitem.setInfo( "video", { "Title" : item.title, "Plot" : item.plot, "Studio" : item.channel.capitalize() } )
-
+    listitem.setInfo("video", it.infoLabels)


### PR DESCRIPTION
item: Ahora no se almacenan datos en los atributos contentXXX, sino q se utiliza el infolabel apropiado para ello.

tmdb: Corregidos errores al buscar listados de modo concurrente. Gracias a @CmosGit
launcher: Solucionado bug #348
xbmctools: Se fija un solo metodo para añadir informacion al listitem. Los antiguos metodos quedan descartados