### PR TITLE
Fix logger en plex cuando no recibe texto

### DIFF
--- a/python/version-plex/core/logger.py
+++ b/python/version-plex/core/logger.py
@@ -6,19 +6,19 @@
 #------------------------------------------------------------
 import bridge
 
-def info(texto):
+def info(texto=""):
     try:
         bridge.log_info( texto )
     except:
         pass
     
-def debug(texto):
+def debug(texto=""):
     try:
         bridge.log_info( texto )
     except:
         pass
 
-def error(texto):
+def error(texto=""):
     try:
         bridge.log_info( texto )
     except:


### PR DESCRIPTION
El logger de la versión Kodi acepta llamar a sus métodos sin recibir ningún argumento, pero en plex es necesario pasarle uno, por lo que se producen errores.