### PR TITLE
Canales adaptados al uso de extendedinfo y trailertools

### DIFF
--- a/python/main-classic/channels/allpeliculas.py
+++ b/python/main-classic/channels/allpeliculas.py
@@ -114,10 +114,10 @@ def busqueda(item):
         item.infoLabels['rating'] = vote
         if "Series" not in genre:
             itemlist.append(item.clone(action="findvideos", title=titulo, fulltitle=title, url=url, thumbnail=thumbnail,
-                                       context="05", contentTitle=title))
+                                       context=["buscar_trailer"], contentTitle=title, contentType="movie"))
         else:
             itemlist.append(item.clone(action="temporadas", title=titulo, fulltitle=title, url=url, thumbnail=thumbnail,
-                                       context="25", contentTitle=title))
+                                       context=["buscar_trailer"], contentTitle=title, contentType="tvshow"))
 
     # Paginacion
     next_page = scrapertools.find_single_match(data, 'class="pagination-active".*?href="([^"]+)"')
@@ -181,11 +181,17 @@ def lista(item):
         item.infoLabels['trailer'] = trailer.replace("youtu.be/", "http://www.youtube.com/watch?v=")
         if item.extra != "tv" or "Series" not in genre:
             itemlist.append(item.clone(action="findvideos", title=titulo, fulltitle=title, url=url, thumbnail=thumbnail,
-                                       context="05", contentTitle=title))
+                                       context=["buscar_trailer"], contentTitle=title, contentType="movie"))
         else:
             itemlist.append(item.clone(action="temporadas", title=titulo, fulltitle=title, url=url, thumbnail=thumbnail,
-                                       context="25", contentTitle=title, show=title))
+                                       context=["buscar_trailer"], contentTitle=title, show=title, contentType="tvshow"))
 
+    try:
+        from core import tmdb
+        # Obtenemos los datos basicos de todas las peliculas mediante multihilos
+        tmdb.set_infoLabels_itemlist(itemlist, __modo_grafico__)
+    except:
+        pass
     # Paginacion
     next_page = scrapertools.find_single_match(data, 'class="pagination-active".*?href="([^"]+)"')
     if next_page != "":
@@ -321,7 +327,7 @@ def temporadas(item):
     matches = list(set(matches))
     for season in matches:
         item.infoLabels['season'] = season
-        itemlist.append(item.clone(action="findvideostv", title="Temporada "+season, context="25"))
+        itemlist.append(item.clone(action="findvideostv", title="Temporada "+season, context=["buscar_trailer"], contentType="season"))
 
     itemlist.sort(key=lambda item: item.title)
     try:
@@ -368,7 +374,7 @@ def findvideostv(item):
             titulo += server.capitalize()+"]   ["+idioma+"] ("+calidad_videos.get(quality)+")"
             item.infoLabels['episode'] = episode
 
-            itemlist.append(item.clone(action="play", title=titulo, url=url))
+            itemlist.append(item.clone(action="play", title=titulo, url=url, contentType="episode"))
 
     #Enlace Descarga
     patron = '<span class="movie-downloadlink-list" id_movies_types="([^"]+)" id_movies_servers="([^"]+)".*?episode=' \

--- a/python/main-classic/channels/cinefox.py
+++ b/python/main-classic/channels/cinefox.py
@@ -114,21 +114,21 @@ def busqueda(item):
             plot = scrapertools.htmlclean(plot)
             if "/serie/" in scrapedurl:
                 action = "episodios"
-                context = "25"
                 show = scrapedtitle
                 scrapedurl += "/episodios"
                 title = " [Serie]"
+                contentType = "tvshow"
             elif "/pelicula/" in scrapedurl:
                 action = "menu_info"
-                context = "05"
                 show = ""
                 title = " [Película]"
+                contentType = "movie"
             else:
                 continue
             title = scrapedtitle + title + " (" + year + ")"
             itemlist.append(item.clone(action=action, title=title, url=scrapedurl, thumbnail=scrapedthumbnail,
-                                       contentTitle=scrapedtitle, fulltitle=scrapedtitle, context=context, plot=plot,
-                                       show=show, text_color=color2))
+                                       contentTitle=scrapedtitle, fulltitle=scrapedtitle, context=["buscar_trailer"],
+                                       plot=plot, show=show, text_color=color2, contentType=contentType))
 
     try:
         from core import tmdb
