### PR TITLE
[libtorrent client] Usar el directorio de "downloads"

### DIFF
--- a/python/main-classic/platformcode/platformtools.py
+++ b/python/main-classic/platformcode/platformtools.py
@@ -973,7 +973,7 @@ def play_torrent(item, xlistitem, mediaurl):
 
         # Iniciamos el cliente:
         c = Client(url=mediaurl, is_playing_fnc=xbmc.Player().isPlaying, wait_time=None, timeout=10,
-                   temp_path=os.path.join(config.get_data_path(), "torrent"), print_status=debug)
+                   temp_path=os.path.join(config.get_setting("downloadpath"), "torrent"), print_status=debug)
 
         # Mostramos el progreso
         progreso = dialog_progress("Pelisalacarta - Torrent", "Iniciando...")

--- a/python/main-classic/platformcode/platformtools.py
+++ b/python/main-classic/platformcode/platformtools.py
@@ -971,9 +971,13 @@ def play_torrent(item, xlistitem, mediaurl):
         # Importamos el cliente
         from btserver import Client
 
+        clientTmpPath = config.get_setting("downloadpath")
+        if not clientTmpPath:
+            clientTmpPath = config.get_data_path()
+
         # Iniciamos el cliente:
         c = Client(url=mediaurl, is_playing_fnc=xbmc.Player().isPlaying, wait_time=None, timeout=10,
-                   temp_path=os.path.join(config.get_setting("downloadpath"), "torrent"), print_status=debug)
+                   temp_path=os.path.join(clientTmpPath, "torrent"), print_status=debug)
 
         # Mostramos el progreso
         progreso = dialog_progress("Pelisalacarta - Torrent", "Iniciando...")

--- a/python/main-classic/platformcode/platformtools.py
+++ b/python/main-classic/platformcode/platformtools.py
@@ -977,7 +977,7 @@ def play_torrent(item, xlistitem, mediaurl):
 
         # Iniciamos el cliente:
         c = Client(url=mediaurl, is_playing_fnc=xbmc.Player().isPlaying, wait_time=None, timeout=10,
-                   temp_path=os.path.join(clientTmpPath, "torrent"), print_status=debug)
+                   temp_path=os.path.join(clientTmpPath, "pelisalacarta-torrent"), print_status=debug)
 
         # Mostramos el progreso
         progreso = dialog_progress("Pelisalacarta - Torrent", "Iniciando...")


### PR DESCRIPTION
Ya que actualmente va simplemente a "get_data()" lo cual no me parece correcto. Debería estar en el downloads (o otro individual para los torrents) para poder llevarlo a otros sitios con más espacio (o donde nos de la gana).

Creo que el otro cliente interno (que me peta) ya usa este directorio.