### PR TITLE
[novedades] Añadir cuadro de progreso

### DIFF
--- a/python/main-classic/channels/cineasiaenlinea.py
+++ b/python/main-classic/channels/cineasiaenlinea.py
@@ -81,6 +81,7 @@ def newest(categoria):
     try:
         if categoria == 'peliculas':
             item.url = host+"archivos/peliculas"
+            item.action = "peliculas"
             itemlist = peliculas(item)
 
             if itemlist[-1].action == "peliculas":

--- a/python/main-classic/channels/cineasiaenlinea.xml
+++ b/python/main-classic/channels/cineasiaenlinea.xml
@@ -12,9 +12,20 @@
 	<bannermenu>http://i.imgur.com/k72CZD7.png?1</bannermenu>
 
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/channels/</update_url>
-	<version>1</version>
-	<date>09/01/2017</date>
-	<changes>Primera version</changes>
+	<version>2</version>
+
+	<changes>
+		<change>
+			<date>07/02/17</date>
+			<autor>super_berny</autor>
+			<description>Fix bug in newest</description>
+		</change>
+		<change>
+			<date>09/01/2017</date>
+			<autor>Cmos</autor>
+			<description>Primera version</description>
+		</change>
+	</changes>
 
 	<categories>
 		<category>movie</category>

--- a/python/main-classic/channels/clasicofilm.py
+++ b/python/main-classic/channels/clasicofilm.py
@@ -84,6 +84,7 @@ def newest(categoria):
     try:
         if categoria == 'peliculas':
             item.url = "http://www.clasicofilm.com/feeds/posts/summary?start-index=1&max-results=20&alt=json-in-script&callback=finddatepost"
+            item.action = "peliculas"
             itemlist = peliculas(item)
 
             if itemlist[-1].action == "peliculas":

--- a/python/main-classic/channels/clasicofilm.xml
+++ b/python/main-classic/channels/clasicofilm.xml
@@ -12,9 +12,20 @@
 	<bannermenu></bannermenu>
 
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/channels/</update_url>
-	<version>1</version>
-	<date>09/01/2017</date>
-	<changes>Primera version</changes>
+	<version>2</version>
+
+	<changes>
+		<change>
+			<date>07/02/17</date>
+			<autor>super_berny</autor>
+			<description>Fix bug in newest</description>
+		</change>
+		<change>
+			<date>09/01/2017</date>
+			<autor>Cmos</autor>
+			<description>Primera version</description>
+		</change>
+	</changes>
 
 	<categories>
 		<category>movie</category>

--- a/python/main-classic/channels/divxatope.py
+++ b/python/main-classic/channels/divxatope.py
@@ -173,7 +173,7 @@ def lista(item):
             itemlist.append( Item(channel=item.channel, action="episodios", title=title , fulltitle = title, url=url ,
                                   thumbnail=thumbnail , plot=plot , folder=True, hasContentDetails="true",
                                   contentTitle=contentTitle, language=idioma, contentSeason=int(temporada),
-                                  contentEpisodeNumber=int(episodio), contentCalidad=calidad))
+                                  contentEpisodeNumber=int(episodio), contentQuality=calidad))
 
         else:
             if len(matches) == 2:
@@ -183,7 +183,7 @@ def lista(item):
             itemlist.append( Item(channel=item.channel, action="findvideos", title=title , fulltitle = title, url=url ,
                                   thumbnail=thumbnail , plot=plot , folder=True, hasContentDetails="true",
                                   contentTitle=contentTitle, language=idioma, contentThumbnail=thumbnail,
-                                  contentCalidad=calidad))
+                                  contentQuality=calidad))
 
     next_page_url = scrapertools.find_single_match(data1,'<li><a href="([^"]+)">Next</a></li>')
     if next_page_url!="":

--- a/python/main-classic/channels/novedades.py
+++ b/python/main-classic/channels/novedades.py
@@ -38,12 +38,21 @@ from core import logger
 from core.item import Item
 from platformcode import platformtools
 
-DEBUG = config.get_setting("debug")
 THUMBNAILS = {'0': 'posters', '1': 'banners', '2': 'squares'}
 
-color1, color2 = ['0xFF0B7B92','0xFFACD5D4']
+__perfil__= int(config.get_setting('perfil',"novedades"))
+
+# Fijar perfil de color
+perfil = [['0xFF0B7B92', '0xFF89FDFB', '0xFFACD5D4'],
+          ['0xFFB31313', '0xFFFF9000', '0xFFFFEE82'],
+          ['0xFF891180', '0xFFCB22D7', '0xFFEEA1EB'],
+          ['0xFFA5DEE5', '0xFFE0F9B5', '0xFFFEFDCA'],
+          ['0xFFF23557', '0xFF22B2DA', '0xFFF0D43A']]
+
+color1, color2, color3 = perfil[__perfil__]
 
 list_newest =[]