@@ -347,7 +347,7 @@ def peliculas(item):
                 url = urlparse.urljoin(host, scrapedurl)
                 itemlist.append(Item(channel=item.channel, action=action, title=scrapedtitle, url=url, extra="media",
                                      thumbnail=scrapedthumbnail, contentTitle=scrapedtitle, fulltitle=scrapedtitle,
-                                     text_color=color2, context="05"))
+                                     text_color=color2, context=["buscar_trailer"], contentType="movie"))
         else:
             patron = '<div class="audio-info">(.*?)<div class="quality-info".*?>([^<]+)</div>' \
                      '.*?src="([^"]+)".*?href="([^"]+)">([^<]+)</a>'
@@ -365,7 +365,7 @@ def peliculas(item):
 
                 itemlist.append(Item(channel=item.channel, action=action, title=title, url=url, extra="media",
                                      thumbnail=scrapedthumbnail, contentTitle=scrapedtitle, fulltitle=scrapedtitle,
-                                     text_color=color2, context="05"))
+                                     text_color=color2, context=["buscar_trailer"], contentType="movie"))
 
     next_page = scrapertools.find_single_match(data, 'href="([^"]+)"[^>]+>Siguiente')
     if next_page != "" and item.title != "":
@@ -406,8 +406,8 @@ def ultimos(item):
             title = show + " - " + re.sub(show, '', scrapedtitle) + " [" + "/".join(audios) + "]"
             url = urlparse.urljoin(host, scrapedurl)
             itemlist.append(item.clone(action=action, title=title, url=url, thumbnail=scrapedthumbnail,
-                                       contentTitle=show, fulltitle=show, show=show, context="25",
-                                       text_color=color2, extra="ultimos"))
+                                       contentTitle=show, fulltitle=show, show=show, context=["buscar_trailer"],
+                                       text_color=color2, extra="ultimos", contentType="tvshow"))
 
     try:
         from core import tmdb
@@ -438,7 +438,7 @@ def series(item):
             url = urlparse.urljoin(host, scrapedurl + "/episodios")
             itemlist.append(Item(channel=item.channel, action="episodios", title=scrapedtitle, url=url,
                                  thumbnail=scrapedthumbnail, contentTitle=scrapedtitle, fulltitle=scrapedtitle,
-                                 show=scrapedtitle, text_color=color2, context="25"))
+                                 show=scrapedtitle, text_color=color2, context=["buscar_trailer"], contentType="tvshow"))
 
     try:
         from core import tmdb
@@ -527,7 +527,7 @@ def episodios(item):
             extra = "episode"
             if item.extra == "episodios":
                 extra = "episode|"
-            itemlist.append(item.clone(action=action, title=title, url=scrapedurl, text_color=color2, extra=extra))
+            itemlist.append(item.clone(action=action, title=title, url=scrapedurl, text_color=color2, extra=extra, contentType="episode"))
 
     if item.extra != "episodios":
         try:

--- a/python/main-classic/channels/cinetux.py
+++ b/python/main-classic/channels/cinetux.py
@@ -151,7 +151,8 @@ def peliculas(item):
             "title=[" + scrapedtitle + "], url=[" + scrapedurl + "], thumbnail=[" + scrapedthumbnail + "]")
         new_item = item.clone(action="findvideos", title=scrapedtitle, fulltitle=fulltitle,
                               url=scrapedurl, thumbnail=scrapedthumbnail, infoLabels={},
-                              contentTitle=fulltitle, context="05", viewmode="list")
+                              contentTitle=fulltitle, context=["buscar_trailer"], viewmode="list",
+                              contentType="movie")
         if year != "": new_item.infoLabels['year'] = int(year)
         itemlist.append(new_item)
     try:
@@ -186,7 +187,8 @@ def vistas(item):
             "title=[" + scrapedtitle + "], url=[" + scrapedurl + "], thumbnail=[" + scrapedthumbnail + "]")
         new_item = item.clone(action="findvideos", title=scrapedtitle, fulltitle=scrapedtitle,
                               url=scrapedurl, thumbnail=scrapedthumbnail, infoLabels={},
-                              contentTitle=scrapedtitle, context="05", viewmode="list")
+                              contentTitle=scrapedtitle, context=["buscar_trailer"], viewmode="list",
+                              contentType="movie")
         itemlist.append(new_item)
 
     # Extrae el paginador

