### PR TITLE
Bug al añadir series cuando item.extra no es un str

### DIFF
--- a/python/main-classic/core/library.py
+++ b/python/main-classic/core/library.py
@@ -596,7 +596,7 @@ def add_serie_to_library(item, channel=None):
     else:
         # Esta marca es porque el item tiene algo más aparte en el atributo "extra"
         item.action = item.extra
-        if "###" in item.extra:
+        if isinstance(item.extra, str) and "###" in item.extra:
             item.action = item.extra.split("###")[0]
             item.extra = item.extra.split("###")[1]
 


### PR DESCRIPTION
A raiz de [este ](http://www.mimediacenter.info/foro/viewtopic.php?f=14&t=8202&hilit=+if+isinstance+item.extra%2C+str+%23%23%23+in+item.extra&p=37093#p37028)mensaje del foro y de la PR #496