+channels_ID_name = {}
 
 def mainlist(item,thumbnail_type="squares"):
     logger.info()
@@ -131,8 +140,8 @@ def get_list_canales():
 
     for infile in sorted(glob.glob(channels_path)):
         list_result_canal = []
-        channel_name = os.path.basename(infile)[:-4]
-        channel_parameters = channeltools.get_channel_parameters(channel_name)
+        channel_id = os.path.basename(infile)[:-4]
+        channel_parameters = channeltools.get_channel_parameters(channel_id)
 
         # No incluir si es un canal inactivo
         if channel_parameters["active"] != "true":
@@ -148,9 +157,10 @@ def get_list_canales():
 
         # Incluir en cada categoria, si en su configuracion el canal esta activado para mostrar novedades
         for categoria in list_canales:
-            include_in_newest = config.get_setting("include_in_newest_" + categoria, channel_name)
+            include_in_newest = config.get_setting("include_in_newest_" + categoria, channel_id)
             if include_in_newest:
-                list_canales[categoria].append(channel_name)
+                channels_ID_name[channel_id] = channel_parameters["title"]
+                list_canales[categoria].append((channel_id,channel_parameters["title"]))
 
     return list_canales
 
@@ -178,20 +188,21 @@ def novedades(item):
     list_canales = get_list_canales()
     number_of_channels = len(list_canales[item.extra])
 
-    for index, channel_name in enumerate(list_canales[item.extra]):
+    for index, channel in enumerate(list_canales[item.extra]):
+        channel_id, channel_title = channel
         percentage = index * 100 / number_of_channels
         # Modo Multi Thread
         if multithread:
-            t = Thread(target=get_newest, args=[channel_name, item.extra], name=channel_name.capitalize())
+            t = Thread(target=get_newest, args=[channel_id, item.extra], name=channel_title)
             t.start()
             l_hilo.append(t)
-            progreso.update(percentage/2, "Buscando en '%s'..." % channel_name.capitalize())
+            progreso.update(percentage/2, "Buscando en '%s'..." % channel_title)
 
         # Modo single Thread
         else:
-            logger.info("Obteniendo novedades de channel_name=" + channel_name)
-            progreso.update(percentage, "Buscando en '%s'..." % channel_name.capitalize())
-            get_newest(channel_name, item.extra)
+            logger.info("Obteniendo novedades de channel_id=" + channel_id)
+            progreso.update(percentage, "Buscando en '%s'..." % channel_title)
+            get_newest(channel_id, item.extra)
 
     # Modo Multi Thread: esperar q todos los hilos terminen
     if multithread:
@@ -201,10 +212,10 @@ def novedades(item):
 
             if len(pendent) > 5:
                 progreso.update(percentage,
-                                "Buscando '%s' en %d/%d canales..." % (item.category, len(pendent), len(l_hilo)))
+                                "Buscando en %d/%d canales..." % (len(pendent), len(l_hilo)))
             else:
                 list_pendent_names = [a.getName() for a in pendent]
-                mensaje = "Buscando '%s' en %s" % (item.category, ", ".join(list_pendent_names))
+                mensaje = "Buscando en %s" % (", ".join(list_pendent_names))
                 progreso.update(percentage, mensaje)
                 logger.debug(mensaje)
 
@@ -237,8 +248,8 @@ def novedades(item):
     return ret
 
 
-def get_newest(channel_name, categoria):
-    logger.info("pelisalacarta.channels.novedades get_newest channel_name="+channel_name+", categoria="+categoria)
+def get_newest(channel_id, categoria):
+    logger.info("channel_id="+channel_id+", categoria="+categoria)
 
     global list_newest
 
@@ -248,10 +259,10 @@ def get_newest(channel_name, categoria):
 
         puede = True
         try:
-            modulo = __import__('channels.%s' % channel_name, fromlist=["channels.%s" % channel_name])
+            modulo = __import__('channels.%s' % channel_id, fromlist=["channels.%s" % channel_id])
         except:
             try:
-                exec "import channels."+channel_name+" as modulo"
+                exec "import channels."+channel_id+" as modulo"
             except:
                 puede = False
 
