### PR TITLE
Nuevas opciones en canal tengourl

### DIFF
--- a/python/main-classic/channels/tengourl.py
+++ b/python/main-classic/channels/tengourl.py
@@ -7,6 +7,7 @@
 
 from core import config
 from core import logger
+from core import scrapertools
 from core import servertools
 from core.item import Item
 
@@ -18,7 +19,9 @@ def mainlist(item):
     logger.info("[tengourl.py] mainlist")
 
     itemlist = []
-    itemlist.append( Item(channel=item.channel, action="search", title="Entra aquí y teclea la URL"))
+    itemlist.append( Item(channel=item.channel, action="search", title="Entra aquí y teclea la URL [Enlace a servidor online/descarga]"))
+    itemlist.append( Item(channel=item.channel, action="search", title="Entra aquí y teclea la URL [Enlace directo a un vídeo]"))
+    itemlist.append( Item(channel=item.channel, action="search", title="Entra aquí y teclea la URL [Búsqueda de enlaces en una url]"))
 
     return itemlist
 
@@ -31,10 +34,19 @@ def search(item,texto):
 
     itemlist = []
 
-    itemlist = servertools.find_video_items(data=texto)
-    for item in itemlist:
-        item.channel="tengourl"
-        item.action="play"
+    if "servidor" in item.title:
+        itemlist = servertools.find_video_items(data=texto)
+        for item in itemlist:
+            item.channel="tengourl"
+            item.action="play"
+    elif "directo" in item.title:
+        itemlist.append( Item(channel=item.channel, action="play", url=texto, server="directo", title="Ver enlace directo"))
+    else:
+        data = scrapertools.downloadpage(texto)
+        itemlist = servertools.find_video_items(data=data)
+        for item in itemlist:
+            item.channel="tengourl"
+            item.action="play"
 
     if len(itemlist)==0:
         itemlist.append( Item(channel=item.channel, action="search", title="No hay ningún vídeo compatible en esa URL"))


### PR DESCRIPTION
He añadido dos nuevas opciones en el canal tengourl para complementar a la ya existente que solo busca urls coincidentes entre los conectores. Por un lado una para enlaces directos a un vídeo (mp4, m3u8, etc...) y por otro para buscar enlaces en una página concreta, lo cual puede venir bien para páginas que no tienen un canal propio, para hacer pruebas sin necesidad de navegar por el canal, etc...