### PR TITLE
[FIX #589] logger.error

### DIFF
--- a/python/main-classic/core/logger.py
+++ b/python/main-classic/core/logger.py
@@ -99,8 +99,7 @@ def debug(texto=""):
 
 
 def error(texto=""):
-    if loggeractive:
-        texto = "    [" + get_caller() + "] " + encode_log(texto)
+    texto = "    [" + get_caller() + "] " + encode_log(texto)
 
-        xbmc.log("######## ERROR #########", xbmc.LOGNOTICE)
-        xbmc.log(texto, xbmc.LOGNOTICE)
+    xbmc.log("######## ERROR #########", xbmc.LOGERROR)
+    xbmc.log(texto, xbmc.LOGERROR)


### PR DESCRIPTION
Atendiendo la peticion #589 (y lo hablado con @r0balo en la #627) he eliminado la comprobacion a la hora de escribir en el log en caso de error: logger.error() ahora siempre esta activado.
Ademas ahora lo escribe como un ERROR y no como una NOTICE como hasta ahora.

Por supuesto hay q usarlo para lo q realmente es, para indicar errores y no trazas (q serian los logger.info()) o para depurar (q serian los logger.debug()). Y si puntualmente queremos usarlo como un simple print, deberemos prestar atencion para eliminarlos cuando terminemos la depuracion.

Esta probado en Xbmc v10 (Dharma), kodi v16 y kodi v17.
En la version mediaserver ya estaba implementado asi. En las versiones plex y command-line ya se escribia siempre cualquier funcion del logger (no habia q activar nada). 