### PR TITLE
Real-debrid en plataformas no kodi - Fix hdfull para plex - Fix openload/Flashx

### DIFF
--- a/python/main-classic/channels/ayuda.py
+++ b/python/main-classic/channels/ayuda.py
@@ -46,11 +46,15 @@ def mainlist(item):
         cuantos += cuantos
 
     if not config.is_xbmc():
-        title = "Activar cuenta real-debrid"
+        from core import channeltools
+        title = "Activar cuenta real-debrid (No activada)"
         action = "realdebrid"
+        token_auth = channeltools.get_channel_setting("realdebrid_token", "realdebrid")
         if config.get_setting("realdebridpremium") == "false":
-            title += " (Marca la casilla en la ventana de configuración de pelisalacarta para continuar)"
+            title = "Activar cuenta real-debrid (Marca la casilla en la ventana de configuración de pelisalacarta para continuar)"
             action = ""
+        elif token_auth:
+            title = "Activar cuenta real-debrid (Activada correctamente)"
         itemlist.append(Item(channel=item.channel, action=action, title=title))
 
     return itemlist

--- a/python/main-classic/channels/ayuda.py
+++ b/python/main-classic/channels/ayuda.py
@@ -45,6 +45,14 @@ def mainlist(item):
                              title="Restaurar advancedsettings.xml del backup", folder=False))
         cuantos += cuantos
 
+    if not config.is_xbmc():
+        title = "Activar cuenta real-debrid"
+        action = "realdebrid"
+        if config.get_setting("realdebridpremium") == "false":
+            title += " (Marca la casilla en la ventana de configuración de pelisalacarta para continuar)"
+            action = ""
+        itemlist.append(Item(channel=item.channel, action=action, title=title))
+
     return itemlist
 
 
@@ -308,3 +316,88 @@ def recover_advancedsettings(item):
         logger.info("pelisalacarta.channels.ayuda Optimizacion de adavancedsettings.xml cancelada!")
 
     return []
+
+
+def realdebrid(item):
+    logger.info("pelisalacarta.channels.ayuda realdebrid")
+    itemlist = []
+    
+    verify_url, user_code, device_code = request_access()
+    
+    itemlist.append(Item(channel=item.channel, action="", title="Pasos para realizar la autenticación (Estando logueado en tu cuenta real-debrid):"))
+    itemlist.append(Item(channel=item.channel, action="", title="1. Abre el navegador y entra en esta página: %s" % verify_url))
+    itemlist.append(Item(channel=item.channel, action="", title='2. Introduce este código y presiona "Allow": %s' % user_code))
+    itemlist.append(Item(channel=item.channel, action="authentication", title="--> Pulsa aquí una vez introducido el código <---", extra=device_code))
+    
+    return itemlist
+
+
+def request_access():
+    logger.info("pelisalacarta.channels.ayuda request_access")
+    from core import jsontools
+    from core import scrapertools
+    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:47.0) Gecko/20100101 Firefox/47.0'}
+    try:
+        client_id = "YTWNFBIJEEBP6"
+        
+        # Se solicita url y código de verificación para conceder permiso a la app
+        url = "http://api.real-debrid.com/oauth/v2/device/code?client_id=%s&new_credentials=yes" % (client_id)
+        data = scrapertools.downloadpage(url, headers=headers.items())
+        data = jsontools.load_json(data)
+        verify_url = data["verification_url"]
+        user_code = data["user_code"]
+        device_code = data["device_code"]
+
+        return verify_url, user_code, device_code
+    except:
+        import traceback
+        logger.error(traceback.format_exc())
+        return "", "", ""
+
+
+def authentication(item):
+    logger.info("pelisalacarta.channels.ayuda authentication")
+    import urllib
+    from core import channeltools
+    from core import jsontools
+    from core import scrapertools
+
+    itemlist = []
+    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:47.0) Gecko/20100101 Firefox/47.0'}
+    client_id = "YTWNFBIJEEBP6"
+    device_code = item.extra
+    token = ""
+    try:
+        url = "https://api.real-debrid.com/oauth/v2/device/credentials?client_id=%s&code=%s" \
+              % (client_id, device_code)
+        data = scrapertools.downloadpage(url, headers=headers.items())
+        data = jsontools.load_json(data)
+
+        debrid_id = data["client_id"]
+        secret = data["client_secret"] 
+
+        # Se solicita el token de acceso y el de actualización para cuando el primero caduque
+        post = urllib.urlencode({"client_id": debrid_id, "client_secret": secret, "code": device_code,
+                                 "grant_type": "http://oauth.net/grant_type/device/1.0"})
+        data = scrapertools.downloadpage("https://api.real-debrid.com/oauth/v2/token", post=post,
+                                         headers=headers.items())
+        data = jsontools.load_json(data)
+
+        token = data["access_token"]
+        refresh = data["refresh_token"]
+
+        channeltools.set_channel_setting("realdebrid_id", debrid_id, "realdebrid")
+        channeltools.set_channel_setting("realdebrid_secret", secret, "realdebrid")
+        channeltools.set_channel_setting("realdebrid_token", token, "realdebrid")
+        channeltools.set_channel_setting("realdebrid_refresh", refresh, "realdebrid")
+        
+    except:
+        import traceback
+        logger.error(traceback.format_exc())
+
+    if token:
+        itemlist.append(Item(channel=item.channel, action="", title="Cuenta activada correctamente"))
+    else:
+        itemlist.append(Item(channel=item.channel, action="", title="Error en el proceso de activación, vuelve a intentarlo"))
+
+    return itemlist

