### PR TITLE
Añadida opción en menú configuración - Propuesta para mensajes de error - Reparado streaminto

### DIFF
--- a/python/main-classic/channels/configuracion.py
+++ b/python/main-classic/channels/configuracion.py
@@ -154,7 +154,7 @@ def addchannel(item):
         result = downloadtools.downloadfile(tecleado, localfilename, continuar=False)
         if result == -3:
             dyesno = platformtools.dialog_yesno("El archivo ya existe", "Ya existe el %s %s." \
-                                                " ¿Desea sobreescribirlo?" % (info_accion, filename))
+                                                " ¿Desea sobrescribirlo?" % (info_accion, filename))
             if dyesno:
                 backup = filetools.join(config.get_data_path(), 'backups')
                 if not filetools.exists(backup):

--- a/python/main-classic/channels/configuracion.py
+++ b/python/main-classic/channels/configuracion.py
@@ -51,6 +51,7 @@ def mainlist(item):
                              title="   Buscar nuevos episodios y actualizar biblioteca", folder=False))
 
     itemlist.append(Item(channel=CHANNELNAME, title="   Comprobar actualizaciones", action="check_for_updates", folder=False))
+    itemlist.append(Item(channel=CHANNELNAME, title="   Añadir o Actualizar canal/conector desde una URL", action="menu_addchannels"))
     itemlist.append(Item(channel=item.channel, action="", title="", folder=False))
 
     if not config.OLD_PLATFORM:
@@ -101,3 +102,93 @@ def updatebiblio(item):
     library_service.main()
 
 
+def menu_addchannels(item):
+    logger.info("pelisalacarta.channels.configuracion menu_addchannels")
+    itemlist = []
+    itemlist.append(Item(channel=CHANNELNAME, title="Añadir o actualizar canal", action="addchannel", folder=False))
+    itemlist.append(Item(channel=CHANNELNAME, title="Añadir o actualizar conector", action="addchannel", folder=False))
+
+    return itemlist
+
+
+def addchannel(item):
+    from platformcode import platformtools
+    from core import filetools
+    logger.info("pelisalacarta.channels.configuracion addchannel")
+    
+    tecleado = platformtools.dialog_input("", "Introduzca la URL")
+    if not tecleado:
+        return
+    logger.info("pelisalacarta.channels.configuracion url=%s" % tecleado)
+
+    local_folder = config.get_runtime_path()
+    if "canal" in item.title:
+        local_folder = filetools.join(local_folder, 'channels')
+        folder_to_extract = "channels"
+        info_accion = "canal"
+    else:
+        local_folder = filetools.join(local_folder, 'servers')
+        folder_to_extract = "servers"
+        info_accion = "conector"
+
+    # Detecta si es un enlace a un .py o .xml (pensado sobre todo para enlaces de github)
+    try:
+        extension = tecleado.rsplit(".",1)[1]
+    except:
+        extension = ""
+
+    if extension == "py" or extension == "xml":
+        filename = tecleado.rsplit("/",1)[1]
+        localfilename = filetools.join(local_folder, filename)
+        zip = False
+    else:
+        filename = 'new%s.zip' % info_accion
+        localfilename = filetools.join(config.get_data_path(), filename)
+        zip = True
+
+    logger.info("pelisalacarta.channels.configuracion localfilename=%s" % localfilename)
+    logger.info("pelisalacarta.channels.configuracion descarga fichero...")
+    
+    try:
+        from core import downloadtools
+        result = downloadtools.downloadfile(tecleado, localfilename, continuar=False)
+        if result == -3:
+            dyesno = platformtools.dialog_yesno("El archivo ya existe", "Ya existe el %s %s." \
+                                                " ¿Desea sobreescribirlo?" % (info_accion, filename))
+            if dyesno:
+                backup = filetools.join(config.get_data_path(), 'backups')
+                if not filetools.exists(backup):
+                    filetools.mkdir(backup)
+                import shutil
+                shutil.copy2(localfilename, filetools.join(backup, filename))
+                result = downloadtools.downloadfile(tecleado, localfilename, continuar=True)
+            else:
+                return
+    except:
+        import traceback
+        logger.info("Detalle del error: %s" % traceback.format_exc())
+        return
+
+
+    if zip:
+        try:
+            # Lo descomprime
+            logger.info("pelisalacarta.channels.configuracion descomprime fichero...")
+            from core import ziptools
+            unzipper = ziptools.ziptools()
+            logger.info("pelisalacarta.channels.configuracion destpathname=%s" % local_folder)
+            unzipper.extract(localfilename, local_folder, folder_to_extract, True, True)
+        except:
+            import traceback
+            logger.info("Detalle del error: %s" % traceback.format_exc())
+            # Borra el zip descargado
+            filetools.remove(localfilename)
+            platformtools.dialog_ok("Error", "Se ha producido un error extrayendo el archivo")
+            return
+		
+        # Borra el zip descargado
+        logger.info("pelisalacarta.channels.configuracion borra fichero...")
+        filetools.remove(localfilename)
+        logger.info("pelisalacarta.channels.configuracion ...fichero borrado")
+
+    platformtools.dialog_ok("Éxito", "%s instalado/actualizado correctamente" % info_accion.capitalize())

