### PR TITLE
Arregla fallo de monitor.abortRequested() en Frodo

### DIFF
--- a/python/main-classic/library_service.py
+++ b/python/main-classic/library_service.py
@@ -330,9 +330,11 @@ if __name__ == "__main__":
 
     # Se ejecuta ciclicamente
     import xbmc
-    try:
+    version_xbmc = int(xbmc.getInfoLabel("System.BuildVersion").split(".", 1)[0])
+
+    if version_xbmc >= 14:
         monitor = xbmc.Monitor()  # For Kodi >= 14
-    except:
+    else:
         monitor = None  # For Kodi < 14
 
     if monitor:


### PR DESCRIPTION
En la última v4.2.0~beta2 la selección de versión de Kodi que hace con `monitor=xbmc.Monitor()` devuelve una función válida en Frodo (12.3), que luego falla en `monitor.abortRequested()`

Este otro método para seleccionar la versión parece más robusto:
`version_xbmc = int(xbmc.getInfoLabel("System.BuildVersion").split(".", 1)[0])`