--- a/python/main-classic/channels/hdfull.py
+++ b/python/main-classic/channels/hdfull.py
@@ -19,7 +19,11 @@ from core import servertools
 
 
 host = "http://hdfull.tv"
-account = ( config.get_setting('hdfulluser', 'hdfull') != "" )
+if config.get_setting('hdfulluser', 'hdfull'):
+    account = True
+else:
+    account = False
+
 
 
 def settingCanal(item):

--- a/python/main-classic/channels/hdfull.py
+++ b/python/main-classic/channels/hdfull.py
@@ -104,6 +104,7 @@ def search(item,texto):
 
     sid = scrapertools.get_match(data, '.__csrf_magic. value="(sid:[^"]+)"')
     item.extra = urllib.urlencode({'__csrf_magic':sid})+'&menu=search&query='+texto
+    item.title = "Buscar..."
     item.url = host+"/buscar"
 
     try:

--- a/python/main-classic/channels/hdfull.xml
+++ b/python/main-classic/channels/hdfull.xml
@@ -12,9 +12,9 @@
 	<bannermenu>http://media.tvalacarta.info/pelisalacarta/bannermenu/hdfull.png</bannermenu>
 
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/channels/</update_url>
-	<version>5</version>
-	<date>19/07/2016</date>
-	<changes>Corregida funcion play</changes>
+	<version>6</version>
+	<date>05/08/2016</date>
+	<changes>Arreglada búsqueda global</changes>
 
 
 	<categories>
@@ -41,8 +41,8 @@
 		<id>include_in_global_search</id>
 		<type>bool</type>
 		<label>Incluir en busqueda global</label>
-		<default>false</default>
-		<enabled>!eq(-1,'') + !eq(-2,'')</enabled>
-		<visible>false</visible>
+		<default>true</default>
+		<enabled>true</enabled>
+		<visible>true</visible>
 	</settings>
 </channel>

