### PR TITLE
Forzar el anuncio del magnet para capturar los metadatos al instante

### DIFF
--- a/python/main-classic/platformcode/mct.py
+++ b/python/main-classic/platformcode/mct.py
@@ -154,6 +154,10 @@ def play(url, xlistitem, is_view=None, subtitle=""):
                 dp.close()
                 remove_files( download, torrent_file, video_file, ses, h )
                 return
+
+            h.force_dht_announce()
+            xbmc.sleep(1000)
+
         dp.close()
         info = h.get_torrent_info()
         data = lt.bencode( lt.create_torrent(info).generate() )

--- a/python/main-classic/platformcode/mct.py
+++ b/python/main-classic/platformcode/mct.py
@@ -91,36 +91,25 @@ def play(url, xlistitem, is_view=None, subtitle=""):
 
     ses.add_dht_router("router.bittorrent.com",6881)
     ses.add_dht_router("router.utorrent.com",6881)
-    ses.add_dht_router("router.bitcomet.com",554)
     ses.add_dht_router("dht.transmissionbt.com",6881)
 
     trackers = [
-        "http://exodus.desync.com:6969/announce",
-        "udp://tracker.publicbt.com:80/announce",
         "udp://tracker.openbittorrent.com:80/announce",
         "http://tracker.torrentbay.to:6969/announce",
-        "http://fr33dom.h33t.com:3310/announce",
         "http://tracker.pow7.com/announce",
         "udp://tracker.ccc.de:80/announce",
-        "http://tracker.bittorrent.am:80/announce",
-        "http://denis.stalker.h3q.com:6969/announce",
-        "udp://tracker.prq.to:80/announce",
-        "udp://tracker.istole.it:80/announce",
         "udp://open.demonii.com:1337",
 
         "http://9.rarbg.com:2710/announce",
-        "http://announce.torrentsmd.com:6969/announce",
         "http://bt.careland.com.cn:6969/announce",
         "http://explodie.org:6969/announce",
         "http://mgtracker.org:2710/announce",
         "http://tracker.best-torrents.net:6969/announce",
         "http://tracker.tfile.me/announce",
-        "http://tracker.torrenty.org:6969/announce",
         "http://tracker1.wasabii.com.tw:6969/announce",
         "udp://9.rarbg.com:2710/announce",
         "udp://9.rarbg.me:2710/announce",
         "udp://coppersurfer.tk:6969/announce",
-        "udp://tracker.btzoo.eu:80/announce",
 
         "http://www.spanishtracker.com:2710/announce",
         "http://www.todotorrents.com:2710/announce",


### PR DESCRIPTION
Añadiendo esas 2 líneas al bucle de búsqueda de metadatos del magnet la captura se hace al instante. Sin esas líneas, al menos a mí, me tarda una eternidad según le de (a veces más de 1 minuto)  y supongo que como máximo tardará 15 minutos. En cualquier caso da la impresión de estar bloqueado sin hacer nada.

También he aprovechado y quitado los dominios que no resolvían.

fixes #458 