### PR TITLE
Mejoras en filtertools y logger

### DIFF
--- a/python/main-classic/channels/filtertools.py
+++ b/python/main-classic/channels/filtertools.py
@@ -57,7 +57,48 @@ class Filter:
 # TODO echar un ojo a https://pyformat.info/, se puede formatear el estilo y hacer referencias directamente a elementos
 
 __channel__ = "filtertools"
-DEBUG = config.get_setting("debug")
+
+
+def context():
+    _context = ""
+    '''
+    configuración para mostrar la opción de filtro, actualmente sólo se permite en xbmc, se cambiará cuando
+    'platformtools.show_channel_settings' esté disponible para las distintas plataformas
+    '''
+    if config.is_xbmc():
+        _context = [{"title": "Menu Filtro",
+                     "action": "config_filter",
+                     "channel": "filtertools"}]
+
+    # elif command == "guardar_filtro":
+    # context_commands.append(("Guardar Filtro Serie", "XBMC.RunPlugin(%s?%s)" % (sys.argv[0], item.clone(
+    #     channel="filtertools",
+    #     action="save_filter",
+    #     from_channel=item.channel
+    # ).tourl())))
+    #
+    # elif command == "borrar_filtro":
+    #     context_commands.append(("Eliminar Filtro", "XBMC.RunPlugin(%s?%s)" % (sys.argv[0], item.clone(
+    #         channel="filtertools",
+    #         action="del_filter",
+    #         from_channel=item.channel
+    #     ).tourl())))
+
+    return _context
+
+context = context()
+
+
+def show_option(itemlist, channel, list_idiomas, list_calidad):
+    itemlist.append(Item(channel=__channel__, title="[COLOR yellow]Configurar filtro para series...[/COLOR]",
+                         action="open_filtertools", list_idiomas=list_idiomas, list_calidad=list_calidad,
+                         from_channel=channel))
+
+    return itemlist
+
+
+def open_filtertools(item):
+    return mainlist_filter(channel=item.from_channel, list_idiomas=item.list_idiomas, list_calidad=item.list_calidad)
 
 
 def get_filtered_links(list_item, channel):
@@ -73,8 +114,7 @@ def get_filtered_links(list_item, channel):
     """
     logger.info("[filtertools.py] get_filtered_links")
 
-    if DEBUG:
-        logger.info("total de items : {0}".format(len(list_item)))
+    logger.info("total de items : {0}".format(len(list_item)))
 
     new_itemlist = []
     quality_count = 0
@@ -123,14 +163,12 @@ def get_filtered_links(list_item, channel):
                 new_itemlist.append(new_item)
                 logger.info("{0} | context: {1}".format(item.title, item.context))
                 # TODO mirar el context para cambiarlo por como dice super_berny
-                if DEBUG:
-                    logger.info(" -Enlace añadido")
+                logger.info(" -Enlace añadido")
 
-            if DEBUG:
-                logger.info(" idioma valido?: {0}, item.language: {1}, filter.language: {2}"
-                            .format(is_language_valid, item.language, _filter.language))
-                logger.info(" calidad valida?: {0}, item.quality: {1}, filter.quality_not_allowed: {2}"
-                            .format(is_quality_valid, quality, _filter.quality_not_allowed))
+            logger.info(" idioma valido?: {0}, item.language: {1}, filter.language: {2}"
+                        .format(is_language_valid, item.language, _filter.language))
+            logger.info(" calidad valida?: {0}, item.quality: {1}, filter.quality_not_allowed: {2}"
+                        .format(is_quality_valid, quality, _filter.quality_not_allowed))
 
         logger.info("ITEMS FILTRADOS: {0}/{1}, idioma[{2}]:{3}, calidad_no_permitida{4}:{5}"
                     .format(len(new_itemlist), len(list_item), _filter.language, language_count,
@@ -197,8 +235,7 @@ def get_filtered_tvshows(from_channel):
     if TAG_TVSHOW_FILTER in dict_data:
         dict_series = dict_data[TAG_TVSHOW_FILTER]
 
-    if DEBUG:
-        logger.info("json_series: {0}".format(dict_series))
+    logger.info("json_series: {0}".format(dict_series))
 
     return dict_series
 
@@ -252,14 +289,14 @@ def mainlist_filter(channel, list_idiomas, list_calidad):
     idx = 0
     for tvshow in sorted(dict_series):
         if dict_series[tvshow][TAG_ACTIVE]:
-          tag_color = "0xff008000"
-        else: 
-          tag_color = "0xff00fa9a"
+            tag_color = "0xff008000"
+        else:
+            tag_color = "0xff00fa9a"
         if idx % 2 == 0:
             if dict_series[tvshow][TAG_ACTIVE]:
-              tag_color = "blue"
+                tag_color = "blue"
             else:
-               tag_color = "0xff00bfff"
+                tag_color = "0xff00bfff"
 
         idx += 1
         name = dict_series.get(tvshow, {}).get(TAG_NAME, tvshow)

--- a/python/main-classic/channels/filtertools.py
+++ b/python/main-classic/channels/filtertools.py
@@ -51,9 +51,6 @@ class Filter:
         self.language = dict_filter[TAG_LANGUAGE]
         self.quality_not_allowed = dict_filter[TAG_QUALITY_NOT_ALLOWED]
 
-# TODO mejorar tema de colores
-# TODO mejorar logger
-# TODO meter try/catch
 # TODO echar un ojo a https://pyformat.info/, se puede formatear el estilo y hacer referencias directamente a elementos
 
 __channel__ = "filtertools"
@@ -112,9 +109,9 @@ def get_links(list_item, channel):
     :return: lista de Item
     :rtype: list[Item]
     """