--- a/python/main-classic/core/servertools.py
+++ b/python/main-classic/core/servertools.py
@@ -240,13 +240,12 @@ def resolve_video_urls_for_playing(server,url,video_password="",muestra_dialogo=
                   progreso.update((100 / len(opciones)) * opciones.index(premium)  , "Conectando con "+premium)
                 exec "from servers import "+premium+" as premium_conector"
                 if premium == "realdebrid":
-                    if config.is_xbmc() or config.get_platform() == "mediaserver":
-                        debrid_urls = premium_conector.get_video_url( page_url=url , premium=True , video_password=video_password )
-                        if not "REAL-DEBRID:" in debrid_urls[0][0]:
-                            video_urls.extend(debrid_urls)
-                        else:
-                            if len(video_urls) == 0:
-                                return video_urls, False, debrid_urls[0][0]
+                    debrid_urls = premium_conector.get_video_url( page_url=url , premium=True , video_password=video_password )
+                    if not "REAL-DEBRID:" in debrid_urls[0][0]:
+                        video_urls.extend(debrid_urls)
+                    else:
+                        if len(video_urls) == 0:
+                            return video_urls, False, debrid_urls[0][0]
                 else:
                     video_urls.extend(premium_conector.get_video_url( page_url=url , premium=True , user=config.get_setting(premium+"user") , password=config.get_setting(premium+"password"), video_password=video_password ))
 

--- a/python/main-classic/lib/jjdecode.py
+++ b/python/main-classic/lib/jjdecode.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python
+#
+# Python version of the jjdecode function written by Syed Zainudeen
+# http://csc.cs.utm.my/syed/images/files/jjdecode/jjdecode.html
+# 
+# +NCR/CRC! [ReVeRsEr] - crackinglandia@gmail.com
+# Thanks to Jose Miguel Esparza (@EternalTodo) for the final push to make it work!
+#
+
+import re
+
+class JJDecoder(object):
+
+	def __init__(self, jj_encoded_data):
+		self.encoded_str = jj_encoded_data
+
+		
+	def clean(self):
+		return re.sub('^\s+|\s+$', '', self.encoded_str)
+
+		
+	def checkPalindrome(self, Str):
+		startpos = -1
+		endpos = -1
+		gv, gvl = -1, -1
+
+		index = Str.find('"\'\\"+\'+",')
+
+		if index == 0:
+			startpos = Str.find('$$+"\\""+') + 8
+			endpos = Str.find('"\\"")())()')
+			gv = Str[Str.find('"\'\\"+\'+",')+9:Str.find('=~[]')]
+			gvl = len(gv)
+		else:
+			gv = Str[0:Str.find('=')]
+			gvl = len(gv)
+			startpos = Str.find('"\\""+') + 5
+			endpos = Str.find('"\\"")())()')
+
+		return (startpos, endpos, gv, gvl)
+
+		
+	def decode(self):
+		
+		self.encoded_str = self.clean()
+		startpos, endpos, gv, gvl = self.checkPalindrome(self.encoded_str)
+
+		if startpos == endpos:
+			raise Exception('No data!')
+
+		data = self.encoded_str[startpos:endpos]
+
+		b = ['___+', '__$+', '_$_+', '_$$+', '$__+', '$_$+', '$$_+', '$$$+', '$___+', '$__$+', '$_$_+', '$_$$+', '$$__+', '$$_$+', '$$$_+', '$$$$+']
+
+		str_l = '(![]+"")[' + gv + '._$_]+'
+		str_o 	= gv + '._$+'
+		str_t = gv + '.__+'
+		str_u = gv + '._+'
+		
+		str_hex = gv + '.'
+
+		str_s = '"'
+		gvsig = gv + '.'
+
+		str_quote = '\\\\\\"'
+		str_slash = '\\\\\\\\'
+
+		str_lower = '\\\\"+'
+		str_upper = '\\\\"+' + gv + '._+'
+
+		str_end	= '"+'
+
+		out = ''
+		while data != '':
+			# l o t u
+			if data.find(str_l) == 0:
+				data = data[len(str_l):]
+				out += 'l'
+				continue
+			elif data.find(str_o) == 0:
+				data = data[len(str_o):]
+				out += 'o'
+				continue
+			elif data.find(str_t) == 0:
+				data = data[len(str_t):]
+				out += 't'
+				continue
+			elif data.find(str_u) == 0:
+				data = data[len(str_u):]
+				out += 'u'
+				continue
+
+			# 0123456789abcdef
+			if data.find(str_hex) == 0:
+				data = data[len(str_hex):]
+				
+				for i in range(len(b)):
+					if data.find(b[i]) == 0:
+						data = data[len(b[i]):]
+						out += '%x' % i
+						break
+				continue
+
+			# start of s block
+			if data.find(str_s) == 0:
+				data = data[len(str_s):]
+
+				# check if "R
+				if data.find(str_upper) == 0: # r4 n >= 128
+					data = data[len(str_upper):] # skip sig
+					ch_str = ''
+					for i in range(2): # shouldn't be more than 2 hex chars
+						# gv + "."+b[ c ]
+						if data.find(gvsig) == 0:
+							data = data[len(gvsig):]
+							for k in range(len(b)): # for every entry in b
+								if data.find(b[k]) == 0:
+									data = data[len(b[k]):]
+									ch_str = '%x' % k
+									break
+						else:
+							break
+
+					out += chr(int(ch_str, 16))
+					continue
+
+				elif data.find(str_lower) == 0: # r3 check if "R // n < 128
+					data = data[len(str_lower):] # skip sig
+					
+					ch_str = ''
+					ch_lotux = ''
+					temp = ''
+					b_checkR1 = 0
+					for j in range(3): # shouldn't be more than 3 octal chars
+						if j > 1: # lotu check
+							if data.find(str_l) == 0:
+								data = data[len(str_l):]
+								ch_lotux = 'l'
+								break
+							elif data.find(str_o) == 0:
+								data = data[len(str_o):]
+								ch_lotux = 'o'
+								break
+							elif data.find(str_t) == 0:
+								data = data[len(str_t):]
+								ch_lotux = 't'
+								break
+							elif data.find(str_u) == 0:
+								data = data[len(str_u):]
+								ch_lotux = 'u'
+								break
+
+						# gv + "."+b[ c ]
+						if data.find(gvsig) == 0:
+							temp = data[len(gvsig):]
+							for k in range(8): # for every entry in b octal
+								if temp.find(b[k]) == 0:
+									if int(ch_str + str(k), 8) > 128:
+										b_checkR1 = 1
+										break
+
+									ch_str += str(k)
+									data = data[len(gvsig):] # skip gvsig
+									data = data[len(b[k]):]
+									break
+
+							if b_checkR1 == 1:
+								if data.find(str_hex) == 0: # 0123456789abcdef
+									data = data[len(str_hex):]
+									# check every element of hex decode string for a match
+									for i in range(len(b)):
+										if data.find(b[i]) == 0:
+											data = data[len(b[i]):]
+											ch_lotux = '%x' % i
+											break
+									break
+						else:
+							break
+
+					out += chr(int(ch_str,8)) + ch_lotux
+					continue
+
+				else: # "S ----> "SR or "S+
+					# if there is, loop s until R 0r +
+					# if there is no matching s block, throw error
+					
+					match = 0;
+					n = None
+
+					# searching for matching pure s block
+					while True:
+						n = ord(data[0])
+						if data.find(str_quote) == 0:
+							data = data[len(str_quote):]
+							out += '"'
+							match += 1
+							continue
+						elif data.find(str_slash) == 0:
+							data = data[len(str_slash):]
+							out += '\\'
+							match += 1
+							continue
+						elif data.find(str_end) == 0: # reached end off S block ? +
+							if match == 0:
+								raise '+ no match S block: ' + data
+							data = data[len(str_end):]
+							break # step out of the while loop
+						elif data.find(str_upper) == 0: # r4 reached end off S block ? - check if "R n >= 128
+							if match == 0:
+								raise 'no match S block n>128: ' + data
+							data = data[len(str_upper):] # skip sig
+							
+							ch_str = ''
+							ch_lotux = ''
+
+							for j in range(10): # shouldn't be more than 10 hex chars
+								if j > 1: # lotu check
+									if data.find(str_l) == 0:
+										data = data[len(str_l):]
+										ch_lotux = 'l'
+										break
+									elif data.find(str_o) == 0:
+										data = data[len(str_o):]
+										ch_lotux = 'o'
+										break
+									elif data.find(str_t) == 0:
+										data = data[len(str_t):]
+										ch_lotux = 't'
+										break
+									elif data.find(str_u) == 0:
+										data = data[len(str_u):]
+										ch_lotux = 'u'
+										break
+
+								# gv + "."+b[ c ]
+								if data.find(gvsig) == 0:
+									data = data[len(gvsig):] # skip gvsig
+									for k in range(len(b)): # for every entry in b
+										if data.find(b[k]) == 0:
+											data = data[len(b[k]):]
+											ch_str += '%x' % k
+											break
+								else:
+									break # done
+							out += chr(int(ch_str, 16))
+							break # step out of the while loop
+						elif data.find(str_lower) == 0: # r3 check if "R // n < 128
+							if match == 0:
+								raise 'no match S block n<128: ' + data
+
+							data = data[len(str_lower):] # skip sig
+
+							ch_str = ''
+							ch_lotux = ''
+							temp = ''
+							b_checkR1 = 0
+
+							for j in range(3): # shouldn't be more than 3 octal chars
+								if j > 1: # lotu check
+									if data.find(str_l) == 0:
+										data = data[len(str_l):]
+										ch_lotux = 'l'
+										break
+									elif data.find(str_o) == 0:
+										data = data[len(str_o):]
+										ch_lotux = 'o'
+										break
+									elif data.find(str_t) == 0:
+										data = data[len(str_t):]
+										ch_lotux = 't'
+										break
+									elif data.find(str_u) == 0:
+										data = data[len(str_u):]
+										ch_lotux = 'u'
+										break
+
+								# gv + "."+b[ c ]
+								if data.find(gvsig) == 0:
+									temp = data[len(gvsig):]
+									for k in range(8): # for every entry in b octal
+										if temp.find(b[k]) == 0:
+											if int(ch_str + str(k), 8) > 128:
+												b_checkR1 = 1
+												break
+
+											ch_str += str(k)
+											data = data[len(gvsig):] # skip gvsig
+											data = data[len(b[k]):]
+											break
+
+									if b_checkR1 == 1:
+										if data.find(str_hex) == 0: # 0123456789abcdef
+											data = data[len(str_hex):]
+											# check every element of hex decode string for a match
+											for i in range(len(b)):
+												if data.find(b[i]) == 0:
+													data = data[len(b[i]):]
+													ch_lotux = '%x' % i
+													break
+								else:
+									break
+							out += chr(int(ch_str, 8)) + ch_lotux
+							break # step out of the while loop
+						elif (0x21 <= n and n <= 0x2f) or (0x3A <= n and n <= 0x40) or ( 0x5b <= n and n <= 0x60 ) or ( 0x7b <= n and n <= 0x7f ):
+							out += data[0]
+							data = data[1:]
+							match += 1
+					continue
+			print 'No match : ' + data
+			break
+		return out

--- a/python/main-classic/servers/flashx.py
+++ b/python/main-classic/servers/flashx.py
@@ -7,6 +7,8 @@
 
 import os
 import re
+import time
+import urllib
 
 from core import config
 from core import logger
@@ -14,13 +16,15 @@ from core import jsunpack
 from core import scrapertools
 
 
-headers = [['User-Agent', 'Mozilla/5.0']]
+headers = [['User-Agent', 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:46.0) Gecko/20100101 Firefox/46.0'],
+           ['Accept', '*/*'],
+           ['Connection', 'keep-alive']]
 
 
 def test_video_exists(page_url):
     logger.info("pelisalacarta.servers.flashx test_video_exists(page_url='%s')" % page_url)
 
-    data = scrapertools.cache_page(page_url, headers=headers)
+    data = scrapertools.downloadpageWithoutCookies(page_url)
 
     if 'FILE NOT FOUND' in data:
         return False, "[FlashX] El archivo no existe o ha sido borrado"
@@ -31,18 +35,31 @@ def test_video_exists(page_url):
 def get_video_url(page_url, premium=False, user="", password="", video_password=""):
     logger.info("pelisalacarta.servers.flashx url=" + page_url)
 
-    # Lo pide una vez
-    data = scrapertools.cache_page(page_url, headers=headers)
-    # Si salta aviso, se carga la pagina de comprobacion y luego la inicial
-    if "You try to access this video with Kodi" in data:
-        url_reload = scrapertools.find_single_match(data, 'try to reload the page.*?href="([^"]+)"')
-        data = scrapertools.cache_page(url_reload, headers=headers)
-        data = scrapertools.cache_page(page_url, headers=headers)
+    data = scrapertools.downloadpageWithoutCookies(page_url)
 
-    match = scrapertools.find_single_match(data, "<script type='text/javascript'>(.*?)</script>")
+    file_id = scrapertools.find_single_match(data, "'file_id', '([^']+)'")
+    aff = scrapertools.find_single_match(data, "'aff', '([^']+)'")
+    headers_c = [['User-Agent', 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:46.0) Gecko/20100101 Firefox/46.0'],
+                 ['Referer', page_url],
+                 ['Cookie', '; lang=1']]
+    coding = scrapertools.downloadpage("http://www.flashx.tv/coding.js?c=%s" % file_id, headers=headers_c)
 
-    if match.startswith("eval"):
+    data = scrapertools.downloadpage(page_url, headers=headers)
+    flashx_id = scrapertools.find_single_match(data, 'name="id" value="([^"]+)"')
+    fname = scrapertools.find_single_match(data, 'name="fname" value="([^"]+)"')
+    hash_f = scrapertools.find_single_match(data, 'name="hash" value="([^"]+)"')
+    post = 'op=download1&usr_login=&id=%s&fname=%s&referer=&hash=%s&imhuman=Proceed+to+video' % (flashx_id, urllib.quote(fname), hash_f)
+
+    time.sleep(6)
+    headers.append(['Referer', page_url])
+    headers.append(['Cookie', 'lang=1; file_id=%s; aff=%s' % (file_id, aff)])
+    data = scrapertools.downloadpage('http://www.flashx.tv/dl?%s' % flashx_id, post=post, headers=headers)
+
+    match = scrapertools.find_single_match(data, "(eval\(function\(p,a,c,k.*?)\s+</script>")
+    if match:
         match = jsunpack.unpack(match)
+    else:
+        match = data
 
     # Extrae la URL
     # {file:"http://f11-play.flashx.tv/luq4gfc7gxixexzw6v4lhz4xqslgqmqku7gxjf4bk43u4qvwzsadrjsozxoa/video1.mp4"}
@@ -78,13 +95,13 @@ def find_videos(data):
 
     # http://flashx.tv/z3nnqbspjyne
     # http://www.flashx.tv/embed-li5ydvxhg514.html
-    patronvideos = 'flashx.(?:tv|pw)/(?:embed.php\?c=|embed-|)([A-z0-9]+)'
+    patronvideos = 'flashx.(?:tv|pw)/(?:embed.php\?c=|embed-|playvid-|)([A-z0-9]+)'
     logger.info("pelisalacarta.servers.flashx find_videos #" + patronvideos + "#")
     matches = re.compile(patronvideos, re.DOTALL).findall(data)
 
     for match in matches:
         titulo = "[flashx]"
-        url = "http://www.flashx.tv/playvid-%s.html" % match
+        url = "http://www.flashx.tv/%s.html" % match
         if url not in encontrados:
             logger.info("  url=" + url)
             devuelve.append([titulo, url, 'flashx'])

--- a/python/main-classic/servers/flashx.py
+++ b/python/main-classic/servers/flashx.py
@@ -26,7 +26,7 @@ def test_video_exists(page_url):
 
     data = scrapertools.downloadpageWithoutCookies(page_url)
 
-    if 'FILE NOT FOUND' in data:
+    if 'File Not Found' in data:
         return False, "[FlashX] El archivo no existe o ha sido borrado"
 
     return True, ""
@@ -42,7 +42,10 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
     headers_c = [['User-Agent', 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:46.0) Gecko/20100101 Firefox/46.0'],
                  ['Referer', page_url],
                  ['Cookie', '; lang=1']]
-    coding = scrapertools.downloadpage("http://www.flashx.tv/coding.js?c=%s" % file_id, headers=headers_c)
+    coding_url = scrapertools.find_single_match(data, 'src="(http://www.flashx.tv/\w+.js\?[^"]+)"')
+    if coding_url.endswith("="):
+        coding_url += file_id
+    coding = scrapertools.downloadpage(coding_url, headers=headers_c)
 
     data = scrapertools.downloadpage(page_url, headers=headers)
     flashx_id = scrapertools.find_single_match(data, 'name="id" value="([^"]+)"')

--- a/python/main-classic/servers/openload.py
+++ b/python/main-classic/servers/openload.py
@@ -53,6 +53,7 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
                     videourl = decode_hidden(hiddenurl)
                 else:
                     videourl = decodeopenload(data)
+            videourl = scrapertools.getLocationHeaderFromResponse(videourl)
         else:
             text_encode = scrapertools.find_multiple_matches(data, '(ﾟωﾟ.*?\(\'\_\'\));')
             try:
@@ -222,11 +223,14 @@ def decodeopenload(data):
 
 def decode_hidden(text):
     text = scrapertools.decodeHtmlentities(text)
+    text = text.replace("&gt9", ">").replace("&quot9", '"').replace("&lt9", '<').replace("&amp9", '&')
     s = []
     for char in text:
         j = ord(char)
         s.append(chr(33 + ((j+14) % 94)))
 
-    videourl = "https://openload.co/stream/{0}?mime=true".format("".join(s))
+    temp = "".join(s)
+    text_decode = temp[:len(temp)-1] + chr(ord(temp[-1]) + 2)
+    videourl = "https://openload.co/stream/{0}?mime=true".format(text_decode)
 
     return videourl

--- a/python/main-classic/servers/openload.py
+++ b/python/main-classic/servers/openload.py
@@ -155,12 +155,21 @@ def decodeopenload(data):
         imageTabs[i][j].append(imageStr[idx])
 
     # get signature data
-    scripts = scrapertools.find_multiple_matches(data, '<script src="(/assets/js/obfuscator/[^"]+)"')
-    for scr in scripts:
-        data = scrapertools.downloadpageWithoutCookies('https://openload.co%s' % scr)
-        if "signatureNumbers" in data:
-            break
-    signStr = scrapertools.find_single_match(data, '[\'"]([^"\']+)[\'"]')
+    signStr = ""
+    try:
+        data_obf = scrapertools.downloadpageWithoutCookies("https://openload.co/assets/js/obfuscator/n.js")
+        if "signatureNumbers" in data_obf:
+            signStr = scrapertools.find_single_match(data_obf, '[\'"]([^"\']+)[\'"]')
+    except:
+        pass
+
+    if not signStr:
+        scripts = scrapertools.find_multiple_matches(data, '<script src="(/assets/js/obfuscator/[^"]+)"')
+        for scr in scripts:
+            data_obf = scrapertools.downloadpageWithoutCookies('https://openload.co%s' % scr)
+            if "signatureNumbers" in data_obf:
+                signStr = scrapertools.find_single_match(data_obf, '[\'"]([^"\']+)[\'"]')
+                break
 
     # split signature data
     signTabs = []

--- a/python/main-classic/servers/openload.py
+++ b/python/main-classic/servers/openload.py
@@ -12,7 +12,7 @@ from core import logger
 from core import scrapertools
 
 
-headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:46.0) Gecko/20100101 Firefox/46.0'}
+headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:47.0) Gecko/20100101 Firefox/47.0'}
 
 
 def test_video_exists(page_url):
