### PR TITLE
Revert "Trackt itemlist elements for "search" action item"

### DIFF
--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -256,25 +256,16 @@ def run():
             elif item.action == "search":
                 logger.info("pelisalacarta.platformcode.launcher search")
 
+                last_search = ""
                 last_search_active = config.get_setting("last_search", "buscador")
-                tecleado = None
+                if last_search_active:
+                    try:
+                        current_saved_searches_list = list(config.get_setting("saved_searches_list", "buscador"))
+                        last_search = current_saved_searches_list[0]
+                    except:
+                        pass
 
-                if config.get_setting("reuse_search_active") == "true":
-                    tecleado = config.get_setting("reuse_search_text")
-                else:
-                    last_search = ""
-                    if last_search_active:
-                        try:
-                            current_saved_searches_list = list(config.get_setting("saved_searches_list", "buscador"))
-                            last_search = current_saved_searches_list[0]
-                        except:
-                            pass
-
-                    tecleado = platformtools.dialog_input(last_search)
-                    config.set_setting("reuse_search_active", "true")
-                    if not tecleado is None:
-                        config.set_setting("reuse_search_text", tecleado)
-
+                tecleado = platformtools.dialog_input(last_search)
                 if tecleado is not None:
                     if last_search_active:
                         from channels import buscador
@@ -291,11 +282,6 @@ def run():
             else:
                 logger.info("pelisalacarta.platformcode.launcher executing channel '"+item.action+"' method")
                 itemlist = getattr(channel, item.action)(item)
-                if itemlist:
-                    for item in itemlist:
-                        if item.action == "search":
-                            config.set_setting("reuse_search_active", "false")
-                            break
                 platformtools.render_items(itemlist, item)
 
     except urllib2.URLError, e:

--- a/python/main-classic/resources/settings.xml
+++ b/python/main-classic/resources/settings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-    <setting id="reuse_search_active" type="bool" default="false" />
-    <setting id="reuse_search_text" type="text" default="" />
-
     <category label="General">
         <setting id="player_type" type="enum" values="Auto|MPlayer|DVDPlayer" label="30000" default="2"/>
         <setting id="player_mode" type="enum" values="Direct|SetResolvedUrl|Built-In|Download and Play" label="30044" default="0"/>


### PR DESCRIPTION
This reverts commit cd507e6cb1da750b70e173fa6ecf275501ab78e3.

Pull request #548

Como parece que recuperan la cache en Kodi 17 hago un revert de la funcionalidad, que además da algunos ligeros problemas en Kodis con cache (< 17).

Concretamente al darle hacia atrás, como no carga de nuevo los items, no se desactiva el elemento buscado. Es decir, da problemas en Kodi's con caches. Como parece que la han recuperado, lo revierto para que se comporte como siempre.