### PR TITLE
Actualizado animeflv.me

### DIFF
--- a/python/main-classic/channels/animeflv_me.xml
+++ b/python/main-classic/channels/animeflv_me.xml
@@ -12,9 +12,18 @@
 	<bannermenu>http://i.imgur.com/dTZwCPq.png</bannermenu>
 
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/channels/</update_url>
-	<version>10</version>
+	<version>11</version>
 	
     <changes>
+		<change>
+			<date>05/01/2017</date>
+			<autor>GinSakata</autor>
+			<description>
+				Actualizada url de la opción Novedades
+				Arreglado un error que impedia que se mostrara un solo resultado al realizar busquedas
+				Limpieza de código
+			</description>
+		</change>
 		<change>
 			<date>01/07/2016</date>
 			<autor>SeiTaN</autor>


### PR DESCRIPTION
Actualizado el canal Animeflv.me:

- Limpieza de código
- Arreglado un problema que hacia que al realizar búsquedas y estas devolvieran un solo resultado, se mostrara una lista vacía.
- Modificada la url de la opción Novedades de http://animeflv.me/ListadeAnime/LatestUpdate a http://animeflv.me/ListadeAnime/Nuevo.
- Se elimino una petición innecesaria para obtener las páginas de búsqueda por orden alfabético.
- Se paso a usar httptools.
- Soluciona el error al no encontrar vídeos debido a un cambio en el dominio (api.animeflv.me -> player.animeflv.me) que se realizo hace unas horas.
- Se agrego renumbertools al menú contextual en las búsquedas.