@@ -260,27 +271,48 @@ def get_newest(channel_name, categoria):
 
         logger.info("pelisalacarta.channels.novedades running channel "+modulo.__name__+" "+modulo.__file__)
         list_result = modulo.newest(categoria)
-        logger.info("pelisalacarta.channels.novedades.get_newest canal= %s %d resultados" %(channel_name, len(list_result)))
+        logger.info("pelisalacarta.channels.novedades.get_newest canal= %s %d resultados" %(channel_id, len(list_result)))
 
         for item in list_result:
-            logger.info("pelisalacarta.channels.novedades.get_newest   item="+item.tostring())
-            item.channel = channel_name
+            #logger.info("pelisalacarta.channels.novedades.get_newest   item="+item.tostring())
+            item.channel = channel_id
             list_newest.append(item)
 
     except:
-        logger.error("No se pueden recuperar novedades de: "+ channel_name)
+        logger.error("No se pueden recuperar novedades de: "+ channel_id)
         import traceback
         logger.error(traceback.format_exc())
 
 
+def get_title(item):
+    if item.contentSerieName: # Si es una serie
+        title = item.contentSerieName
+        if not scrapertools.get_season_and_episode(title) and item.contentEpisodeNumber:
+            if not item.contentSeason: item.contentSeason = '1'
+            title = "%s - %sx%s" % (title, item.contentSeason, "{:0>2d}".format(int(item.contentEpisodeNumber)))
+
+    elif item.contentTitle: # Si es una pelicula con el canal adaptado
+        title = item.contentTitle
+    elif item.fulltitle: # Si el canal no esta adaptado
+        title = item.fulltitle
+    else: # Como ultimo recurso
+        title = item.title
+
+    # Limpiamos el titulo de etiquetas de formato anteriores
+    title = re.compile("\[/*COLO.*?\]", re.DOTALL).sub("", title)
+    title = re.compile("\[/*B\]", re.DOTALL).sub("", title)
+    title = re.compile("\[/*I\]", re.DOTALL).sub("", title)
+
+    return title
+
+
 def noAgrupar(list_result_canal, categoria):
     itemlist = []
+    global channels_ID_name
 
     for i in list_result_canal:
-        i.title = re.compile("\[/*COLO.*?\]",re.DOTALL).sub("",i.title)
-        i.title = re.compile("\[/*B\]",re.DOTALL).sub("",i.title)
-        i.title = i.title + " ["+i.channel+"]"
-        i.text_color=color2
+        i.title = get_title(i) + " ["+channels_ID_name[i.channel]+"]"
+        i.text_color=color3
 
         itemlist.append(i.clone())
 
@@ -288,65 +320,50 @@ def noAgrupar(list_result_canal, categoria):
 
 
 def agruparXcanal(list_result_canal, categoria):
-    dict_canales ={}
-    itemlist =[]
+    global channels_ID_name
+    dict_canales = {}
+    itemlist = []
 
     for i in list_result_canal:
         if not i.channel in dict_canales:
             dict_canales[i.channel] = []
-
         # Formatear titulo
-        i.title = i.contentTitle
-        if (categoria == 'series' or categoria == 'anime'):
-            i.title = i.contentSerieName
-            if not scrapertools.get_season_and_episode(i.title) and i.contentEpisodeNumber:
-                if not i.contentSeason:
-                    i.contentSeason = '1'
-
-                try:
-                    i.title += " - %sx%s" % (i.contentSeason, "{:0>2d}".format(int(i.contentEpisodeNumber)))
-                except:
-                    pass
-
+        i.title = get_title(i)
         # Añadimos el contenido al listado de cada canal
         dict_canales[i.channel].append(i)
 
     # Añadimos el contenido encontrado en la lista list_result
     for c in sorted(dict_canales):
-        itemlist.append(Item(channel="novedades", title=c.capitalize()+':', text_color=color1, text_blod=True))
+        '''if c not in channels_ID_name:
+            channels_ID_name[c] = channeltools.get_channel_parameters(c)["title"]'''
+
+        itemlist.append(Item(channel="novedades", title=channels_ID_name[c]+':', text_color=color1, text_blod=True))
+
         for i in dict_canales[c]:
             if i.contentQuality:  i.title += ' (%s)' % i.contentQuality
             if i.language: i.title += ' [%s]' % i.language
             i.title = '    %s' % i.title
-            i.text_color=color2
+            i.text_color=color3
             itemlist.append(i.clone())
 
     return itemlist
 
 
 def agruparXcontenido(list_result_canal, categoria):
