### PR TITLE
Usar la última búsqueda para evitar la repetición de pregunta en Kodi 17

### DIFF
--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -251,16 +251,25 @@ def run():
             elif item.action == "search":
                 logger.info("pelisalacarta.platformcode.launcher search")
 
-                last_search = ""
                 last_search_active = config.get_setting("last_search", "buscador")
-                if last_search_active:
-                    try:
-                        current_saved_searches_list = list(config.get_setting("saved_searches_list", "buscador"))
-                        last_search = current_saved_searches_list[0]
-                    except:
-                        pass
+                tecleado = None
 
-                tecleado = platformtools.dialog_input(last_search)
+                if config.get_setting("reuse_search_active") == "true":
+                    tecleado = config.get_setting("reuse_search_text")
+                else:
+                    last_search = ""
+                    if last_search_active:
+                        try:
+                            current_saved_searches_list = list(config.get_setting("saved_searches_list", "buscador"))
+                            last_search = current_saved_searches_list[0]
+                        except:
+                            pass
+
+                    tecleado = platformtools.dialog_input(last_search)
+                    config.set_setting("reuse_search_active", "true")
+                    if not tecleado is None:
+                        config.set_setting("reuse_search_text", tecleado)
+
                 if tecleado is not None:
                     if last_search_active:
                         from channels import buscador
@@ -277,6 +286,11 @@ def run():
             else:
                 logger.info("pelisalacarta.platformcode.launcher executing channel '"+item.action+"' method")
                 itemlist = getattr(channel, item.action)(item)
+                if itemlist:
+                    for item in itemlist:
+                        if item.action == "search":
+                            config.set_setting("reuse_search_active", "false")
+                            break
                 platformtools.render_items(itemlist, item)
 
     except urllib2.URLError, e:

--- a/python/main-classic/resources/settings.xml
+++ b/python/main-classic/resources/settings.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
+    <setting id="reuse_search_active" type="bool" default="false" />
+    <setting id="reuse_search_text" type="text" default="" />
+
     <category label="General">
         <setting id="player_type" type="enum" values="Auto|MPlayer|DVDPlayer" label="30000" default="2"/>
         <setting id="player_mode" type="enum" values="Direct|SetResolvedUrl|Built-In|Download and Play" label="30044" default="0"/>


### PR DESCRIPTION
Al hacer:
canal --> Buscar -[se abre teclado]-> introducir texto --> Darle a un resultado

Si ahora en este punto en Kodi 16 vamos hacia atrás salen los últimos resultados (al menos en la mayoría de dispositivos, hay quejas de que se produce lo que intenta evitar este PR también en Kodi 16 según el dispositivo) y si le das hacia atrás vas al main del canal. Si le vuelves a dar a buscar sale el teclado de nuevo.

En Kodi 17 se ha eliminado la cache, o eso parece, por lo que al darle hacia atrás aparece de nuevo el teclado, lo que es muy incómodo.

En este PR lo que hago es guardar la última búsqueda (independientemente del sistema de guardar última búsqueda que se muestra en el teclado). Se trackean los elementos retornados por las diferentes acciones en búsqueda de elementos con "item.action == 'search'" para desactivar la reutilización automática de esta búsqueda.

Este PR es una variación del cerrado: https://github.com/tvalacarta/pelisalacarta/pull/531