### PR TITLE
Error al leer archivos json de canal corrompidos

### DIFF
--- a/python/main-classic/core/channeltools.py
+++ b/python/main-classic/core/channeltools.py
@@ -163,7 +163,7 @@ def get_channel_setting(name, channel):
         # Obtenemos configuracion guardada de ../settings/channel_data.json
         try:
             dict_file = jsontools.load_json(open(file_settings, "r").read())
-            if dict_file.has_key('settings'): 
+            if isinstance(dict_file, dict) and dict_file.has_key('settings'):
               dict_settings = dict_file['settings']
         except EnvironmentError:
             logger.info("ERROR al leer el archivo: {0}".format(file_settings))


### PR DESCRIPTION
jsontools.load_json devuelve "" en caso de error y no un dict.
Comprobarlo antes de leer del dict.

Me ha cascado al estar jugando con la búsqueda y se ha generado un archivo json que no se podía leer correctamente