@@ -48,9 +48,13 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
                 videourl = "http://"
 
             if videourl == "http://":
-                videourl = decodeopenload(data)
+                hiddenurl = scrapertools.find_single_match(data, 'id="hiddenurl\s*">(.*?)<')
+                if hiddenurl:
+                    videourl = decode_hidden(hiddenurl)
+                else:
+                    videourl = decodeopenload(data)
         else:
-            text_encode = scrapertools.find_multiple_matches(data,'<script[^>]+>(ﾟωﾟ.*?)</script>')
+            text_encode = scrapertools.find_multiple_matches(data, '(ﾟωﾟ.*?\(\'\_\'\));')
             try:
                 decodeindex = aadecode(text_encode[0])
                 subtract = scrapertools.find_single_match(decodeindex, 'welikekodi.*?(\([^;]+\))')
@@ -63,7 +67,11 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
                 text_decode = aadecode(text_encode[index])
                 videourl = "https://" + scrapertools.find_single_match(text_decode, "(openload.co/.*?)\}")
             else:
-                videourl = decodeopenload(data)
+                hiddenurl = scrapertools.find_single_match(data, 'id="hiddenurl\s*">(.*?)<')
+                if hiddenurl:
+                    videourl = decode_hidden(hiddenurl)
+                else:
+                    videourl = decodeopenload(data)
 
             videourl = scrapertools.getLocationHeaderFromResponse(videourl)
     except:
@@ -209,4 +217,16 @@ def decodeopenload(data):
     res = res[3] + '~' + res[1] + '~' + res[2] + '~' + res[0]
     videourl = 'https://openload.co/stream/{0}?mime=true'.format(res)
     
+    return videourl
+
+
+def decode_hidden(text):
+    text = scrapertools.decodeHtmlentities(text)
+    s = []
+    for i in range(0, len(text)):
+        j = ord(text[i])
+        s.append(chr(33 + ((j+14) % 94)))
+
+    videourl = "https://openload.co/stream/{0}?mime=true".format("".join(s))
+
     return videourl

--- a/python/main-classic/servers/openload.py
+++ b/python/main-classic/servers/openload.py
@@ -33,7 +33,7 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
     data = scrapertools.downloadpageWithoutCookies(page_url)
     subtitle = scrapertools.find_single_match(data, '<track kind="captions" src="([^"]+)" srclang="es"')
     #Header para la descarga
-    header_down = "|User-Agent="+headers['User-Agent']+"|"
+    header_down = "|User-Agent="+headers['User-Agent']
 
     try:
         from lib.aadecode import decode as aadecode
@@ -49,8 +49,6 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
 
             if videourl == "http://":
                 videourl = decodeopenload(data)
-            extension = scrapertools.find_single_match(data, '<meta name="description" content="([^"]+)"')
-            extension = "." + extension.rsplit(".", 1)[1]
         else:
             text_encode = scrapertools.find_multiple_matches(data,'<script[^>]+>(ﾟωﾟ.*?)</script>')
             try:
@@ -63,11 +61,11 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
                 index = int(eval(subtract))
                 # Buscamos la variable que nos indica el script correcto
                 text_decode = aadecode(text_encode[index])
-                videourl = "http://" + scrapertools.find_single_match(text_decode, "(openload.co/.*?)\}")
-                extension = "." + scrapertools.find_single_match(text_decode, "video/(\w+)")
+                videourl = "https://" + scrapertools.find_single_match(text_decode, "(openload.co/.*?)\}")
             else:
                 videourl = decodeopenload(data)
-                extension = "." + scrapertools.find_single_match(decodeindex, "video/(\w+)")
+
+            videourl = scrapertools.getLocationHeaderFromResponse(videourl)
     except:
         import traceback
         logger.info("pelisalacarta.servers.openload "+traceback.format_exc())
@@ -85,7 +83,10 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
             data = jsontools.load_json(data)
             extension = "." + scrapertools.find_single_match(data["result"]["content_type"], '/(\w+)')
             videourl = data['result']['url'] + '?mime=true'
+            videourl = scrapertools.getLocationHeaderFromResponse(videourl)
 
+    extension = scrapertools.find_single_match(data, '<meta name="description" content="([^"]+)"')
+    extension = "." + extension.rsplit(".", 1)[1]
     if config.get_platform() != "plex":
         video_urls.append([extension + " [Openload] ", videourl+header_down+extension, 0, subtitle])
     else:
@@ -206,6 +207,6 @@ def decodeopenload(data):
         res.append(''.join(linkData[idx]).replace(',', ''))
 
     res = res[3] + '~' + res[1] + '~' + res[2] + '~' + res[0]
-    videourl = 'http://openload.co/stream/{0}?mime=true'.format(res)
+    videourl = 'https://openload.co/stream/{0}?mime=true'.format(res)
     
     return videourl

--- a/python/main-classic/servers/openload.py
+++ b/python/main-classic/servers/openload.py
@@ -149,7 +149,11 @@ def decodeopenload(data):
         imageTabs[i][j].append(imageStr[idx])
 
     # get signature data
-    data = scrapertools.downloadpageWithoutCookies('https://openload.co/assets/js/obfuscator/numbers.js')
+    scripts = scrapertools.find_multiple_matches(data, '<script src="(/assets/js/obfuscator/[^"]+)"')
+    for scr in scripts:
+        data = scrapertools.downloadpageWithoutCookies('https://openload.co%s' % scr)
+        if "signatureNumbers" in data:
+            break
     signStr = scrapertools.find_single_match(data, '[\'"]([^"\']+)[\'"]')
 
     # split signature data

--- a/python/main-classic/servers/openload.py
+++ b/python/main-classic/servers/openload.py
@@ -223,8 +223,8 @@ def decodeopenload(data):
 def decode_hidden(text):
     text = scrapertools.decodeHtmlentities(text)
     s = []
-    for i in range(0, len(text)):
-        j = ord(text[i])
+    for char in text:
+        j = ord(char)
         s.append(chr(33 + ((j+14) % 94)))
 
     videourl = "https://openload.co/stream/{0}?mime=true".format("".join(s))

--- a/python/main-classic/servers/openload.py
+++ b/python/main-classic/servers/openload.py
@@ -41,18 +41,24 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
             url = page_url.replace("/embed/","/f/")
             data = scrapertools.downloadpageWithoutCookies(url)
             text_encode = scrapertools.find_single_match(data,"Click to start Download.*?<script[^>]+>(.*?)</script")
-            text_decode = aadecode(text_encode)
+            try:
+                text_decode = aadecode(text_encode)
+                videourl = "http://" + scrapertools.find_single_match(text_decode, '(openload.co/.*?)\}')
+            except:
+                videourl = "http://"
 
-            videourl = "http://" + scrapertools.find_single_match(text_decode, '(openload.co/.*?)\}')
             if videourl == "http://":
                 videourl = decodeopenload(data)
             extension = scrapertools.find_single_match(data, '<meta name="description" content="([^"]+)"')
             extension = "." + extension.rsplit(".", 1)[1]