--- a/python/main-classic/channels/descargasmix.py
+++ b/python/main-classic/channels/descargasmix.py
@@ -88,11 +88,11 @@ def busqueda(item):
         if ("Películas" in scrapedcat or "Documentales" in scrapedcat) and not "Series" in scrapedcat:
             titulo = scrapedtitle.split("[")[0]
             itemlist.append(item.clone(action="findvideos", title=scrapedtitle, url=scrapedurl,
-                                       thumbnail=scrapedthumbnail, fulltitle=titulo, context="05", contentTitle=titulo))
+                                       thumbnail=scrapedthumbnail, fulltitle=titulo, context=["buscar_trailer"], contentTitle=titulo, contentType="movie"))
         else:
-            itemlist.append(item.clone(action="episodios", title=scrapedtitle, url=scrapedurl,  context="25",
+            itemlist.append(item.clone(action="episodios", title=scrapedtitle, url=scrapedurl,  context=["buscar_trailer"],
                                        thumbnail=scrapedthumbnail, fulltitle=scrapedtitle, contentTitle=scrapedtitle,
-                                       show=scrapedtitle))
+                                       show=scrapedtitle, contentType="tvshow"))
 
     next_page = scrapertools.find_single_match(data, '<a class="nextpostslink".*?href="([^"]+)"')
     if next_page != "":
@@ -157,7 +157,7 @@ def entradas(item):
             if "series" in item.url or "anime" in item.url:
                 item.show = scrapedtitle
             itemlist.append(item.clone(action="episodios", title=titulo, url=scrapedurl, thumbnail=scrapedthumbnail,
-                                       fulltitle=scrapedtitle, context="25", contentTitle=scrapedtitle))
+                                       fulltitle=scrapedtitle, context=["buscar_trailer"], contentTitle=scrapedtitle, contentType="tvshow"))
     else:
         patron = '<a class="clip-link".*?href="([^"]+)".*?<img alt="([^"]+)" src="([^"]+)".*?<span class="cat">(.*?)</span>(.*?)</p>'
         matches = scrapertools.find_multiple_matches(bloque, patron)
@@ -185,8 +185,8 @@ def entradas(item):
             scrapedthumbnail = scrapedthumbnail.rsplit("/", 1)[0]+"/"+urllib.quote(scrapedthumbnail.rsplit("/", 1)[1])
             if (DEBUG): logger.info("title=["+scrapedtitle+"], url=["+scrapedurl+"], thumbnail=["+scrapedthumbnail+"]")
             itemlist.append(item.clone(action=action, title=titulo, url=scrapedurl, thumbnail=scrapedthumbnail,
-                                       fulltitle=scrapedtitle, context="05", contentTitle=scrapedtitle,
-                                       viewmode="movie_with_plot", show=show))
+                                       fulltitle=scrapedtitle, context=["buscar_trailer"], contentTitle=scrapedtitle,
+                                       viewmode="movie_with_plot", show=show, contentType="movie"))
 
     #Paginación
     next_page = scrapertools.find_single_match(data, '<a class="nextpostslink".*?href="([^"]+)"')
@@ -227,7 +227,7 @@ def episodios(item):
             title = item.fulltitle+" "+scrapedtitle.strip()
         else:
             title = scrapedtitle.strip()
-        itemlist.append(new_item.clone(action="findvideos", title=title, extra=scrapedtitle, fulltitle=title))
+        itemlist.append(new_item.clone(action="findvideos", title=title, extra=scrapedtitle, fulltitle=title, contentType="episode"))
 
     itemlist.sort(key=lambda item: item.title, reverse=True)
     item.plot = scrapertools.find_single_match(data, '<strong>SINOPSIS</strong>:(.*?)</p>')

--- a/python/main-classic/channels/gnula.py
+++ b/python/main-classic/channels/gnula.py
@@ -74,11 +74,12 @@ def peliculas(item):
         plot = scrapertools.htmlclean(resto).strip()
         title = scrapedtitle+" "+plot
         fulltitle = title
-        contentTitle = title
+        contentTitle = scrapedtitle
         url = urlparse.urljoin(item.url,scrapedurl)
         thumbnail = urlparse.urljoin(item.url,scrapedthumbnail)
         if DEBUG: logger.info("title=["+title+"], url=["+url+"], thumbnail=["+thumbnail+"]")