-    logger.info("[filtertools.py] get_filtered_links")
+    logger.info()
 
-    logger.info("total de items : {0}".format(len(list_item)))
+    logger.debug("total de items : {0}".format(len(list_item)))
 
     new_itemlist = []
     quality_count = 0
@@ -127,7 +124,7 @@ def get_links(list_item, channel):
         _filter = Filter(dict_filtered_shows[tvshow])
 
     if _filter and _filter.active:
-        logger.info("filter datos: {0}".format(_filter))
+        logger.debug("filter datos: {0}".format(_filter))
 
         for item in list_item:
 
@@ -161,14 +158,13 @@ def get_links(list_item, channel):
             if is_language_valid and is_quality_valid:
                 new_item = item.clone(channel=channel)
                 new_itemlist.append(new_item)
-                logger.info("{0} | context: {1}".format(item.title, item.context))
-                # TODO mirar el context para cambiarlo por como dice super_berny
-                logger.info(" -Enlace añadido")
+                logger.debug("{0} | context: {1}".format(item.title, item.context))
+                logger.debug(" -Enlace añadido")
 
-            logger.info(" idioma valido?: {0}, item.language: {1}, filter.language: {2}"
-                        .format(is_language_valid, item.language, _filter.language))
-            logger.info(" calidad valida?: {0}, item.quality: {1}, filter.quality_not_allowed: {2}"
-                        .format(is_quality_valid, quality, _filter.quality_not_allowed))
+            logger.debug(" idioma valido?: {0}, item.language: {1}, filter.language: {2}"
+                         .format(is_language_valid, item.language, _filter.language))
+            logger.debug(" calidad valida?: {0}, item.quality: {1}, filter.quality_not_allowed: {2}"
+                         .format(is_quality_valid, quality, _filter.quality_not_allowed))
 
         logger.info("ITEMS FILTRADOS: {0}/{1}, idioma[{2}]:{3}, calidad_no_permitida{4}:{5}"
                     .format(len(new_itemlist), len(list_item), _filter.language, language_count,
@@ -200,7 +196,7 @@ def no_filter(item):
     :return: liasta de enlaces
     :rtype: list[Item]
     """
-    logger.info("[filtertools.py] no_filter")
+    logger.info()
 
     lista = []
     for i in item.lista:
@@ -218,7 +214,7 @@ def get_tvshows(from_channel):
     :return: dict con las series
     :rtype: dict
     """
-    logger.info("[filtertools.py] get_filtered_tvshows")
+    logger.info()
     dict_series = {}
     name_file = from_channel
 
@@ -235,7 +231,7 @@ def get_tvshows(from_channel):
     if TAG_TVSHOW_FILTER in dict_data:
         dict_series = dict_data[TAG_TVSHOW_FILTER]
 
-    logger.info("json_series: {0}".format(dict_series))
+    logger.debug("json_series: {0}".format(dict_series))
 
     return dict_series
 
@@ -252,21 +248,21 @@ def check_json_file(data, fname, dict_data):
     :param dict_data: nombre del diccionario
     :type dict_data: dict
     """
-    logger.info("[filtertools.py] check_json_file")
+    logger.info()
     if not dict_data:
-        logger.info("Error al cargar el json del fichero {0}".format(fname))
+        logger.error("Error al cargar el json del fichero {0}".format(fname))
 
         if data != "":
             # se crea un nuevo fichero
             title = filetools.write("{0}.bk".format(fname), data)
             if title != "":
-                logger.info("Ha habido un error al guardar el fichero: {0}.bk"
-                            .format(fname))
+                logger.error("Ha habido un error al guardar el fichero: {0}.bk"
+                             .format(fname))
             else:
-                logger.info("Se ha guardado una copia con el nombre: {0}.bk"
-                            .format(fname))
+                logger.debug("Se ha guardado una copia con el nombre: {0}.bk"
+                             .format(fname))
         else:
-            logger.info("Está vacío el fichero: {0}".format(fname))
+            logger.debug("Está vacío el fichero: {0}".format(fname))
 
 
 def mainlist(channel, list_idiomas, list_calidad):
@@ -282,7 +278,7 @@ def mainlist(channel, list_idiomas, list_calidad):
     :return: lista de Item
     :rtype: list[Item]
     """
-    logger.info("[filtertools.py] mainlist_filter")
+    logger.info()
     itemlist = []
     dict_series = get_tvshows(channel)
 
@@ -322,7 +318,7 @@ def config_item(item):
     :param item: item
     :type item: Item
     """
-    logger.info("[filtertools.py] config_filter")
+    logger.info()
     logger.info("item {0}".format(item.tostring()))
 
     # OBTENEMOS LOS DATOS DEL JSON
@@ -399,7 +395,7 @@ def config_item(item):
 
 
 def borrar_filtro(item):
-    logger.info("[filtertools.py] borrar_filtro")
+    logger.info()
     if item:
         # OBTENEMOS LOS DATOS DEL JSON
         dict_series = get_tvshows(item.from_channel)
@@ -434,7 +430,7 @@ def guardar_valores(item, dict_data_saved):
     :param dict_data_saved: diccionario con los datos salvados
     :type dict_data_saved: dict
     """
-    logger.info("[filtertools.py] guardar_valores")
+    logger.info()
     # Aqui tienes q gestionar los datos obtenidos del cuadro de dialogo
     if item and dict_data_saved:
         logger.debug('item: {0}\ndatos: {1}'.format(item.tostring(), dict_data_saved))
@@ -480,7 +476,7 @@ def update_json_data(dict_series, filename):
     :return: fname, json_data
     :rtype: str, dict
     """
-    logger.info("[filtertools.py] update_json_data")
+    logger.info()
     if not os.path.exists(os.path.join(config.get_data_path(), "settings_channels")):
         os.mkdir(os.path.join(config.get_data_path(), "settings_channels"))
     fname = os.path.join(config.get_data_path(), "settings_channels", filename + "_data.json")
@@ -489,14 +485,14 @@ def update_json_data(dict_series, filename):
     # es un dict
     if dict_data:
         if TAG_TVSHOW_FILTER in dict_data:
-            logger.info("   existe el key SERIES")
+            logger.debug("   existe el key SERIES")
             dict_data[TAG_TVSHOW_FILTER] = dict_series
         else:
-            logger.info("   NO existe el key SERIES")
+            logger.debig("   NO existe el key SERIES")
             new_dict = {TAG_TVSHOW_FILTER: dict_series}
             dict_data.update(new_dict)
     else:
-        logger.info("   NO es un dict")
+        logger.debug("   NO es un dict")
         dict_data = {TAG_TVSHOW_FILTER: dict_series}
     json_data = jsontools.dump_json(dict_data)
     return fname, json_data

--- a/python/main-classic/channels/filtertools.py
+++ b/python/main-classic/channels/filtertools.py
@@ -91,17 +91,17 @@ context = context()
 
 def show_option(itemlist, channel, list_idiomas, list_calidad):
     itemlist.append(Item(channel=__channel__, title="[COLOR yellow]Configurar filtro para series...[/COLOR]",
-                         action="open_filtertools", list_idiomas=list_idiomas, list_calidad=list_calidad,
+                         action="load", list_idiomas=list_idiomas, list_calidad=list_calidad,
                          from_channel=channel))
 
     return itemlist
 
 
-def open_filtertools(item):
-    return mainlist_filter(channel=item.from_channel, list_idiomas=item.list_idiomas, list_calidad=item.list_calidad)
+def load(item):
+    return mainlist(channel=item.from_channel, list_idiomas=item.list_idiomas, list_calidad=item.list_calidad)
 
 
-def get_filtered_links(list_item, channel):
+def get_links(list_item, channel):
     """
     Devuelve una lista de enlaces filtrados.
 
@@ -121,7 +121,7 @@ def get_filtered_links(list_item, channel):
     language_count = 0
     _filter = None
 
-    dict_filtered_shows = get_filtered_tvshows(channel)
+    dict_filtered_shows = get_tvshows(channel)
     tvshow = list_item[0].show.lower().strip()
     if tvshow in dict_filtered_shows.keys():
         _filter = Filter(dict_filtered_shows[tvshow])
@@ -209,7 +209,7 @@ def no_filter(item):
     return lista
 
 
-def get_filtered_tvshows(from_channel):
+def get_tvshows(from_channel):
     """
     Obtiene las series filtradas de un canal
 
@@ -269,7 +269,7 @@ def check_json_file(data, fname, dict_data):
             logger.info("Está vacío el fichero: {0}".format(fname))
 
 
-def mainlist_filter(channel, list_idiomas, list_calidad):
+def mainlist(channel, list_idiomas, list_calidad):
     """
     Muestra una lista de las series filtradas
 
@@ -284,7 +284,7 @@ def mainlist_filter(channel, list_idiomas, list_calidad):
     """
     logger.info("[filtertools.py] mainlist_filter")
     itemlist = []
-    dict_series = get_filtered_tvshows(channel)
+    dict_series = get_tvshows(channel)
 
     idx = 0
     for tvshow in sorted(dict_series):
@@ -315,7 +315,7 @@ def mainlist_filter(channel, list_idiomas, list_calidad):
     return itemlist
 
 
-def config_filter(item):
+def config(item):
     """
     muestra una serie filtrada para su configuración
 
@@ -326,7 +326,7 @@ def config_filter(item):
     logger.info("item {0}".format(item.tostring()))
 
     # OBTENEMOS LOS DATOS DEL JSON
-    dict_series = get_filtered_tvshows(item.from_channel)
+    dict_series = get_tvshows(item.from_channel)
 
     tvshow = item.show.lower().strip()
 
@@ -402,7 +402,7 @@ def borrar_filtro(item):
     logger.info("[filtertools.py] borrar_filtro")
     if item:
         # OBTENEMOS LOS DATOS DEL JSON
-        dict_series = get_filtered_tvshows(item.from_channel)
+        dict_series = get_tvshows(item.from_channel)
         tvshow = item.show.strip().lower()
 
         heading = "¿Está seguro que desea eliminar el filtro?"
@@ -442,7 +442,7 @@ def guardar_valores(item, dict_data_saved):
         # OBTENEMOS LOS DATOS DEL JSON
         if item.from_channel == "biblioteca":
             item.from_channel = item.contentChannel
-        dict_series = get_filtered_tvshows(item.from_channel)
+        dict_series = get_tvshows(item.from_channel)
         tvshow = item.show.strip().lower()
 
         logger.info("Se actualiza los datos")

--- a/python/main-classic/channels/filtertools.py
+++ b/python/main-classic/channels/filtertools.py
@@ -67,7 +67,7 @@ def context():
     '''
     if config.is_xbmc():
         _context = [{"title": "Menu Filtro",
-                     "action": "config_filter",
+                     "action": "config_item",
                      "channel": "filtertools"}]
 
     # elif command == "guardar_filtro":
@@ -305,7 +305,7 @@ def mainlist(channel, list_idiomas, list_calidad):
             activo = ""
         title = "Configurar [COLOR {0}][{1}][/COLOR]{2}".format(tag_color, name, activo)
 
-        itemlist.append(Item(channel=__channel__, action="config_filter", title=title, show=name,
+        itemlist.append(Item(channel=__channel__, action="config_item", title=title, show=name,
                              list_idiomas=list_idiomas, list_calidad=list_calidad, from_channel=channel))
 
     if len(itemlist) == 0:
@@ -315,7 +315,7 @@ def mainlist(channel, list_idiomas, list_calidad):
     return itemlist
 
 
-def config(item):
+def config_item(item):
     """
     muestra una serie filtrada para su configuración
 
@@ -516,7 +516,7 @@ def update_json_data(dict_series, filename):
 #     dict_series = get_filtered_tvshows(item.from_channel)
 #
 #     name = item.show.lower().strip()
-#     logger.info("[filtertools.py] config_filter name {0}".format(name))
+#     logger.info("[filtertools.py] config_item name {0}".format(name))
 #
 #     open_tag_idioma = (0, item.title.find("[")+1)[item.title.find("[") >= 0]
 #     close_tag_idioma = (0, item.title.find("]"))[item.title.find("]") >= 0]

--- a/python/main-classic/channels/seriesblanco.py
+++ b/python/main-classic/channels/seriesblanco.py
@@ -201,7 +201,7 @@ def episodios(item):
                              url=item.url, action="series"))
 
     if len(itemlist) > 0 and filtertools.context:
-        itemlist = filtertools.get_filtered_links(itemlist, item.channel)
+        itemlist = filtertools.get_links(itemlist, item.channel)
 
     # Opción "Añadir esta serie a la biblioteca de XBMC"
     if config.get_library_support() and len(itemlist) > 0:
@@ -241,7 +241,7 @@ def parseVideos(item, typeStr, data):
             # context=filtertools.context+"|guardar_filtro"))
 
         if len(itemlist) > 0 and filtertools.context:
-            itemlist = filtertools.get_filtered_links(itemlist, item.channel)
+            itemlist = filtertools.get_links(itemlist, item.channel)
 
         if len(itemlist) > 0:
             return itemlist

--- a/python/main-classic/channels/seriesblanco.py
+++ b/python/main-classic/channels/seriesblanco.py
@@ -24,14 +24,6 @@ HOST = "http://seriesblanco.com/"
 IDIOMAS = {'es': 'Español', 'en': 'Inglés', 'la': 'Latino', 'vo': 'VO', 'vos': 'VOS', 'vosi': 'VOSI', 'otro': 'OVOS'}
 list_idiomas = [v for v in IDIOMAS.values()]
 CALIDADES = ['SD', 'HDiTunes', 'Micro-HD-720p', 'Micro-HD-1080p', '1080p', '720p']
-
-'''
-configuración para mostrar la opción de filtro, actualmente sólo se permite en xbmc, se cambiará cuando
-'platformtools.show_channel_settings' esté disponible para las distintas plataformas
-'''
-OPCION_FILTRO = config.is_xbmc()
-CONTEXT = ("", "menu_filtro")[OPCION_FILTRO]
-DEBUG = config.get_setting("debug")
 CHANNEL_HOST = 'http://seriesblanco.com'
 CHANNEL_HEADERS = [
     ['User-Agent', 'Mozilla/5.0'],
@@ -55,16 +47,10 @@ def mainlist(item):
                          url=urlparse.urljoin(HOST, "lista_series/"), thumbnail=thumb_series))
     itemlist.append(Item(channel=item.channel, title="Buscar...", action="search", url=HOST, thumbnail=thumb_buscar))
 
-    if OPCION_FILTRO:
-        itemlist.append(Item(channel=item.channel, title="[COLOR yellow]Configurar filtro para series...[/COLOR]",
-                             action="open_filtertools"))
+    if filtertools.context:
+        itemlist = filtertools.show_option(itemlist, item.channel, list_idiomas, CALIDADES)
 
     return itemlist
-
-
-def open_filtertools(item):
-
-    return filtertools.mainlist_filter(channel=item.channel, list_idiomas=list_idiomas, list_calidad=CALIDADES)
 
 
 def series_listado_alfabetico(item):
@@ -119,7 +105,7 @@ def search(item, texto):
     for scrapedthumb, scrapedurl, scrapedtitle in matches:
         itemlist.append(Item(channel=item.channel, title=scrapedtitle.strip(), url=urlparse.urljoin(HOST, scrapedurl),
                              action="episodios", show=scrapedtitle.strip(), thumbnail=scrapedthumb,
-                             list_idiomas=list_idiomas, list_calidad=CALIDADES, context=CONTEXT))
+                             list_idiomas=list_idiomas, list_calidad=CALIDADES, context=filtertools.context))
 
     try:
         return itemlist
@@ -151,7 +137,7 @@ def series(item):
     for scrapedurl, scrapedtitle in matches:
         itemlist.append(Item(channel=item.channel, title=scrapedtitle.strip(), url=urlparse.urljoin(HOST, scrapedurl),
                              action="episodios", show=scrapedtitle.strip(), thumbnail=thumbnail,
-                             list_idiomas=list_idiomas, list_calidad=CALIDADES, context=CONTEXT))
+                             list_idiomas=list_idiomas, list_calidad=CALIDADES, context=filtertools.context))
 
     return itemlist
 
@@ -207,14 +193,14 @@ def episodios(item):
         title = item.show + " - " + scrapedtitle + idioma
         itemlist.append(Item(channel=item.channel, title=title, url=urlparse.urljoin(HOST, scrapedurl),
                              action="findvideos", show=item.show, thumbnail=thumbnail, plot=plot, language=idioma,
-                             list_idiomas=list_idiomas, list_calidad=CALIDADES, context=CONTEXT))
+                             list_idiomas=list_idiomas, list_calidad=CALIDADES, context=filtertools.context))
 
     if len(itemlist) == 0 and "<title>404 Not Found</title>" in data:
         itemlist.append(Item(channel=item.channel, title="la url '" + item.url +
-                                                        "' parece no estar disponible en la web. Iténtalo más tarde.",
+                                                         "' parece no estar disponible en la web. Iténtalo más tarde.",
                              url=item.url, action="series"))
 
-    if len(itemlist) > 0 and OPCION_FILTRO:
+    if len(itemlist) > 0 and filtertools.context:
         itemlist = filtertools.get_filtered_links(itemlist, item.channel)
 
     # Opción "Añadir esta serie a la biblioteca de XBMC"
@@ -251,9 +237,10 @@ def parseVideos(item, typeStr, data):
             itemlist.append(Item(channel=item.channel, title=title, url=urlparse.urljoin(HOST, vFields.get("link")),
                                  action="play", show=item.show, language=IDIOMAS.get(vFields.get("language"), "OVOS"),
                                  quality=quality, list_idiomas=list_idiomas, list_calidad=CALIDADES,
-                                 fulltitle=item.title, context=CONTEXT+"|guardar_filtro"))
+                                 fulltitle=item.title, context=filtertools.context))
+            # context=filtertools.context+"|guardar_filtro"))
 
-        if len(itemlist) > 0 and OPCION_FILTRO:
+        if len(itemlist) > 0 and filtertools.context:
             itemlist = filtertools.get_filtered_links(itemlist, item.channel)
 
         if len(itemlist) > 0:
@@ -271,9 +258,9 @@ def extractVideosSection(data):
 
     row = len(result) - 2
     if result[row][1]:
-      idx = 1
+        idx = 1
     else:
-      idx = 0
+        idx = 0
 
     return [result[row][idx], result[row + 1][idx]]
 

--- a/python/main-classic/channels/seriesblanco.py
+++ b/python/main-classic/channels/seriesblanco.py
@@ -34,7 +34,7 @@ CHANNEL_HEADERS = [
 
 
 def mainlist(item):
-    logger.info("pelisalacarta.seriesblanco mainlist")
+    logger.info()
 
     thumb_series = get_thumbnail("thumb_canales_series.png")
     thumb_series_az = get_thumbnail("thumb_canales_series_az.png")
@@ -54,7 +54,7 @@ def mainlist(item):
 
 
 def series_listado_alfabetico(item):
-    logger.info("pelisalacarta.seriesblanco series_listado_alfabetico")
+    logger.info()
 
     itemlist = []
 
@@ -72,7 +72,7 @@ def series_por_letra(item):
 
 
 def search(item, texto):
-    logger.info("[pelisalacarta.seriesblanco search texto={0}".format(texto))
+    logger.info("texto={0}".format(texto))
 
     itemlist = []
 
@@ -118,7 +118,7 @@ def search(item, texto):
 
 
 def series(item):
-    logger.info("pelisalacarta.seriesblanco series")
+    logger.info()
 
     itemlist = []
 
@@ -143,7 +143,7 @@ def series(item):
 
 
 def episodios(item):
-    logger.info("pelisalacarta.seriesblanco episodios")
+    logger.info()
 
     itemlist = []
 
@@ -266,7 +266,7 @@ def extractVideosSection(data):
 
 
 def findvideos(item):
-    logger.info("pelisalacarta.seriesblanco findvideos")
+    logger.info()
 
     # Descarga la página
     data = scrapertools.anti_cloudflare(item.url, headers=CHANNEL_HEADERS, host=CHANNEL_HOST)
@@ -276,7 +276,7 @@ def findvideos(item):
 
 
 def play(item):
-    logger.info("pelisalacarta.channels.seriesblanco play url={0}".format(item.url))
+    logger.info("play url={0}".format(item.url))
 
     if item.url.startswith(HOST):
         data = scrapertools.anti_cloudflare(item.url, headers=CHANNEL_HEADERS, host=CHANNEL_HOST)

--- a/python/main-classic/channels/seriesdanko.py
+++ b/python/main-classic/channels/seriesdanko.py
@@ -193,7 +193,7 @@ def episodios(item):
                              list_idiomas=list_idiomas, list_calidad=CALIDADES, context=filtertools.context))
 
     if len(itemlist) > 0 and filtertools.context:
-            itemlist = filtertools.get_filtered_links(itemlist, item.channel)
+            itemlist = filtertools.get_links(itemlist, item.channel)
 
     # Opción "Añadir esta serie a la biblioteca de XBMC"
     if config.get_library_support() and len(itemlist) > 0:
@@ -240,7 +240,7 @@ def parse_videos(item, tipo, data):
         # context=CONTEXT+"|guardar_filtro"))
 
     if len(itemlist) > 0 and filtertools.context:
-        itemlist = filtertools.get_filtered_links(itemlist, item.channel)
+        itemlist = filtertools.get_links(itemlist, item.channel)
 
     return itemlist
 

--- a/python/main-classic/channels/seriesdanko.py
+++ b/python/main-classic/channels/seriesdanko.py
@@ -25,7 +25,7 @@ DEBUG = config.get_setting("debug")
 
 
 def mainlist(item):
-    logger.info("pelisalacarta.seriesdanko mainlist")
+    logger.info()
 
     itemlist = list()
     itemlist.append(Item(channel=item.channel, title="Novedades", action="novedades", url=HOST))
@@ -41,7 +41,7 @@ def mainlist(item):
 
 
 def novedades(item):
-    logger.info("pelisalacarta.seriesdanko novedades")
+    logger.info()
 
     itemlist = list()
 
@@ -66,7 +66,7 @@ def novedades(item):
 
 
 def mas_vistas(item):
-    logger.info("pelisalacarta.seriesdanko mas_vistas")
+    logger.info()
 
     data = scrapertools.cache_page(item.url)
     data = re.sub(r"\n|\r|\t|\s{2}|&nbsp;|<Br>|<BR>|<br>|<br/>|<br />|-\s", "", data)
@@ -79,7 +79,7 @@ def mas_vistas(item):
 
 
 def listado_completo(item):
-    logger.info("pelisalacarta.seriesdanko listado_completo")
+    logger.info()
 
     data = scrapertools.cache_page(item.url)
     data = re.sub(r"\n|\r|\t|\s{2}|&nbsp;|<Br>|<BR>|<br>|<br/>|<br />|-\s", "", data)
@@ -91,7 +91,7 @@ def listado_completo(item):
 
 
 def series_seccion(item, data):
-    logger.info("pelisalacarta.seriesdanko series_seccion")
+    logger.info()
 
     itemlist = []
     patron = "<a href='([^']+)'.*?>(.*?)</a>"
@@ -104,7 +104,7 @@ def series_seccion(item, data):
 
 
 def listado_alfabetico(item):
-    logger.info("pelisalacarta.seriesdanko listado_alfabetico")
+    logger.info()
 
     itemlist = []
 
@@ -121,7 +121,7 @@ def series_por_letra(item):
 
 
 def search(item, texto):
-    logger.info("[pelisalacarta.seriesdanko search texto={0}".format(texto))
+    logger.info("texto={0}".format(texto))
 
     if texto != "":
         item.url = urlparse.urljoin(HOST, "/pag_search.php?q1={0}".format(texto))
@@ -137,7 +137,7 @@ def search(item, texto):
 
 
 def series(item):
-    logger.info("pelisalacarta.seriesdanko series")
+    logger.info()
 
     itemlist = []
 
@@ -160,7 +160,7 @@ def series(item):
 
 
 def episodios(item):
-    logger.info("pelisalacarta.seriesdanko episodios")
+    logger.info()
 
     itemlist = []
 
@@ -204,7 +204,7 @@ def episodios(item):
 
 
 def findvideos(item):
-    logger.info("pelisalacarta.seriesdanko findvideos")
+    logger.info()
 
     data = scrapertools.cache_page(item.url)
     data = re.sub(r"\n|\r|\t|\s{2}|&nbsp;|<Br>|<BR>|<br>|<br/>|<br />|-\s", "", data)
@@ -217,7 +217,7 @@ def findvideos(item):
 
 
 def parse_videos(item, tipo, data):
-    logger.info("pelisalacarta.seriesdanko parse_videos")
+    logger.info()
 
     itemlist = []
 
@@ -246,7 +246,7 @@ def parse_videos(item, tipo, data):
 
 
 def play(item):
-    logger.info("pelisalacarta.seriesdanko play url={0}".format(item.url))
+    logger.info("play url={0}".format(item.url))
 
     data = scrapertools.cache_page(item.url)
     data = re.sub(r"\n|\r|\t|\s{2}|&nbsp;|<Br>|<BR>|<br>|<br/>|<br />|-\s", "", data)

--- a/python/main-classic/core/logger.py
+++ b/python/main-classic/core/logger.py
@@ -59,7 +59,7 @@ def encode_log(message=None):
 def get_caller(message=None):
     module = inspect.getmodule(inspect.stack()[2][0])
 
-    # En boxee en cosaiones no detecta el modulo, de este modo lo hacemos manual
+    # En boxee en ocasiones no detecta el modulo, de este modo lo hacemos manual
     if module is None:
         module = ".".join(os.path.splitext(inspect.stack()[2][1].split("pelisalacarta")[1])[0].split(os.path.sep))[1:]
     else:

--- a/python/main-classic/core/logger.py
+++ b/python/main-classic/core/logger.py
@@ -23,14 +23,15 @@
 # along with pelisalacarta 4.  If not, see <http://www.gnu.org/licenses/>.
 # --------------------------------------------------------------------------------
 # Logger (kodi)
-#------------------------------------------------------------
+# --------------------------------------------------------------------------------
 
-from core import config
 import inspect
 import os
-import xbmc
 
-loggeractive = (config.get_setting("debug")=="true")
+import xbmc
+from core import config
+
+loggeractive = (config.get_setting("debug") == "true")
 
 
 def log_enable(active):
@@ -38,58 +39,75 @@ def log_enable(active):
     loggeractive = active
 
 
-def encode_log(message):
-    #Unicode to utf8
-    if type(message) == unicode: 
-        message = message.encode("utf8")
-        
-    #All encodings to utf8
-    elif type(message) == str:
-        message = unicode(message, "utf8", errors="replace").encode("utf8")
-        
-    #Objects to string
-    else:
-        message = repr(message) #or str(message)
+def encode_log(message=None):
+    if message:
+        # Unicode to utf8
+        if type(message) == unicode:
+            message = message.encode("utf8")
+
+        # All encodings to utf8
+        elif type(message) == str:
+            message = unicode(message, "utf8", errors="replace").encode("utf8")
+
+        # Objects to string
+        else:
+            message = repr(message)  # or str(message)
 
     return message
 
-def get_caller(message = None):
-        module=inspect.getmodule(inspect.stack()[2][0])
-        
-        #En boxee en cosaiones no detecta el modulo, de este modo lo hacemos manual
-        if module == None: 
-          module = ".".join(os.path.splitext(inspect.stack()[2][1].split("pelisalacarta")[1])[0].split(os.path.sep))[1:]
-        else: 
-          module = module.__name__
-        
-        function = inspect.stack()[2][3]
-        
-        if module == "__main__": module = "pelisalacarta" 
-        else: module = "pelisalacarta." + module
-        if message:
-          if not module in message:
-              if function == "<module>": return module + " " + message
-              else: return module + " [" + function + "] " + message
-          else:
-              return message
-        else:
-          if function == "<module>": return module
-          else: return module + "." + function
 
-def info(texto):
+def get_caller(message=None):
+    module = inspect.getmodule(inspect.stack()[2][0])
+
+    # En boxee en cosaiones no detecta el modulo, de este modo lo hacemos manual
+    if module is None:
+        module = ".".join(os.path.splitext(inspect.stack()[2][1].split("pelisalacarta")[1])[0].split(os.path.sep))[1:]
+    else:
+        module = module.__name__
+
+    function = inspect.stack()[2][3]
+
+    if module == "__main__":
+        module = "pelisalacarta"
+    else:
+        module = "pelisalacarta." + module
+    if message:
+        if module not in message:
+            if function == "<module>":
+                return module + " " + message
+            else:
+                return module + " [" + function + "] " + message
+        else:
+            return message
+    else:
+        if function == "<module>":
+            return module
+        else:
+            return module + "." + function
+
+
+def info(texto=None):
     if loggeractive:
         xbmc.log(get_caller(encode_log(texto)), xbmc.LOGNOTICE)
 
 
-def debug(texto):
+def debug(texto=None):
     if loggeractive:
-        texto= "    [" + get_caller() + "] " + encode_log(texto)
+        if texto:
+            texto = "    [" + get_caller() + "] " + encode_log(texto)
+        else:
+            texto = "    [" + get_caller() + "] "
+
         xbmc.log("######## DEBUG #########", xbmc.LOGNOTICE)
         xbmc.log(texto, xbmc.LOGNOTICE)
 
 
-def error(texto):
+def error(texto=None):
     if loggeractive:
-        texto= "    [" + get_caller() + "] " + encode_log(texto)
+        if texto:
+            texto = "    [" + get_caller() + "] " + encode_log(texto)
+        else:
+            texto = "    [" + get_caller() + "] "
+
         xbmc.log("######## ERROR #########", xbmc.LOGNOTICE)
         xbmc.log(texto, xbmc.LOGNOTICE)

--- a/python/main-classic/platformcode/platformtools.py
+++ b/python/main-classic/platformcode/platformtools.py
@@ -267,28 +267,7 @@ def set_context_commands(item, parent_item):
     for command in context:
         # Predefinidos
         if type(command) == str:
-            if command == "menu_filtro":
-                context_commands.append(("Menu Filtro", "XBMC.RunPlugin(%s?%s)" % (sys.argv[0], item.clone(
-                    channel="filtertools",
-                    action="config_filter",
-                    from_channel=item.channel
-                ).tourl())))
-
-            elif command == "guardar_filtro":
-                context_commands.append(("Guardar Filtro Serie", "XBMC.RunPlugin(%s?%s)" % (sys.argv[0], item.clone(
-                    channel="filtertools",
-                    action="save_filter",
-                    from_channel=item.channel
-                ).tourl())))
-
-            elif command == "borrar_filtro":
-                context_commands.append(("Eliminar Filtro", "XBMC.RunPlugin(%s?%s)" % (sys.argv[0], item.clone(
-                    channel="filtertools",
-                    action="del_filter",
-                    from_channel=item.channel
-                ).tourl())))
-
-            elif command == "buscar_trailer" or item.action == "findvideos":
+            if command == "buscar_trailer" or item.action == "findvideos":
                 context_commands.append(("Buscar Trailer", "XBMC.RunPlugin(%s?%s)" % (sys.argv[0], item.clone(
                     channel="trailertools",
                     action="buscartrailer",


### PR DESCRIPTION
## filtertools
Se encapsula filtertools para que sea menos invasivo y más adaptable a los canales.

- cambio en el modo de mostrar la opción de filtros para hacerlo más simple.
- se carga variable de filtertools para mostrar o no el contexto.
- se mueve el método del contexto a su canal y sea genérico.
- se elimina referencia de platformtools.

## logger

Se modifica logger para permitir llamar a las funciones sin argumento por comodidad, gracias a la modificación de divadr aparecerá el fichero y método desde el que se llama.

```python
def mainlist(channel):
    logger.info()
    logger.info("info")
    logger.debug()
    logger.debug("debug")
    logger.error()
    logger.error("error")
```

> 09:25:45 T:13320  NOTICE: pelisalacarta.channels.renumeratetools.mainlist
> 09:25:45 T:13320  NOTICE: pelisalacarta.channels.renumeratetools [mainlist] info
> 09:25:45 T:13320  NOTICE: ######## DEBUG #########
> 09:25:45 T:13320  NOTICE:     [pelisalacarta.channels.renumeratetools.mainlist]
> 09:25:45 T:13320  NOTICE: ######## DEBUG #########
> 09:25:45 T:13320  NOTICE:     [pelisalacarta.channels.renumeratetools.mainlist] debug
> 09:25:45 T:13320  NOTICE: ######## ERROR #########
> 09:25:45 T:13320  NOTICE:     [pelisalacarta.channels.renumeratetools.mainlist]
> 09:25:45 T:13320  NOTICE: ######## ERROR #########
> 09:25:45 T:13320  NOTICE:     [pelisalacarta.channels.renumeratetools.mainlist] error