### PR TITLE
Posibilidad (configurable) de usar el título original en las carpetas de la biblioteca

### DIFF
--- a/python/main-classic/channels/biblioteca.xml
+++ b/python/main-classic/channels/biblioteca.xml
@@ -132,5 +132,12 @@
 		<label>Mostrar cuadro de selección de canales</label>
 		<default>false</default>
 	</settings>
-
+	<settings>
+		<id>original_title_folder</id>
+		<type>list</type>
+		<label>Crear directorios en el sistema usando</label>
+		<default>0</default>
+		<lvalues>Título localizado</lvalues>
+		<lvalues>Título original</lvalues>
+	</settings>
 </channel>

--- a/python/main-classic/core/library.py
+++ b/python/main-classic/core/library.py
@@ -279,7 +279,9 @@ def save_library_tvshow(item, episodelist):
         return 0, 0, -1
 
     _id = item.infoLabels['code']
-    if item.infoLabels['title']:
+    if config.get_setting("original_title_folder", "biblioteca") == 1 and item.infoLabels['originaltitle']:
+        base_name = item.infoLabels['originaltitle']
+    elif item.infoLabels['title']:
         base_name = item.infoLabels['title']
     else:
         base_name = item.contentSerieName


### PR DESCRIPTION
En la nueva versión se puso, para intentar evitar problemas con ciertos caracteres, el uso del título localizado en las carpetas de la biblioteca.

Aunque estas carpetas en el uso habitual de un usuario deben de ser invisibles, en mi caso prefiero tener el título original (para cuando entro a ellas por algún motivo: compartir, toquetear cosas o lo que sea), como ocurría antes, por lo que he puesto una opción (que trabaja de la nueva forma por defecto) para poder usar el título localizado o bien el original.