-        itemlist.append( Item(channel=item.channel, action='findvideos', title=title , fulltitle=fulltitle , url=url , thumbnail=thumbnail , plot=plot , extra=title, hasContentDetails="true", contentTitle=contentTitle, contentThumbnail=thumbnail) )
+        itemlist.append( Item(channel=item.channel, action='findvideos', title=title , fulltitle=fulltitle , url=url , thumbnail=thumbnail , plot=plot , extra=title, hasContentDetails="true", contentTitle=contentTitle, contentThumbnail=thumbnail,
+                              contentType="movie", context=["buscar_trailer"]) )
 
     return itemlist
 

--- a/python/main-classic/channels/inkapelis.py
+++ b/python/main-classic/channels/inkapelis.py
@@ -123,7 +123,8 @@ def entradas(item):
             thumbnail = scrapedthumbnail.replace("w185", "original")
             if (DEBUG): logger.info("title=["+scrapedtitle+"], url=["+scrapedurl+"], thumbnail=["+thumbnail+"]")
             itemlist.append(item.clone(action="findvideos", title=scrapedtitle, url=scrapedurl, thumbnail=thumbnail,
-                                       contentTitle=scrapedtitle, fulltitle=scrapedtitle, context="05"))
+                                       contentTitle=scrapedtitle, fulltitle=scrapedtitle, context=["buscar_trailer"],
+                                       contentType="movie"))
 
     else:
         # Extrae las entradas
@@ -149,7 +150,8 @@ def entradas(item):
                 thumbnail = scrapedthumbnail.replace("w185", "original")
                 if DEBUG: logger.info("title=["+title+"], url=["+url+"], thumbnail=["+scrapedthumbnail+"]")
                 itemlist.append(item.clone(action="findvideos", title=title, url=url, contentTitle=scrapedtitle,
-                                           fulltitle=scrapedtitle, thumbnail=thumbnail, context="05"))
+                                           fulltitle=scrapedtitle, thumbnail=thumbnail, context=["buscar_trailer"],
+                                           contentType="movie"))
 
     # Extrae la marca de la siguiente página
     next_page = scrapertools.find_single_match(data, '<span class="current">.*?<\/span><a href="([^"]+)"')

--- a/python/main-classic/channels/newpct1.py
+++ b/python/main-classic/channels/newpct1.py
@@ -143,8 +143,17 @@ def listado(item):
         show = title
         if item.extra!="buscar-list":
             title = title + ' ' + calidad
+
+        context_title = scrapertools.find_single_match(url, "http://www.newpct1.com/(.*?)/(.*?)/")
+        context = context_title[0].replace("pelicula","movie").replace("descargar","movie").replace("series","tvshow")
+        context_title = context_title[1].replace("-"," ")
+        if re.search( '\d{4}', context_title[-4:]):
+            context_title = context_title[:-4]
+        elif re.search( '\(\d{4}\)', context_title[-6:]):
+            context_title = context_title[:-6]
             
-        itemlist.append( Item(channel=item.channel, action=action, title=title, url=url, thumbnail=thumbnail, extra=extra, show=show ) )
+        itemlist.append( Item(channel=item.channel, action=action, title=title, url=url, thumbnail=thumbnail, extra=extra, show=show,
+                              contentTitle=context_title, contentType=context, context=["buscar_trailer"]) )
 
     if "pagination" in data:
         patron = '<ul class="pagination">(.*?)</ul>'

--- a/python/main-classic/channels/pelisdanko.py
+++ b/python/main-classic/channels/pelisdanko.py
@@ -112,7 +112,7 @@ def novedades(item):
             itemlist.append(item.clone(action="enlaces", title=bbcode_kodi2html(scrapedtitle),
                                        url=scrapedurl, thumbnail=scrapedthumbnail, fanart=scrapedthumbnail,
                                        fulltitle=contentTitle, filtro=False, contentTitle=contentTitle,
-                                       context="05", trailer=True))
+                                       context=["buscar_trailer"], contentType="movie", trailer=True))
 
     # Busca enlaces de paginas siguientes...
     next_page_url = scrapertools.find_single_match(data, '<a href="([^"]+)" rel="next">')
@@ -157,7 +157,7 @@ def actualizadas(item):
             itemlist.append(item.clone(action="enlaces", title=bbcode_kodi2html(scrapedtitle),
                                        url=scrapedurl, thumbnail=scrapedthumbnail, fanart=scrapedthumbnail,
                                        fulltitle=contentTitle, filtro=False, contentTitle=contentTitle,
-                                       context="05"))
+                                       context=["buscar_trailer"], contentType="movie"))
 
     return itemlist
 

