### PR TITLE
Corregida función añadir/actualizar canales

### DIFF
--- a/python/main-classic/channels/configuracion.py
+++ b/python/main-classic/channels/configuracion.py
@@ -268,7 +268,7 @@ def addchannel(item):
             overwrite_all = False
         from core import downloadtools
         for url, localfilename, filename in files:
-            result = downloadtools.downloadfile(url, localfilename, continuar=False)
+            result = downloadtools.downloadfile(url, localfilename, continuar=False, resumir=False)
             if result == -3:
                 if len(files) == 1:
                     dyesno = platformtools.dialog_yesno("El archivo ya existe", "Ya existe el %s %s. "
@@ -293,7 +293,7 @@ def addchannel(item):
                         os.makedirs(backup)
                     import shutil
                     shutil.copy2(localfilename, filetools.join(backup, filename))
-                    downloadtools.downloadfile(url, localfilename, continuar=True)
+                    downloadtools.downloadfile(url, localfilename, continuar=True, resumir=False)
                 else:
                     if len(files) == 1:
                         return

--- a/python/main-classic/core/downloadtools.py
+++ b/python/main-classic/core/downloadtools.py
@@ -564,7 +564,6 @@ def downloadfile(url, nombrefichero, headers=None, silent=False, continuar=False
                 f.seek(exist_size)
             else:
                 exist_size = 0
-                f = open(nombrefichero, 'wb')
                 grabado = 0
 
         # el fichero ya existe y no se quiere continuar, se aborta

--- a/python/main-classic/core/downloadtools.py
+++ b/python/main-classic/core/downloadtools.py
@@ -523,7 +523,7 @@ def downloadbest(video_urls, title, continuar=False):
     return -2
 
 
-def downloadfile(url, nombrefichero, headers=None, silent=False, continuar=False):
+def downloadfile(url, nombrefichero, headers=None, silent=False, continuar=False, resumir=True):
     logger.info("pelisalacarta.core.downloadtools downloadfile: url=" + url)
     logger.info("pelisalacarta.core.downloadtools downloadfile: nombrefichero=" + nombrefichero)
 
@@ -557,11 +557,15 @@ def downloadfile(url, nombrefichero, headers=None, silent=False, continuar=False
             #    existSize = f.size(nombrefichero)
             # except:
             f = open(nombrefichero, 'r+b')
-            exist_size = os.path.getsize(nombrefichero)
-
-            logger.info("pelisalacarta.core.downloadtools downloadfile: el fichero existe, size=%d" % exist_size)
-            grabado = exist_size
-            f.seek(exist_size)
+            if resumir:
+                exist_size = os.path.getsize(nombrefichero)
+                logger.info("pelisalacarta.core.downloadtools downloadfile: el fichero existe, size=%d" % exist_size)
+                grabado = exist_size
+                f.seek(exist_size)
+            else:
+                exist_size = 0
+                f = open(nombrefichero, 'wb')
+                grabado = 0
 
         # el fichero ya existe y no se quiere continuar, se aborta
         elif os.path.exists(nombrefichero) and not continuar:


### PR DESCRIPTION
En el caso de que el archivo exista en lugar de sobrescribirlo añadía el nuevo contenido al final del archivo existente, para corregir eso se añade un nuevo parámetro a downloadtools.downloadfile para que en caso de existir el archivo y querer sobreescribirlo, se haga por completo en lugar de añadirse al final del archivo como ocurría. Por defecto se mantiene tal y como estaba y se resume el archivo si no se indica nada.