-            video_urls.append([extension + " [Openload]", videourl+header_down+extension])
         else:
             text_encode = scrapertools.find_multiple_matches(data,'<script[^>]+>(ﾟωﾟ.*?)</script>')
-            decodeindex = aadecode(text_encode[0])
-            subtract = scrapertools.find_single_match(decodeindex, 'welikekodi.*?(\([^;]+\))')
+            try:
+                decodeindex = aadecode(text_encode[0])
+                subtract = scrapertools.find_single_match(decodeindex, 'welikekodi.*?(\([^;]+\))')
+            except:
+                subtract = ""
+            
             if subtract:
                 index = int(eval(subtract))
                 # Buscamos la variable que nos indica el script correcto

--- a/python/main-classic/servers/realdebrid.py
+++ b/python/main-classic/servers/realdebrid.py
@@ -29,9 +29,12 @@ def get_video_url(page_url, premium=False, video_password=""):
     # Se comprueba si existe un token guardado y sino se ejecuta el proceso de autentificación
     token_auth = channeltools.get_channel_setting("realdebrid_token", "realdebrid")
     if token_auth is None or token_auth == "":
-        token_auth = authentication()
-        if token_auth == "":
-            return [["REAL-DEBRID: No se ha completado el proceso de autentificación", ""]]
+        if config.is_xbmc():
+            token_auth = authentication()
+            if token_auth == "":
+                return [["REAL-DEBRID: No se ha completado el proceso de autentificación", ""]]
+        else:
+            return [["REAL-DEBRID: Es necesario activar la cuenta. Accede al menú de ayuda", ""]]
 
     post_link = urllib.urlencode([("link", page_url), ("password", video_password)])
     headers["Authorization"] = "Bearer %s" % token_auth

--- a/python/main-classic/servers/realdebrid.py
+++ b/python/main-classic/servers/realdebrid.py
@@ -34,7 +34,7 @@ def get_video_url(page_url, premium=False, video_password=""):
             if token_auth == "":
                 return [["REAL-DEBRID: No se ha completado el proceso de autentificación", ""]]
         else:
-            return [["REAL-DEBRID: Es necesario activar la cuenta. Accede al menú de ayuda", ""]]
+            return [["Es necesario activar la cuenta. Accede al menú de ayuda", ""]]
 
     post_link = urllib.urlencode([("link", page_url), ("password", video_password)])
     headers["Authorization"] = "Bearer %s" % token_auth

--- a/python/main-classic/servers/thevideome.py
+++ b/python/main-classic/servers/thevideome.py
@@ -21,10 +21,16 @@ def get_video_url( page_url , premium = False , user="" , password="", video_pas
         page_url = page_url.replace("http://thevideo.me/","http://thevideo.me/embed-") + ".html"
     
     data = scrapertools.cache_page( page_url )
+
+    tkn = scrapertools.find_single_match(data, "tkn='([^']+)'")
+    data_vt = scrapertools.downloadpage("http://thevideo.me/jwv/%s" % tkn)
+    data_vt = scrapertools.find_single_match(data_vt, 'jwConfig\|([^\|]+)\|')
+    
     media_urls = scrapertools.find_multiple_matches(data,"label\s*\:\s*'([^']+)'\s*\,\s*file\s*\:\s*'([^']+)'")
     video_urls = []
 
-    for label,media_url in media_urls:
+    for label, media_url in media_urls:
+        media_url += "?direct=false&ua=1&vt=%s" % data_vt
         video_urls.append( [ scrapertools.get_filename_from_url(media_url)[-4:]+" ("+label+") [thevideo.me]",media_url])
 
     return video_urls

--- a/python/version-command-line/resources/settings.conf
+++ b/python/version-command-line/resources/settings.conf
@@ -67,8 +67,6 @@ fileniumpassword=secreto
 
 # Real Debrid
 realdebridpremium=false
-realdebriduser=tucorreo@dominio.com
-realdebridpassword=secreto
 
 # Alldebrid
 alldebridpremium=false

--- a/python/version-plex/DefaultPrefs.json
+++ b/python/version-plex/DefaultPrefs.json
@@ -12,6 +12,12 @@
     "default": "true"
   },
   {
+    "id": "realdebridpremium",
+    "label": "Cuenta premium Real Debrid (Activar en menú ayuda)",
+    "type": "bool",
+    "default": "false"
+  },
+  {
     "id": "alldebridpremium",
     "label": "Cuenta premium All Debrid",
     "type": "bool",


### PR DESCRIPTION
He incluido en el canal ayuda una opción para activar real-debrid en plataformas distintas a Kodi a través de itemlists en lugar de diálogos. El proceso es el mismo solo que depende de que el usuario interaccione (en Kodi en cuanto detecta la introducción del código se cierra la ventana automáticamente).

Solo lo he probado en plex (versión web), pero no creo que haya problemas para el resto.

- Reparado openload, flashx y thevideome.
- Añadida librería jjdecode para openload.