--- a/python/main-classic/channels/pordede.py
+++ b/python/main-classic/channels/pordede.py
@@ -184,11 +184,13 @@ def parse_mixed_results(item,data):
             referer = urlparse.urljoin(item.url,scrapedurl)
             url = referer.replace("/{0}/".format(sectionStr),"/links/view/slug/")+"/what/{0}".format(sectionStr)
             if (DEBUG): logger.info("title=["+title+"], url=["+url+"], thumbnail=["+thumbnail+"]")
-            itemlist.append( Item(channel=item.channel, action="findvideos" , title=title , extra=referer, url=url, thumbnail=thumbnail, plot=plot, fulltitle=fulltitle, fanart=fanart))
+            itemlist.append( Item(channel=item.channel, action="findvideos" , title=title , extra=referer, url=url, thumbnail=thumbnail, plot=plot, fulltitle=fulltitle, fanart=fanart,
+                                  contentTitle=scrapedtitle, contentType="movie", context=["buscar_trailer"]))
         else:
             referer = item.url
             url = urlparse.urljoin(item.url,scrapedurl)
-            itemlist.append( Item(channel=item.channel, action="episodios" , title=title , extra=referer, url=url, thumbnail=thumbnail, plot=plot, fulltitle=fulltitle, show=title, fanart=fanart))
+            itemlist.append( Item(channel=item.channel, action="episodios" , title=title , extra=referer, url=url, thumbnail=thumbnail, plot=plot, fulltitle=fulltitle, show=title, fanart=fanart,
+                                  contentTitle=scrapedtitle, contentType="tvshow", context=["buscar_trailer"]))
 
 
     next_page = scrapertools.find_single_match(data, '<div class="loadingBar" data-url="([^"]+)"')

--- a/python/main-classic/channels/seriecanal.py
+++ b/python/main-classic/channels/seriecanal.py
@@ -149,7 +149,7 @@ def series(item):
         if (DEBUG): logger.info("title=["+title+"], url=["+url+"], thumbnail=["+scrapedthumbnail+"]")
         itemlist.append(item.clone(action="findvideos", title=title, fulltitle=scrapedtitle, url=url,
                                    thumbnail=scrapedthumbnail, plot=scrapedplot, contentTitle=scrapedtitle,
-                                   context="25", show=scrapedtitle))
+                                   context=["buscar_trailer"], show=scrapedtitle, contentType="tvshow"))
 
     try:
         from core import tmdb
@@ -187,7 +187,8 @@ def findvideos(item):
 
         item.infoLabels['episode'] = scrapertools.find_single_match(scrapedtitle, "Episodio (\d+)")
         if (DEBUG): logger.info("title=["+scrapedtitle+"], url=["+scrapedurl+"]")
-        itemlist.append(item.clone(action="play", title=scrapedtitle, url=scrapedurl, server="torrent"))
+        itemlist.append(item.clone(action="play", title=scrapedtitle, url=scrapedurl, server="torrent",
+                                   contentType="episode"))
 
     #Busca en la seccion online
     data_online = scrapertools.find_single_match(data, "<th>Enlaces de Visionado Online</th>(.*?)</table>")
@@ -203,7 +204,7 @@ def findvideos(item):
             title = "["+server.capitalize()+"]"+" "+scrapedtitle
 
             item.infoLabels['episode'] = scrapertools.find_single_match(scrapedtitle, "Episodio (\d+)")
-            itemlist.append(item.clone(action="play", title=title, url=scrapedurl))
+            itemlist.append(item.clone(action="play", title=title, url=scrapedurl, contentType="episode"))
 
     #Comprueba si hay otras temporadas
     if not "No hay disponible ninguna Temporada adicional" in data:
@@ -219,7 +220,8 @@ def findvideos(item):
             if temporada != "":
                 item.infoLabels['season'] = temporada
                 item.infoLabels['episode'] = ""
-            itemlist.append(item.clone(action="findvideos", title=scrapedtitle, url=url, text_color="red"))
+            itemlist.append(item.clone(action="findvideos", title=scrapedtitle, url=url, text_color="red",
+                                       contentType="season"))
 
     try:
         from core import tmdb