+    global channels_ID_name
     dict_contenidos = {}
     list_result = []
 
     for i in list_result_canal:
         # Formatear titulo
-        i.title = i.contentTitle
-        if (categoria == 'series' or categoria == 'anime'):
-            i.title = i.contentSerieName
-            if not scrapertools.get_season_and_episode(i.title) and i.contentEpisodeNumber:
-                if not i.contentSeason:
-                    i.contentSeason = '1'
-
-                try:
-                    i.title += " - %sx%s" % (i.contentSeason, "{:0>2d}".format(int(i.contentEpisodeNumber)))
-                except:
-                    pass
+        i.title = get_title(i)
 
         # Eliminar tildes y otros caracteres especiales para la key
         import unicodedata
         try:
             newKey = i.title.lower().strip().decode("UTF-8")
             newKey = ''.join((c for c in unicodedata.normalize('NFD', newKey) if unicodedata.category(c) != 'Mn'))
+
         except:
             newKey = i.title
 
@@ -364,7 +381,7 @@ def agruparXcontenido(list_result_canal, categoria):
             canales_no_duplicados = []
             for i in v:
                 if not i.channel in canales_no_duplicados:
-                    canales_no_duplicados.append(i.channel)
+                    canales_no_duplicados.append(channels_ID_name[i.channel])
 
             if len(canales_no_duplicados) > 1:
                 canales = ', '.join([i for i in canales_no_duplicados[:-1]])
@@ -373,26 +390,28 @@ def agruparXcontenido(list_result_canal, categoria):
                 title += " (En %s)" % (', '.join([i for i in canales_no_duplicados]))
 
             newItem = v[0].clone(channel="novedades", title=title, action="ver_canales",
-                                 sub_list=[i.tourl() for i in v])
+                                 sub_list=[i.tourl() for i in v], extra=channels_ID_name)
         else:
             newItem = v[0].clone(title=title)
 
-        newItem.text_color = color2
+        newItem.text_color = color3
         list_result.append(newItem)
 
     return sorted(list_result, key=lambda i:  i.title.lower())
 
 
 def ver_canales(item):
-    logger.info("pelisalacarta.channels.novedades ver_canales")
+    logger.info()
+    channels_ID_name = item.extra
     itemlist = []
+
     for i in item.sub_list:
         newItem = Item()
         newItem = newItem.fromurl(i)
         #logger.debug(newItem.tostring())
         if newItem.contentQuality:  newItem.title += ' (%s)' % newItem.contentQuality
         if newItem.language: newItem.title += ' [%s]' % newItem.language
-        newItem.title += ' (%s)' % newItem.channel
+        newItem.title += ' (%s)' % channels_ID_name[newItem.channel]
         newItem.text_color = color1
 
         itemlist.append(newItem.clone())
@@ -444,8 +463,8 @@ def settingCanal(item):
 
     list_controls = []
     for infile in sorted(glob.glob(channels_path)):
-        channel_name = os.path.basename(infile)[:-4]
-        channel_parameters = channeltools.get_channel_parameters(channel_name)
+        channel_id = os.path.basename(infile)[:-4]
+        channel_parameters = channeltools.get_channel_parameters(channel_id)
 
         # No incluir si es un canal inactivo
         if channel_parameters["active"] != "true":
@@ -460,11 +479,11 @@ def settingCanal(item):
             continue
 
         # No incluir si en su configuracion el canal no existe 'include_in_newest'
-        include_in_newest = config.get_setting("include_in_newest_" + item.extra, channel_name)
+        include_in_newest = config.get_setting("include_in_newest_" + item.extra, channel_id)
         if include_in_newest == "":
             continue
 
