### PR TITLE
Quitar elemento de "Sin resultados" en algunos canales

### DIFF
--- a/python/main-classic/channels/peliculasdk.py
+++ b/python/main-classic/channels/peliculasdk.py
@@ -108,8 +108,6 @@ def buscador(item):
 
     matches = re.compile(patron,re.DOTALL).findall(data)
     scrapertools.printMatches(matches)
-    if len(matches)==0 :
-        itemlist.append( Item(channel=item.channel, title=bbcode_kodi2html("[COLOR gold][B]Sin resultados...[/B][/COLOR]"), thumbnail ="http://s6.postimg.org/t8gfes7rl/pdknoisethumb.png", fanart ="http://s6.postimg.org/oy1rj72oh/pdknoisefan.jpg",folder=False) )
 
     for scrapedthumbnail,scrapedurl, scrapedtitle,  scrapedlenguaje, scrapedgenero, scrapedcalidad in matches:
         try:

--- a/python/main-classic/channels/txibitsoft.py
+++ b/python/main-classic/channels/txibitsoft.py
@@ -93,10 +93,6 @@ def buscador(item):
     
     matches = re.compile(patron,re.DOTALL).findall(data)
     scrapertools.printMatches(matches)
-    if len(matches)==0 :
-       itemlist.append( Item(channel=item.channel, title="[COLOR gold][B]No se ha encontrado nada en la busqueda...[/B][/COLOR]", thumbnail ="http://s6.postimg.org/vhczf38ep/oops.png", fanart ="http://s12.postimg.org/59o1c792l/oopstxibi.jpg",folder=False) )
-
-
     
     for scrapedurl, scrapedtitle, scrapedthumbnail, scrapedlenguage, scrapedsize in matches:
         title_fan= re.sub(r"\[.*?\]|\(.*?\)|\d+x\d+.*?Final|\d\d\d\d|-\d+|-|\d+x\d+|Temporada.*?Completa| ;","",scrapedtitle)

--- a/python/main-classic/channels/zentorrents.py
+++ b/python/main-classic/channels/zentorrents.py
@@ -90,10 +90,6 @@ def buscador(item):
 
     matches = re.compile(patron, re.DOTALL).findall(data)
     scrapertools.printMatches(matches)
-    if len(matches) == 0:
-        itemlist.append(Item(channel=item.channel, title="[COLOR gold][B]Sin resultados...[/B][/COLOR]",
-                             thumbnail="http://s6.postimg.org/55zljwr4h/sinnoisethumb.png",
-                             fanart="http://s6.postimg.org/avfu47xap/sinnoisefan.jpg", folder=False))
 
     for scrapedtitulo, scrapedurl, scrapedthumbnail, scrapedplot in matches:
         # evitamos falsos positivos en los enlaces, ya que el buscador de la web muestra de todo,


### PR DESCRIPTION
Hay canales (los que indico) que retornan un item de "No hay resultados".

Se pueden ver fácilmente buscando "slkfjs" (por ejemplo) y ahí los tendréis.

Simplemente he cambiado los canales para que no añadan ese elemento fake y se comporten como los demás: retornen listas vacías.