--- a/python/main-classic/core/downloadtools.py
+++ b/python/main-classic/core/downloadtools.py
@@ -548,7 +548,7 @@ def downloadfile(url,nombrefichero,headers=[],silent=False,continuar=False):
         # el fichero ya existe y no se quiere continuar, se aborta
         elif os.path.exists(nombrefichero) and not continuar:
             logger.info("pelisalacarta.core.downloadtools downloadfile: el fichero existe, no se descarga de nuevo")
-            return
+            return -3
 
         # el fichero no existe
         else:

--- a/python/main-classic/core/ziptools.py
+++ b/python/main-classic/core/ziptools.py
@@ -26,15 +26,15 @@
 # --------------------------------------------------------------------------------
 
 import os
-import os.path
 import zipfile
 
 import logger
+import config
 
 
 class ziptools:
 
-    def extract(self, file, dir):
+    def extract(self, file, dir, folder_to_extract="", overwrite_question=False, backup=False):
         logger.info("file=%s" % file)
         logger.info("dir=%s" % dir)
         
@@ -42,7 +42,8 @@ class ziptools:
             os.mkdir(dir)
 
         zf = zipfile.ZipFile(file)
-        self._createstructure(file, dir)
+        if not folder_to_extract:
+            self._createstructure(file, dir)
         num_files = len(zf.namelist())
 
         for name in zf.namelist():
@@ -53,12 +54,35 @@ class ziptools:
                     (path,filename) = os.path.split(os.path.join(dir, name))
                     logger.info("path=%s" % path)
                     logger.info("name=%s" % name)
-                    os.makedirs( path )
+                    if folder_to_extract:
+                        if path != os.path.join(dir, folder):
+                            break
+                    else:
+                        os.makedirs( path )
                 except:
                     pass
-                outfilename = os.path.join(dir, name)
+                if folder_to_extract:
+                    outfilename = os.path.join(dir, filename)
+                    
+                else:
+                    outfilename = os.path.join(dir, name)
                 logger.info("outfilename=%s" % outfilename)
                 try:
+                    if os.path.exists(outfilename) and overwrite_question:
+                        from platformcode import platformtools
+                        dyesno = platformtools.dialog_yesno("El archivo ya existe",
+                                                            "El archivo %s a descomprimir ya existe" \
+                                                            ", ¿desea sobrescribirlo?" \
+                                                            % os.path.basename(outfilename))
+                        if not dyesno:
+                            break
+                        if backup:
+                            backup = os.path.join(config.get_data_path(), 'backups')
+                            if not os.path.exists(backup):
+                                os.mkdir(backup)
+                            import shutil
+                            shutil.copy2(outfilename, os.path.join(backup, os.path.basename(outfilename)))
+                        
                     outfile = open(outfilename, 'wb')
                     outfile.write(zf.read(name))
                 except:

--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -318,16 +318,28 @@ def run():
         patron = 'File "'+os.path.join(config.get_runtime_path(),"channels","").replace("\\","\\\\")+'([^.]+)\.py"'
         canal = scrapertools.find_single_match(traceback.format_exc(),patron)
         