-        control = {'id': channel_name,
+        control = {'id': channel_id,
                       'type': "bool",
                       'label': channel_parameters["title"],
                       'default': include_in_newest,
@@ -475,7 +494,7 @@ def settingCanal(item):
 
     caption = "Canales incluidos en Novedades " + item.title.replace("Canales incluidos en: ","- ").strip()
     return platformtools.show_channel_settings(list_controls=list_controls, callback="save_settings", item=item,
-                                               caption= caption)
+                                               caption= caption,custom_button={"visible":False})
 
 
 def save_settings(item,dict_values):

--- a/python/main-classic/channels/novedades.xml
+++ b/python/main-classic/channels/novedades.xml
@@ -16,6 +16,11 @@
 	
 	<changes>
 		<change>
+			<date>07/02/17</date>
+			<autor>super_berny</autor>
+			<description>Añadir cuadro de progreso</description>
+		</change>
+		<change>
 			<date>01/07/16</date>
 			<autor>SeiTaN</autor>
 			<description>Eliminado código innecesario.</description>
@@ -34,8 +39,8 @@
 	<settings>
 		<id>multithread</id>
 		<type>bool</type>
-		<label>MultiThread</label>
-		<default>false</default>
+		<label>Buscar de manera concurrente (multiprocesos)</label>
+		<default>true</default>
 		<enabled>true</enabled>
 		<visible>true</visible>
 	</settings>

--- a/python/main-classic/channels/novedades.xml
+++ b/python/main-classic/channels/novedades.xml
@@ -55,4 +55,17 @@
 		<lvalues>Agrupados por canales</lvalues>
 		<lvalues>Sin Agrupar</lvalues>
 	</settings>
+    <settings>
+		<id>perfil</id>
+		<type>list</type>
+		<label>Perfil de color</label>
+		<default>0</default>
+		<enabled>true</enabled>
+		<visible>true</visible>
+		<lvalues>Frio</lvalues>
+		<lvalues>Calido</lvalues>
+		<lvalues>Lila</lvalues>
+        <lvalues>Pastel</lvalues>
+        <lvalues>Vivos</lvalues>
+	</settings>
 </channel>

--- a/python/main-classic/core/item.py
+++ b/python/main-classic/core/item.py
@@ -145,7 +145,7 @@ class Item(object):
         kw = copy.copy(kwargs)
         for k in kw:
             if k in ["contentTitle", "contentPlot", "contentSerieName", "show", "contentType", "contentEpisodeTitle",
-                    "contentSeason", "contentEpisodeNumber", "contentThumbnail", "plot", "duration"]:
+                    "contentSeason", "contentEpisodeNumber", "contentThumbnail", "plot", "duration", "contentQuality"]:
                 self.__setattr__(k, kw[k])
                 del kwargs[k]
 
@@ -174,7 +174,7 @@ class Item(object):
 
        # Al modificar cualquiera de estos atributos content...
         if name in ["contentTitle", "contentPlot", "contentSerieName", "contentType", "contentEpisodeTitle",
-                    "contentSeason", "contentEpisodeNumber", "contentThumbnail", "show"]:
+                    "contentSeason", "contentEpisodeNumber", "contentThumbnail", "show", "contentQuality"]:
             #... marcamos hasContentDetails como "true"...
             self.__dict__["hasContentDetails"] = "true"
             #...y actualizamos infoLables
@@ -194,6 +194,8 @@ class Item(object):
                 self.__dict__["infoLabels"]["episode"] = value
             elif name == "contentThumbnail":
                 self.__dict__["infoLabels"]["thumbnail"] = value
+            elif name == "contentQuality":
+                self.__dict__["infoLabels"]["quality"] = value
 
         elif name == "plot":
             self.__dict__["infoLabels"]["plot"] = value
@@ -249,7 +251,7 @@ class Item(object):
 
         # valores guardados en infoLabels
         elif name in ["contentTitle", "contentPlot", "contentSerieName", "show", "contentType", "contentEpisodeTitle",
-                    "contentSeason", "contentEpisodeNumber", "contentThumbnail", "plot", "duration"]:
+                    "contentSeason", "contentEpisodeNumber", "contentThumbnail", "plot", "duration", "contentQuality"]:
             if name == "contentTitle":
                 return self.__dict__["infoLabels"]["title"]
             elif name == "contentPlot" or name == "plot":
@@ -270,6 +272,8 @@ class Item(object):
                 return self.__dict__["infoLabels"]["episode"]
             elif name == "contentThumbnail":
                 return self.__dict__["infoLabels"]["thumbnail"]
+            elif name == "contentQuality":
+                return self.__dict__["infoLabels"]["quality"]
             else:
                 return self.__dict__["infoLabels"][name]
 


### PR DESCRIPTION
- Añadido cauadro de progreso y trazas en el log como se pedia en #622 
- He aprovechado para añadir perfiles de color, ahora todos los items salen del mismo color.
- He mantenido el modo secuencial por q asi es mas facil localizar si algun canal da problemas y bloquea la busqueda, aunq si esta seleccionado este modo aparece un cuadro de dialogo avisando d q solo debemos usarlo para debugear e invitando a cambiarlo al modo concurrente.
- Un par de canales devolvian el item de "pagina siguiente" y he tenido q modificarlos.
- Aprovecho tb para incluir en Item un nuevo atributo reservado "contentQuality"