### PR TITLE
[logger.py] - Mejoras en logger y fix para Kodi 17 Krypton

### DIFF
--- a/python/main-classic/core/logger.py
+++ b/python/main-classic/core/logger.py
@@ -26,52 +26,63 @@
 #------------------------------------------------------------
 
 from core import config
+import inspect
+import os
+import xbmc
+
 loggeractive = (config.get_setting("debug")=="true")
 
-import xbmc
 
 def log_enable(active):
     global loggeractive
     loggeractive = active
 
+
+def encode_log(message):
+    #Unicode to utf8
+    if type(message) == unicode: 
+        message = texto.encode("utf8")
+        
+    #All encodings to utf8
+    elif type(message) == str:
+        message = unicode(message, "utf8", errors="replace").encode("utf8")
+        
+    #Objects to string
+    else:
+        message = repr(message) #or str(message)
+
+    return message
+
+def get_caller(message = None):
+        module=inspect.getmodule(inspect.stack()[2][0]).__name__
+        function = inspect.stack()[2][3]
+        
+        if module == "__main__": module = "pelisalacarta" 
+        else: module = "pelisalacarta." + module
+        if message:
+          if not module in message:
+              if function == "<module>": return module + " " + message
+              else: return module + " [" + function + "] " + message
+          else:
+              return message
+        else:
+          if function == "<module>": return module
+          else: return module + "." + function
+
 def info(texto):
     if loggeractive:
-        try:
-            xbmc.log(texto)
-        except:
-            # FIXME: ¿Esto de que falle al poner un log no se puede resolver con un encode("ascii",errors="ignore") ?
-            validchars = " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!#$%&'()-@[]^_`{}~."
-            stripped = ''.join(c for c in texto if c in validchars)
-            xbmc.log("(stripped) "+stripped)
+        xbmc.log(get_caller(encode_log(texto)), xbmc.LOGNOTICE)
+
 
 def debug(texto):
     if loggeractive:
-        try:
-            import inspect
-            import os
-            last=inspect.stack()[1]
-            modulo= os.path.basename(os.path.splitext(last[1])[0])
-            funcion= last [3]
-            texto= "    [" + modulo + "." + funcion + "] " + texto
-            xbmc.log("######## DEBUG #########")
-            xbmc.log(texto)
-        except:
-            validchars = " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!#$%&'()-@[]^_`{}~."
-            stripped = ''.join(c for c in texto if c in validchars)
-            xbmc.log("(stripped) "+stripped)
+        texto= "    [" + get_caller() + "] " + encode_log(texto)
+        xbmc.log("######## DEBUG #########", xbmc.LOGNOTICE)
+        xbmc.log(texto, xbmc.LOGNOTICE)
+
 
 def error(texto):
     if loggeractive:
-        try:
-            import inspect
-            import os
-            last=inspect.stack()[1]
-            modulo= os.path.basename(os.path.splitext(last[1])[0])
-            funcion= last [3]
-            texto= "    [" + modulo + "." + funcion + "] " + texto
-            xbmc.log("######## ERROR #########")
-            xbmc.log(texto)
-        except:
-            validchars = " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!#$%&'()-@[]^_`{}~."
-            stripped = ''.join(c for c in texto if c in validchars)
-            xbmc.log("(stripped) "+stripped)
+        texto= "    [" + get_caller() + "] " + encode_log(texto)
+        xbmc.log("######## ERROR #########", xbmc.LOGNOTICE)
+        xbmc.log(texto, xbmc.LOGNOTICE)


### PR DESCRIPTION
Los que habéis probado la beta de Kodi 17 os habréis dado cuenta que el logger no funciona correctamente, esto es debido a que en kodi 17 el nivel de log por defecto es DEBUG mientras que en las versiones antiguas es NOTICE de manera que si no especificamos nada en kodi 17 los mensajes se envían como DEBUG y a no ser que entres en los ajustes de kodi y toquetees por ahí, por defecto esos mensajes no se muestran...

pues bien, lo he solucionado especificando que se envie como NOTICE (igual que se enviaba en las versiones antiguas por defecto) y ya puestos he echo algunos cambios que hacia tiempo que le tenia ganas... 

1. Añade por defecto "pelisalacarta.modulo [funcion]" antes de los mensajes (si estos no comienzan ya por "pelisalacarta.modulo") 
2. Hace un encoding para evitar errores, de modo que:
 - Si el mensaje es Unicode: lo pasa a utf8
 - Si el mensaje es un string: lo recodifica a "utf8" con errors="replace"
 - Si el mensaje es cualquier otra cosa: muestra su representación en string 

La parte que considero mas practica es el ultimo punto ya que cuando guardas algo en el log y no es un texto por ejemplo logger.info(False) o logger.info(None), etc...  estos daban error, ahora guarda "False" y "None", etc...

