### PR TITLE
[Plex] - Fix para mostrar caracteres con tildes en los titulos

### DIFF
--- a/python/version-plex/Code/__init__.py
+++ b/python/version-plex/Code/__init__.py
@@ -155,10 +155,6 @@ def canal(channel_name="",action="",caller_item_serialized=None, itemlist=""):
                 Log.Info("item="+unicode( item.tostring(), "utf-8" , errors="replace" ))
             except:
                 pass
-            try:
-                item.title = unicode( item.title, "utf-8" , errors="replace" )
-            except:
-                pass
             
             if action!="play":
                 #if "type" in item and item.type == "input":
@@ -171,7 +167,7 @@ def canal(channel_name="",action="",caller_item_serialized=None, itemlist=""):
                         
                     if Client.Product in DumbKeyboard.clients:
                         DumbKeyboard("/video/pelisalacarta", oc, get_input,
-                                dktitle = item.title,
+                                dktitle = unicode( item.title, "utf-8" , errors="replace" ),
                                 dkitem = item,
                                 dkplaceholder = value,
                                 dkthumb = item.thumbnail
@@ -180,15 +176,15 @@ def canal(channel_name="",action="",caller_item_serialized=None, itemlist=""):
                         dkitem = item.tourl()
                         oc.add(InputDirectoryObject(
                                 key    = Callback(get_input, dkitem = dkitem),
-                                title  = item.title,
+                                title  = unicode( item.title, "utf-8" , errors="replace" ),
                                 prompt = value,
                                 thumb = item.thumbnail
                             ))
                 else:
-                    oc.add(DirectoryObject(key=Callback(canal, channel_name=item.channel, action=item.action, caller_item_serialized=item.tourl()), title=item.title, thumb=item.thumbnail))
+                    oc.add(DirectoryObject(key=Callback(canal, channel_name=item.channel, action=item.action, caller_item_serialized=item.tourl()), title=unicode( item.title, "utf-8" , errors="replace" ), thumb=item.thumbnail))
             else:
                 Log.Info("Llamando a la funcion play comun")
-                videoClipObject = VideoClipObject(title=item.title,thumb=item.thumbnail, url="pelisalacarta://"+item.url )
+                videoClipObject = VideoClipObject(title=unicode( item.title, "utf-8" , errors="replace" ),thumb=item.thumbnail, url="pelisalacarta://"+item.url )
                 oc.add(videoClipObject)
 
     except:


### PR DESCRIPTION
Como esta comentado en #549 en plex no se mostraban correctamente los caracteres con tildes ya que para plex hay que pasar los títulos en Unicode, el ítem tal como está echo ahora no permite usar otra codificación que no sea "UTF8" y se convierte automáticamente si se intenta usar otra, de ahí que en plex se hacia `item.title = unicode( item.title, "utf-8" , errors="replace" )` pero este se volvía a pasar a utf8 automáticamente, he modificado el __init__.py de plex para solucionar eso.