### PR TITLE
Compatibilidad

### DIFF
--- a/python/main-classic/core/filetools.py
+++ b/python/main-classic/core/filetools.py
@@ -32,7 +32,11 @@ import traceback
 from core import logger
 from core import scrapertools
 from platformcode import platformtools
-from lib.sambatools import libsmb as samba
+try:
+  from lib.sambatools import libsmb as samba
+except:
+  samba = None
+  #Python 2.4 No compatible con modulo samba, hay que revisar
 
 #Windows es "mbcs" linux, osx, android es "utf8"
 if os.name == "nt":

--- a/python/main-classic/core/httptools.py
+++ b/python/main-classic/core/httptools.py
@@ -175,8 +175,13 @@ def downloadpage(url, post=None, headers=None, timeout=None, follow_redirects=Tr
 
     except Exception, e:
         response["sucess"] = False
-        response["code"] = e.errno
-        response["error"] = e.reason
+        if "errno" in e:
+          response["code"] = e.errno
+          response["error"] = e.reason
+        else:
+          response["code"] = e.reason[0][0]
+          response["error"] = e.reason[0][1]
+        
         response["headers"] = {}
         response["data"] = ""
         response["time"] = time.time() - inicio


### PR DESCRIPTION
Se han corregido dos problemas de compatibilidad con Python 2.4:

1. El modulo samba no es compatible con Python 2.4 (hay que revisarlo) de modo que pongo el inport en filetools mediante un try para que por lo menos siga funcionando en local.
2. httptols, corregido el método para obtener el código de error en caso de no poder acceder a la pagina web, ya que al parecer este cambia en Python 2.4