--- a/python/main-classic/channels/trailertools.py
+++ b/python/main-classic/channels/trailertools.py
@@ -49,7 +49,11 @@ def buscartrailer(item):
     logger.info("pelisalacarta.channels.trailertools buscartrailer")
 
     # Se elimina la opciçon de Buscar Trailer del menú contextual para evitar redundancias
-    item.context = item.context.replace("5", "")
+    if type(item.context) is str and "buscar_trailer" in item.context:
+        item.context = item.context.replace("buscar_trailer", "")
+    elif type(item.context) is list and "buscar_trailer" in item.context:
+        item.context.remove("buscar_trailer")
+    
     item.text_color = ""
     # Si no se indica el parámetro contextual se entiende que no se ejecuta desde este mení
     if item.contextual == "":
@@ -92,11 +96,11 @@ def buscartrailer(item):
             title = "Trailer por defecto  [" + server + "]"
             itemlist.append(item.clone(title=title, url=url, server=server, action="play"))
         if item.show != "" or ("tvshowtitle" in item.infoLabels and item.infoLabels['tvshowtitle'] != ""):
-            type = "tv"
+            tipo = "tv"
         else:
-            type = "movie"
+            tipo = "movie"
         try:
-            itemlist.extend(tmdb_trailers(item, type))
+            itemlist.extend(tmdb_trailers(item, tipo))
         except:
             import traceback
             logger.error(traceback.format_exc())
@@ -152,16 +156,16 @@ def manual_search(item):
             return jayhap_search(item.clone(contentTitle=texto))
 
 
-def tmdb_trailers(item, type="movie"):
+def tmdb_trailers(item, tipo="movie"):
     logger.info("pelisalacarta.channels.trailertools tmdb_trailers")
 
     from core.tmdb import Tmdb
     itemlist = []
     tmdb_search = None
     if "tmdb_id" in item.infoLabels and item.infoLabels['tmdb_id'] != "":
-        tmdb_search = Tmdb(id_Tmdb=item.infoLabels['tmdb_id'], tipo=type, idioma_busqueda='es')
+        tmdb_search = Tmdb(id_Tmdb=item.infoLabels['tmdb_id'], tipo=tipo, idioma_busqueda='es')
     elif "year" in item.infoLabels and item.infoLabels['year'] != "":
-        tmdb_search = Tmdb(texto_buscado=item.contentTitle, tipo=type, year=item.infoLabels['year'])
+        tmdb_search = Tmdb(texto_buscado=item.contentTitle, tipo=tipo, year=item.infoLabels['year'])
 
     if tmdb_search:
         for result in tmdb_search.get_videos():

--- a/python/main-classic/channels/verseriesynovelas.py
+++ b/python/main-classic/channels/verseriesynovelas.py
@@ -225,7 +225,7 @@ def novedades(item):
             if (DEBUG): logger.info("title=["+scrapedtitle+"], url=["+scrapedurl+"], thumbnail=["+scrapedthumbnail+"]")
             itemlist.append(item.clone(action="findvideos", title=scrapedtitle, url=scrapedurl,
                                        thumbnail=scrapedthumbnail, fulltitle=titleinfo, show=titleinfo,
-                                       contentTitle=contentTitle, context="25"))
+                                       contentTitle=contentTitle, context=["buscar_trailer"], contentType="tvshow"))
 
     if item.extra != "newest":
         try:
@@ -269,7 +269,8 @@ def ultimas(item, texto=""):
                 logger.info("title=["+scrapedtitle+"], url=["+scrapedurl+"], thumbnail=["+scrapedthumbnail+"]")
             itemlist.append(item.clone(action="episodios", title=scrapedtitle, url=scrapedurl,
                                        thumbnail=scrapedthumbnail, fulltitle=titleinfo,
-                                       contentTitle=titleinfo, context="25", show=titleinfo))
+                                       contentTitle=titleinfo, context=["buscar_trailer"], show=titleinfo,
+                                       contentType="tvshow"))
 
     try:
         from core import tmdb
@@ -313,7 +314,8 @@ def episodios(item):
             if "EN.png" in match:
                 scrapedtitle += "[V.O]"
             if (DEBUG): logger.info("title=["+scrapedtitle+"], url=["+scrapedurl+"]")
-            itemlist.append(item.clone(action="findvideos", title=scrapedtitle, url=scrapedurl, fulltitle=scrapedtitle))
+            itemlist.append(item.clone(action="findvideos", title=scrapedtitle, url=scrapedurl,
+                                       fulltitle=scrapedtitle, contentType="episode"))
 
     itemlist.reverse()
     if itemlist and item.extra != "episodios":