+        try:
+            xbmc_version = int(xbmc.getInfoLabel( "System.BuildVersion" ).split(".", 1)[0])
+            if xbmc_version > 13:
+                log_name = "kodi.log"
+            else:
+                log_name = "xbmc.log"
+            log_message = "Ruta: "+xbmc.translatePath("special://logpath")+log_name
+        except:
+            log_message = ""
+
         if canal:
             xbmcgui.Dialog().ok(
                 "Error inesperado en el canal " + canal,
-                "Esto suele pasar cuando hay un fallo de conexión, cuando la web del canal "
-                "ha cambiado su estructura, o simplemente "
-                "porque hay algo mal en pelisalacarta.\nPara saber más detalles, consulta el log.")
+                "Puede deberse a un fallo de conexión, la web del canal "
+                "ha cambiado su estructura, o un error interno de pelisalacarta.",
+                "Para saber más detalles, consulta el log.", log_message)
         else:
+
             xbmcgui.Dialog().ok(
                 "Se ha producido un error en pelisalacarta",
-                "Comprueba el log para ver mas detalles del error." )
+                "Comprueba el log para ver mas detalles del error.",
+                log_message)
 
 def set_server_list():
     logger.info("pelisalacarta.platformcode.launcher.set_server_list")

--- a/python/main-classic/servers/streaminto.py
+++ b/python/main-classic/servers/streaminto.py
@@ -29,17 +29,8 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
     data = re.sub(r'\n|\t|\s+', '', scrapertools.cache_page(page_url))
 
     video_urls = []
-    # {type:"html5",config:{file:'http://95.211.191.133:8777/3ki7frw76xuzcg3h5f6cbf7a34mbb2zr44g7sdojszegjqx5tdsaxgwr42vq/v.flv','provider':'http'}
-    media_url = scrapertools.get_match(data, """{type:"html5",config:{file:'([^']+)','provider':'http'}""")
+    media_url = scrapertools.get_match(data, """.setup\({file:"([^"]+)",image""")
     video_urls.append([scrapertools.get_filename_from_url(media_url)[-4:] + " [streaminto]", media_url])
-
-    # streamer:"rtmp://95.211.191.133:1935/vod?h=3ki7frw76xuzcg3h5f6cbf7a34mbb2zr44g7sdojszegjqx5tdsaxgwr42vq"
-    rtmp_url = scrapertools.get_match(data, 'streamer:"([^"]+)"')
-    # ({file:"53/7269023927_n.flv?h=3ki7frw76xuzcg3h5f6cbf7a34mbb2zr44g7sdojszegjqx5tdsaxgwr42vq",
-    playpath = scrapertools.get_match(data, '\({file:"([^"]+)",')
-    swfUrl = "http://streamin.to/player/player.swf"
-    media_url = rtmp_url + " playpath=" + playpath + " swfUrl=" + swfUrl
-    video_urls.append(["RTMP [streaminto]", media_url])
 
     for video_url in video_urls:
         logger.info("pelisalacarta.servers.streaminto %s - %s" % (video_url[0], video_url[1]))


### PR DESCRIPTION
- Se añade la opción en el canal de configuración para instalar o actualizar canales o conectores a través de una url. Está pensado tanto para enlaces directos de github (raw), como para archivos comprimidos adjuntados en el foro. Estos últimos deben tener los archivos a copiar en la raíz o dentro de la carpeta channels o servers correspondiente, sino no serían válidos.

Además de detectar y avisar si el archivo ya existe para sobrescribirlo, en este caso se hace antes una copia de seguridad del mismo y se guarda en la carpeta userdata/backups, para así evitar posibles errores y poder volver a la versión anterior. Para todo esto se han modificado los archivos de configuracion, downloadtools y ziptools. Lo he testeado exhaustivamente, pero si algún lo prueba y ve algún error comentádmelo.

- Debido a que por el foro se ven muchos mensajes preguntando en qué carpeta buscar el log, y mientras no se decide el tema de subir y acceder a los logs de forma remota, he pensado que podría ser útil añadir en los mensajes de error comunes en el launcher, la ruta al archivo .log a través del comando "special://logpath".

- Reparado streaminto gracias a robalo :wink: 