### PR TITLE
Reparado hdfull y fallo de autorizacion cloudflare en httptools

### DIFF
--- a/python/main-classic/channels/hdfull.xml
+++ b/python/main-classic/channels/hdfull.xml
@@ -12,9 +12,9 @@
 	<bannermenu>http://media.tvalacarta.info/pelisalacarta/bannermenu/hdfull.png</bannermenu>
 
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/channels/</update_url>
-	<version>6</version>
-	<date>05/08/2016</date>
-	<changes>Arreglada búsqueda global</changes>
+	<version>7</version>
+	<date>05/01/2017</date>
+	<changes>Corregido debido a cloudflare</changes>
 
 
 	<categories>

--- a/python/main-classic/core/httptools.py
+++ b/python/main-classic/core/httptools.py
@@ -226,7 +226,7 @@ def downloadpage(url, post=None, headers=None, timeout=None, follow_redirects=Tr
         logger.info("cloudflare detectado, esperando %s segundos..." % wait_time)
         time.sleep(wait_time)
         logger.info("Autorizando... url: %s" % auth_url)
-        if downloadpage(auth_url, headers=headers).sucess:
+        if downloadpage(auth_url, headers=headers, replace_headers=replace_headers).sucess:
             logger.info("Autorización correcta, descargando página")
             resp = downloadpage(url=url, post=post, headers=headers, timeout=timeout, follow_redirects=follow_redirects,
                                 cookies=cookies, replace_headers=replace_headers, add_referer=add_referer)


### PR DESCRIPTION
Mientras intentaba reparar el canal hdfull que ahora utiliza cloudflare mediante la librería httptools (la cual me encanta, funciona genial y con scrapertools cloudflare suele fallarme), me he dado cuenta de que no terminaba de autorizar la url de cloudflare debido a que al no reemplazar las headers, se unían las headers por defecto y las del parámetro headers, dando error porque deben ser las mismas en todas las llamadas.

Pongo el log de ejemplo para que se vea más claro: http://pastebin.com/S78XFbwF