### PR TITLE
mejora rendimiento logger

### DIFF
--- a/python/main-classic/core/logger.py
+++ b/python/main-classic/core/logger.py
@@ -57,15 +57,15 @@ def encode_log(message=""):
 
 
 def get_caller(message=None):
-    module = inspect.getmodule(inspect.stack()[2][0])
+    module = inspect.getmodule(inspect.currentframe().f_back.f_back)
 
     # En boxee en ocasiones no detecta el modulo, de este modo lo hacemos manual
     if module is None:
-        module = ".".join(os.path.splitext(inspect.stack()[2][1].split("pelisalacarta")[1])[0].split(os.path.sep))[1:]
+        module = ".".join(os.path.splitext(inspect.currentframe().f_back.f_back.f_code.co_filename.split("pelisalacarta")[1])[0].split(os.path.sep))[1:]
     else:
         module = module.__name__
 
-    function = inspect.stack()[2][3]
+    function = inspect.currentframe().f_back.f_back.f_code.co_name
 
     if module == "__main__":
         module = "pelisalacarta"


### PR DESCRIPTION
Tras los últimos cambios, la navegación por pelisalacarta se había vuelto lenta con el debug activado, sobre todo en funciones que hacían mucho uso del logger, tras hablarlo con @superberny70 al principio pensé que era normal ya que se escribían muchas líneas en el log, pero mirándomelo mejor, me di cuenta que el problema se debía al método para detectar el modulo/función desde el que se escribía en el log ya que este penalizaba mucho el rendimiento.

He modificado el método por otro que no penaliza tanto el rendimiento y se obtienen los mismos resultados.