### PR TITLE
Solucionado problema en Buscador

### DIFF
--- a/python/main-classic/channels/buscador.py
+++ b/python/main-classic/channels/buscador.py
@@ -147,6 +147,7 @@ def search_cb(item,values=""):
 # y lo pasará en el parámetro "tecleado"
 def search(item, tecleado):
     logger.info("pelisalacarta.channels.buscador search")
+    tecleado = tecleado.replace("+", " ")
 
     if tecleado != "":
         save_search(tecleado)
@@ -280,18 +281,13 @@ def do_search(item, categories=[]):
     
 
     #Modo Multi Thread
+    #Usando isAlive() no es necesario try-except, 
+    #ya que esta funcion (a diferencia de is_alive()) 
+    #es compatible tanto con versiones antiguas de python como nuevas
     if multithread :
-        try:
-            pendent =  len([a for a in searches if a.is_alive()])
-        except:
-            pendent =  len([a for a in searches if a.isAlive()])
-
+        pendent =  len([a for a in searches if a.isAlive()])
         while pendent:
-            try:
-                pendent =  len([a for a in searches if a.is_alive()])
-            except:
-                pendent =  len([a for a in searches if a.isAlive()])
-
+            pendent =  len([a for a in searches if a.isAlive()])
             percentage =  (len(searches) - pendent) * 100 / len(searches)
             progreso.update(percentage, "Buscando %s en %d canales..." % (tecleado, len(searches)))
             if progreso.iscanceled(): 

--- a/python/main-classic/channels/pornhub.py
+++ b/python/main-classic/channels/pornhub.py
@@ -72,7 +72,7 @@ def peliculas(item):
     patron = '<div class="phimage">.*?'
     patron += '<a href="([^"]+)" title="([^"]+).*?'
     patron += '<var class="duration">([^<]+)</var>(.*?)</div>.*?'
-    patron += 'data-smallthumb="([^"]+)"'
+    patron += 'data-mediumthumb="([^"]+)"'
     
     matches = re.compile(patron,re.DOTALL).findall(videodata)
     


### PR DESCRIPTION
Este PR soluciona 2 problemas en el buscador:

1. Las búsquedas se guardaban con el carácter "+" en vez de espacio.
2. El buscador se quedaba colgado cuando tenias los canales adultos activos y el canal "PornHub" en la lista de canales del buscador (por defecto incluido) debido a un error en el patrón del canal PornHub, que misteriosamente para mi, a demás de hacer que el canal no encontrara resultados, dejaba (por lo menos en kodi) el programa colgado. impidiendo que la búsqueda finalizara y teniendo que reiniciar kodi

He echo varias búsquedas con todos los canales activos y ahora ya finaliza sin ningún problema.