### PR TITLE
Permitir varias calidades cuando se ejecuta "play" desde canal

### DIFF
--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -195,10 +195,15 @@ def run():
                     itemlist = channel.play(item)
                     b_favourite = item.isFavourite
                     # Play should return a list of playable URLS
-                    if len(itemlist) > 0:
+                    if len(itemlist) > 0 and isinstance(itemlist[0], Item):
                         item = itemlist[0]
                         if b_favourite:
                             item.isFavourite = True
+                        platformtools.play_video(item)
+                    
+                    #Permitir varias calidades desde play en el canal
+                    elif len(itemlist) > 0 and isinstance(itemlist[0], list):
+                        item.video_urls = itemlist
                         platformtools.play_video(item)
 
                     # If not, shows user an error message

--- a/python/main-classic/platformcode/platformtools.py
+++ b/python/main-classic/platformcode/platformtools.py
@@ -677,8 +677,12 @@ def get_dialogo_opciones(item, default_action, strm):
     muestra_dialogo = (config.get_setting("player_mode") == "0" and not strm)
 
     # Extrae las URL de los vídeos, y si no puedes verlo te dice el motivo
-    video_urls, puedes, motivo = servertools.resolve_video_urls_for_playing(
-        item.server, item.url, item.password, muestra_dialogo)
+    #Permitir varias calidades para server "directo"
+    if item.video_urls:
+      video_urls, puedes, motivo = item.video_urls, True, ""
+    else:
+      video_urls, puedes, motivo = servertools.resolve_video_urls_for_playing(
+          item.server, item.url, item.password, muestra_dialogo)
 
     seleccion = 0
     # Si puedes ver el vídeo, presenta las opciones

--- a/python/version-mediaserver/platformcode/launcher.py
+++ b/python/version-mediaserver/platformcode/launcher.py
@@ -79,8 +79,15 @@ def run(item):
       if hasattr(channelmodule, 'play'):
           logger.info("pelisalacarta.platformcode.launcher executing channel 'play' method")
           itemlist = channelmodule.play(item)
-          if len(itemlist)>0:
-              play_menu(itemlist)
+          b_favourite = item.isFavourite
+          if len(itemlist)>0 and isinstance(itemlist[0], Item):
+              item = itemlist[0]
+              if b_favourite:
+                  item.isFavourite = True
+              play_menu(item)
+          elif len(itemlist)>0 and isinstance(itemlist[0], list):
+              item.video_urls = itemlist
+              play_menu(item)
           else:
               platformtools.dialog_ok("plugin", "No hay nada para reproducir")
       else:
@@ -550,30 +557,12 @@ def check_video_options(item, video_urls):
 #play_menu, abre el menu con las opciones para reproducir
 def play_menu(item):
 
-    if type(item) ==list and len(item)==1:
-      item = item[0]
-      
-    #Modo Normal
-    if type(item) == Item: 
-      if item.server=="": item.server="directo"
-      video_urls,puedes,motivo = servertools.resolve_video_urls_for_playing(item.server,item.url,item.password,True)
-      
-    #Modo "Play" en canal, puede devolver varias url
-    elif type(item) ==list and len(item)>1:
+    if item.server=="": item.server="directo"
     
-      itemlist = item     #En este caso en el argumento item, en realidad hay un itemlist
-      item = itemlist[0]  #Se asigna al item, el item primero del itemlist
-      
-      video_urls = []
-      for videoitem in itemlist:
-        if videoitem.server=="": videoitem.server="directo"
-        opcion_urls,puedes,motivo = servertools.resolve_video_urls_for_playing(videoitem.server,videoitem.url)
-        opcion_urls[0][0] = opcion_urls[0][0] + " [" + videoitem.fulltitle + "]"
-        video_urls.extend(opcion_urls)
-      item = itemlist[0]
-      puedes = True
-      motivo = ""
-      
+    if item.video_urls:
+      video_urls,puedes,motivo = item.video_urls, True, ""
+    else:
+      video_urls,puedes,motivo = servertools.resolve_video_urls_for_playing(item.server,item.url,item.password,True)
       
     if not "strmfile" in item: item.strmfile=False   
     #TODO: unificar show y Serie ya que se usan indistintamente.

--- a/python/version-plex/Code/__init__.py
+++ b/python/version-plex/Code/__init__.py
@@ -131,8 +131,11 @@ def canal(channel_name="",action="",caller_item_serialized=None, itemlist=""):
             
             itemlist = getattr(channelmodule, action)(caller_item)
 
-            if action=="play" and len(itemlist)>0:
+            if action=="play" and len(itemlist)>0 and isinstance(itemlist[0], Item):
                 itemlist=play_video(itemlist[0])
+            if action=="play" and len(itemlist)>0 and isinstance(itemlist[0], list):
+                item.video_urls = itemlist
+                itemlist=play_video(item)
 
         else:
             Log.Info("El módulo "+caller_item.channel+" *NO* tiene una funcion "+action)
@@ -198,7 +201,11 @@ def resuelve(url):
     return Redirect(url)
 
 def play_video(item):
-    video_urls = servertools.get_video_urls(item.server,item.url)
+    if item.video_urls:
+      video_urls = item.video_urls
+    else:
+      video_urls = servertools.get_video_urls(item.server,item.url)
+      
     itemlist = []
     for video_url in video_urls:
         itemlist.append( Item(channel=item.channel, action="play" , title="Ver el video "+video_url[0] , url=video_url[1], thumbnail=item.thumbnail, plot=item.plot, server=""))


### PR DESCRIPTION
Hasta ahora cuando un canal tenia la función play dentro del canal, esta función devolvía un itemlist, pero solo se utilizaba el primer ítem para pasarlo a reproducir, para canales que tienen la función play en el canal, pero el server del video no es "directo" el server ya se encarga de buscar las diferentes calidades para ese enlace si existen, pero cuando es un enlace directo al vídeo, no hay posibilidad de pasar varias urls para varias calidades si el canal los soporta, de modo que esta modificación lo que hace es:

 - Si el primer resultado de la función play es un "ítem" sigue funcionando como siempre
 - Si el primer resultado de la función play es un "list" lo añade al ítem como ítem.video_urls
 - en platformtools si  el ítem tiene el parámetro video_urls coge estas en vez de pasar por el servertools de modo que muestra las diferentes calidades
 - El formato que ha de devolver la función play es el mismo que en los servers: un listado con `["Descripción", "url"]`