### PR TITLE
[Fix #661] Continuacion de #663

### DIFF
--- a/python/main-classic/channels/biblioteca.xml
+++ b/python/main-classic/channels/biblioteca.xml
@@ -157,8 +157,8 @@
 		<id>xbmc_host</id>
 		<type>text</type>
 		<label>    Nombre Servidor</label>
-		<enabled>true</enabled>
-		<visible>eq(-1,Remota)</visible>
+		<visible>true</visible>
+		<enabled>eq(-1,Remota)</enabled>
 		<default></default>
 	</settings>
 	<settings>
@@ -166,7 +166,7 @@
 		<type>text</type>
 		<label>    Puerto Servidor</label>
 		<enabled>!eq(-1,'')</enabled>
-		<visible>eq(-2,Remota)</visible>
+		<visible>true</visible>
 		<default></default>
 	</settings>
 	<settings>
@@ -209,8 +209,8 @@
 		<type>bool</type>
 		<label>        Mostrar notificación</label>
 		<default>true</default>
-		<enabled>true</enabled>
-		<visible>eq(-1,true)</visible>
+		<visible>true</visible>
+		<enabled>eq(-1,true)</enabled>
 	</settings>
 	<settings>
 		<id>sync_trakt_new_tvshow</id>
@@ -225,8 +225,8 @@
 		<type>bool</type>
 		<label>        Esperar a que se añada la serie a la biblioteca</label>
 		<default>true</default>
-		<enabled>true</enabled>
-		<visible>eq(-1,true)</visible>
+		<visible>true</visible>
+		<enabled>eq(-1,true)</enabled>
 	</settings>
 
 	<settings>

--- a/python/main-classic/library_service.py
+++ b/python/main-classic/library_service.py
@@ -248,14 +248,6 @@ def check_for_update(overwrite=True):
         if config.get_setting("updatelibrary", "biblioteca") != 0 or overwrite:
             config.set_setting("updatelibrary_last_check", hoy.strftime('%Y-%m-%d'), "biblioteca")
 
-            if config.get_setting("updatelibrary", "biblioteca") in [1,3] and not overwrite:
-                # "Actualizar al inicio" y No venimos del canal configuracion
-                updatelibrary_wait = [0, 10000, 20000, 30000, 60000]
-                wait = updatelibrary_wait[int(config.get_setting("updatelibrary_wait", "biblioteca"))]
-                if wait > 0:
-                    import xbmc
-                    xbmc.sleep(wait)
-
             heading = 'Actualizando biblioteca....'
             p_dialog = platformtools.dialog_progress_bg('pelisalacarta', heading)
             p_dialog.update(0, '')
@@ -280,7 +272,7 @@ def check_for_update(overwrite=True):
                     # si la serie no esta activa descartar
                     continue
 
-                # obtenemos las fecha de auctualizacion y de la proxima programada para esta serie
+                # obtenemos las fecha de actualizacion y de la proxima programada para esta serie
                 update_next = serie.update_next
                 if update_next:
                     y, m, d = update_next.split('-')
@@ -370,6 +362,13 @@ def check_for_update(overwrite=True):
 
 if __name__ == "__main__":
     # Se ejecuta en cada inicio
+    import xbmc
+    updatelibrary_wait = [0, 10000, 20000, 30000, 60000]
+    wait = updatelibrary_wait[int(config.get_setting("updatelibrary_wait", "biblioteca"))]
+    if wait > 0:
+        xbmc.sleep(wait)
+
+    # Comprobar version de la bilbioteca y actualizar si es necesario
     if config.get_setting("library_version") != 'v4':
         platformtools.dialog_ok(config.PLUGIN_NAME.capitalize(), "Se va a actualizar la biblioteca al nuevo formato",
                                 "Seleccione el nombre correcto de cada serie o película, si no está seguro pulse 'Cancelar'.")
@@ -385,8 +384,8 @@ if __name__ == "__main__":
         if not config.get_setting("updatelibrary", "biblioteca") == 2:
             check_for_update(overwrite=False)
 
+
     # Se ejecuta ciclicamente
-    import xbmc
     if config.get_platform(True)['num_version'] >= 14:
         monitor = xbmc.Monitor()  # For Kodi >= 14
     else:


### PR DESCRIPTION
Se han pasado todos los ajustes que quedaban pendientes de ocultos a desactivados.
Se ha modificado library_service para q ahora el retraso "updatelibrary_wait" se ejecute dentro del main, por lo q afectara a la conversion de la bilbioteca y al arranque del monitor tb.