@@ -384,6 +386,8 @@ def findvideos(item):
         if url_lista != "":
             itemlist.append(item.clone(action="episodios", title="Ir a la Lista de Capítulos", url=url_lista,
                                        text_color="red", context=""))
+    for item1 in itemlist:
+        logger.info(item1.tostring())
 
     return itemlist
 

--- a/python/main-classic/channels/zpeliculas.py
+++ b/python/main-classic/channels/zpeliculas.py
@@ -120,7 +120,8 @@ def search(item,texto):
             thumbnail = scrapedthumbnail
             plot = ""
             if (DEBUG): logger.info("title=["+title+"], url=["+url+"], thumbnail=["+thumbnail+"]")
-            itemlist.append( Item(channel=item.channel, action="findvideos" , title=title , url=url, thumbnail=thumbnail, plot=plot, show=title, fanart=thumbnail, hasContentDetails="true", contentTitle=title, contentThumbnail=thumbnail))
+            itemlist.append( Item(channel=item.channel, action="findvideos" , title=title , url=url, thumbnail=thumbnail, plot=plot, show=title, fanart=thumbnail, hasContentDetails="true", contentTitle=title, contentThumbnail=thumbnail,
+                                  contentType="movie", context=["buscar_trailer"]))
 
         return itemlist
     # Se captura la excepción, para no interrumpir al buscador global si un canal falla
@@ -209,7 +210,8 @@ def peliculas(item):
         plot = ""
         if (DEBUG): logger.info("title=["+title+"], url=["+url+"], thumbnail=["+thumbnail+"]")
         
-        itemlist.append( Item(channel=item.channel, action="findvideos" , title=title , url=url, thumbnail=thumbnail, plot=plot, hasContentDetails="true", contentTitle=contentTitle, contentThumbnail=thumbnail, fanart=thumbnail))
+        itemlist.append( Item(channel=item.channel, action="findvideos" , title=title , url=url, thumbnail=thumbnail, plot=plot, hasContentDetails="true", contentTitle=contentTitle, contentThumbnail=thumbnail, fanart=thumbnail,
+                              contentType="movie", context=["buscar_trailer"]))
 
     next_page = scrapertools.find_single_match(body,'<a href="([^"]+)">Siguiente')
     if next_page!="":
@@ -249,7 +251,8 @@ def destacadas(item):
         plot = unicode( plot, "iso-8859-1" , errors="replace" ).encode("utf-8")
         if (DEBUG): logger.info("title=["+title+"], url=["+url+"], thumbnail=["+thumbnail+"]")
         
-        itemlist.append( Item(channel=item.channel, action="findvideos" , title=title , url=url, thumbnail=thumbnail, plot=plot, show=title, fanart=thumbnail, hasContentDetails="true", contentTitle=title, contentThumbnail=thumbnail))
+        itemlist.append( Item(channel=item.channel, action="findvideos" , title=title , url=url, thumbnail=thumbnail, plot=plot, show=title, fanart=thumbnail, hasContentDetails="true", contentTitle=title, contentThumbnail=thumbnail,
+                              contentType="movie", context=["buscar_trailer"]))
         
     return itemlist
 
@@ -280,7 +283,8 @@ def sugeridas(item):
         plot = unicode( plot, "iso-8859-1" , errors="replace" ).encode("utf-8")
         if (DEBUG): logger.info("title=["+title+"], url=["+url+"], thumbnail=["+thumbnail+"]")
         
-        itemlist.append( Item(channel=item.channel, action="findvideos" , title=title , url=url, thumbnail=thumbnail, plot=plot, show=title, fanart=thumbnail, hasContentDetails="true", contentTitle=title, contentThumbnail=thumbnail))
+        itemlist.append( Item(channel=item.channel, action="findvideos" , title=title , url=url, thumbnail=thumbnail, plot=plot, show=title, fanart=thumbnail, hasContentDetails="true", contentTitle=title, contentThumbnail=thumbnail,
+                              contentType="movie", context=["buscar_trailer"]))
         
     return itemlist
 


### PR DESCRIPTION
Arreglado trailertools a raíz de los cambios en el PR #415
Adaptados los menús contextuales de extendedinfo y buscar trailer en los canales que los utilizaban y añadidos en algunos que no lo tenían.