### PR TITLE
Usar python_libtorrent global en vez de la de lib

### DIFF
--- a/python/main-classic/platformcode/mct.py
+++ b/python/main-classic/platformcode/mct.py
@@ -33,7 +33,7 @@ import urllib
 import urllib2
 
 try:
-    from lib.python_libtorrent import get_libtorrent, get_platform
+    from python_libtorrent import get_libtorrent, get_platform
     lt = get_libtorrent()
 except Exception, e:
     import libtorrent as lt


### PR DESCRIPTION
En su día se habló de meter python_libtorrent dentro de lib para no tener
que depender de scripts externos, pero veo que todavía no está metida.

Supongo que la llamada a lib.python_libtorrent es un error por lo menos
hasta que se meta libtorrent dentro de lib.

Llamando a python_libtorrent provista por script.module.libtorrent funciona
como siempre