### PR TITLE
Mostrar "configurar canal" en el menú contextual #617, Fix búsqueda, Fix Información, atajos para opciones menu principal

### DIFF
--- a/python/main-classic/channels/configuracion.py
+++ b/python/main-classic/channels/configuracion.py
@@ -90,32 +90,19 @@ def mainlist(item):
                          action="", folder=False,
                          thumbnail=get_thumbnail_path("thumb_configuracion_0.png")))
 
+    # Inicio - Canales configurables
     import channelselector
     from core import channeltools
     channel_list = channelselector.filterchannels("all")
 
     for channel in channel_list:
-        try:
-            jsonchannel = channeltools.get_channel_json(channel.channel)
-        except:
-            continue
-        if jsonchannel.get("settings"):
-            setting = jsonchannel["settings"]
-            if type(setting) == list:
-                if len([s for s in setting if "id" in s and "include_in_" not in s["id"]]):
-                    active_status = None
-                    if config.get_setting("enabled", channel.channel):
-                        active_status = config.get_setting("enabled", channel.channel)
-                    else:
-                        channel_parameters = channeltools.get_channel_parameters(channel.channel)
-                        active_status = channel_parameters['active']
+        channel_parameters = channeltools.get_channel_parameters(channel.channel)
 
-                    if active_status == "true":
-                        itemlist.append(Item(channel=CHANNELNAME,
-                                             title="   Configuración del canal '%s'" % channel.title,
-                                             action="channel_config", config=channel.channel,
-                                             folder=False,
-                                             thumbnail=channel.thumbnail))
+        if channel_parameters["has_settings"]:
+            itemlist.append(Item(channel=CHANNELNAME, title="   Configuración del canal '%s'" % channel.title,
+                                 action="channel_config", config=channel.channel, folder=False,
+                                 thumbnail=channel.thumbnail))
+    # Fin - Canales configurables
 
     itemlist.append(Item(channel=CHANNELNAME, action="", title="", folder=False,
                          thumbnail=get_thumbnail_path("thumb_configuracion_0.png")))

--- a/python/main-classic/channelselector.py
+++ b/python/main-classic/channelselector.py
@@ -70,7 +70,7 @@ def getmainlist(preferred_thumb=""):
 
     itemlist.append(Item(title=config.get_localized_string(30101), channel="descargas", action="mainlist",
                          thumbnail=get_thumb(preferred_thumb, "thumb_descargas.png"), viewmode="list",
-                         context=[{"title": "Configurar descargas", "channel": "descargars",
+                         context=[{"title": "Configurar descargas", "channel": "configuracion", "config": "descargas",
                                    "action": "channel_config"}]))
 
     thumb_configuracion = "thumb_configuracion_"+config.get_setting("plugin_updates_available")+".png"

--- a/python/main-classic/channelselector.py
+++ b/python/main-classic/channelselector.py
@@ -33,160 +33,94 @@ from core import config
 from core import logger
 from core.item import Item
 
-DEBUG = config.get_setting("debug")
 
 def getmainlist(preferred_thumb=""):
-    logger.info("channelselector.getmainlist")
+    logger.info()
     itemlist = list()
 
     # Añade los canales que forman el menú principal
 
-    itemlist.append(Item(title=config.get_localized_string(30130),
-                         channel="novedades", 
-                         action="mainlist",
-                         thumbnail=get_thumb(preferred_thumb,"thumb_novedades.png"),
-                         category=config.get_localized_string(30119),
-                         viewmode="thumbnails"))
+    itemlist.append(Item(title=config.get_localized_string(30130), channel="novedades", action="mainlist",
+                         thumbnail=get_thumb(preferred_thumb, "thumb_novedades.png"),
+                         category=config.get_localized_string(30119), viewmode="thumbnails"))
 
-    itemlist.append(Item(title=config.get_localized_string(30118),
-                         channel="channelselector", 
-                         action="getchanneltypes",
-                         thumbnail=get_thumb(preferred_thumb,"thumb_canales.png"),
-                         category= config.get_localized_string(30119),
-                         viewmode="thumbnails"))
+    itemlist.append(Item(title=config.get_localized_string(30118), channel="channelselector", action="getchanneltypes",
+                         thumbnail=get_thumb(preferred_thumb, "thumb_canales.png"),
+                         category=config.get_localized_string(30119), viewmode="thumbnails"))
 
-    itemlist.append(Item(title=config.get_localized_string(30103),
-                         channel="buscador", 
-                         action="mainlist",
-                         thumbnail=get_thumb(preferred_thumb,"thumb_buscar.png"),
-                         category=config.get_localized_string(30119),
-                         viewmode="list"))
+    itemlist.append(Item(title=config.get_localized_string(30103), channel="buscador", action="mainlist",
+                         thumbnail=get_thumb(preferred_thumb, "thumb_buscar.png"),
+                         category=config.get_localized_string(30119), viewmode="list"))
 
-    itemlist.append(Item(title=config.get_localized_string(30102),
-                         channel="favoritos", 
-                         action="mainlist",
-                         thumbnail=get_thumb(preferred_thumb,"thumb_favoritos.png"),
-                         category=config.get_localized_string(30102),
-                         viewmode="thumbnails"))
+    itemlist.append(Item(title=config.get_localized_string(30102), channel="favoritos", action="mainlist",
+                         thumbnail=get_thumb(preferred_thumb, "thumb_favoritos.png"),
+                         category=config.get_localized_string(30102), viewmode="thumbnails"))
 
     if config.get_library_support():
 
-        itemlist.append(Item(title=config.get_localized_string(30131),
-                             channel="biblioteca", 
-                             action="mainlist",
-                             thumbnail=get_thumb(preferred_thumb,"thumb_biblioteca.png"),
-                             category=config.get_localized_string(30119),
-                             viewmode="thumbnails"))
+        itemlist.append(Item(title=config.get_localized_string(30131), channel="biblioteca", action="mainlist",
+                             thumbnail=get_thumb(preferred_thumb, "thumb_biblioteca.png"),
+                             category=config.get_localized_string(30119), viewmode="thumbnails"))
 
-    itemlist.append(Item(title=config.get_localized_string(30101), 
-                         channel="descargas",
-                         action="mainlist",
-                         thumbnail=get_thumb(preferred_thumb,"thumb_descargas.png"),
-                         viewmode="list"))
+    itemlist.append(Item(title=config.get_localized_string(30101), channel="descargas", action="mainlist",
+                         thumbnail=get_thumb(preferred_thumb, "thumb_descargas.png"), viewmode="list"))
 
     thumb_configuracion = "thumb_configuracion_"+config.get_setting("plugin_updates_available")+".png"
 
-    if "xbmceden" in config.get_platform():
-
-        itemlist.append(Item(title=config.get_localized_string(30100),
-                             channel="configuracion", 
-                             action="mainlist",
-                             thumbnail=get_thumb(preferred_thumb,thumb_configuracion),
-                             folder=False, 
-                             viewmode="list"))
+    if "xbmc-eden" in config.get_platform():
+        itemlist.append(Item(title=config.get_localized_string(30100), channel="configuracion", action="mainlist",
+                             thumbnail=get_thumb(preferred_thumb, thumb_configuracion), folder=False, viewmode="list"))
     else:
-        itemlist.append(Item(title=config.get_localized_string(30100),
-                             channel="configuracion", 
-                             action="mainlist",
-                             thumbnail=get_thumb(preferred_thumb,thumb_configuracion),
-                             category=config.get_localized_string(30100),
-                             viewmode="list"))
+        itemlist.append(Item(title=config.get_localized_string(30100), channel="configuracion", action="mainlist",
+                             thumbnail=get_thumb(preferred_thumb, thumb_configuracion),
+                             category=config.get_localized_string(30100), viewmode="list"))
 
-    itemlist.append(Item(title=config.get_localized_string(30104), 
-                         channel="ayuda", 
-                         action="mainlist",
-                         thumbnail=get_thumb(preferred_thumb,"thumb_ayuda.png"),
-                         category=config.get_localized_string(30104),
-                         viewmode="list"))
+    itemlist.append(Item(title=config.get_localized_string(30104), channel="ayuda", action="mainlist",
+                         thumbnail=get_thumb(preferred_thumb, "thumb_ayuda.png"),
+                         category=config.get_localized_string(30104), viewmode="list"))
     return itemlist
 
-def get_thumb(preferred_thumb,thumb_name):
-    return urlparse.urljoin(get_thumbnail_path(preferred_thumb),thumb_name)
+
+def get_thumb(preferred_thumb, thumb_name):
+    return urlparse.urljoin(get_thumbnail_path(preferred_thumb), thumb_name)
+
 
 def getchanneltypes(preferred_thumb=""):
-    logger.info("channelselector getchanneltypes")
+    logger.info()
 
     # Lista de categorias
-    valid_types = ["movie", "serie", "anime", "documentary", "vos", "torrent", "latino", "adult"]
-    dict_cat_lang = {'movie': config.get_localized_string(30122), 'serie': config.get_localized_string(30123),
-                     'anime': config.get_localized_string(30124), 'documentary': config.get_localized_string(30125),
-                     'vos': config.get_localized_string(30136), 'adult': config.get_localized_string(30126),
-                     'latino': config.get_localized_string(30127)}
-
-    # Lee la lista de canales
-    channel_path = os.path.join(config.get_runtime_path(), "channels", '*.xml')
-    logger.info("channelselector.getchanneltypes channel_path="+channel_path)
-
-    channel_files = glob.glob(channel_path)
+    channel_types = ["movie", "serie", "anime", "documentary", "vos", "torrent", "latino", "adult"]
+    dict_types_lang = {'movie': config.get_localized_string(30122), 'serie': config.get_localized_string(30123),
+                       'anime': config.get_localized_string(30124), 'documentary': config.get_localized_string(30125),
+                       'vos': config.get_localized_string(30136), 'adult': config.get_localized_string(30126),
+                       'latino': config.get_localized_string(30127)}
 
     channel_language = config.get_setting("channel_language")
-    logger.info("channelselector.getchanneltypes channel_language="+channel_language)
-
-    # Construye la lista de tipos
-    channel_types = []
-
-    for index, channel in enumerate(channel_files):
-        logger.info("channelselector.getchanneltypes channel="+channel)
-        if channel.endswith(".xml"):
-            try:
-                channel_parameters = channeltools.get_channel_parameters(channel[:-4])
-                logger.info("channelselector.filterchannels channel_parameters="+repr(channel_parameters))
-
-                # Si es un canal para adultos y el modo adulto está desactivado, se lo salta
-                if channel_parameters["adult"] == "true" and config.get_setting("adult_mode") == "false":
-                    continue
-
-                # Si el canal está en un idioma filtrado
-                if channel_language != "all" and channel_parameters["language"] != channel_language:
-                    continue
-
-                categories = channel_parameters["categories"]
-                for category in categories:
-                    logger.info("channelselector.filterchannels category="+category)
-                    if category not in channel_types and category in valid_types:
-                        channel_types.append(category)
-
-            except:
-                logger.info("Se ha producido un error al leer los datos del canal " + channel + traceback.format_exc())
-
-    logger.info("channelselector.getchanneltypes Encontrados:")
-    for channel_type in channel_types:
-        logger.info("channelselector.getchanneltypes channel_type="+channel_type)
+    logger.info("channel_language="+channel_language)
 
     # Ahora construye el itemlist ordenadamente
     itemlist = list()
     title = config.get_localized_string(30121)
     itemlist.append(Item(title=title, channel="channelselector", action="filterchannels",
                          category=title, channel_type="all",
-                         thumbnail=urlparse.urljoin(get_thumbnail_path(preferred_thumb),
-                                                                    "thumb_canales_todos.png"), viewmode="thumbnails"))
-    logger.info("channelselector.getchanneltypes Ordenados:")
-    for channel_type in valid_types:
-        logger.info("channelselector.getchanneltypes channel_type="+channel_type)
-        if channel_type in channel_types:
-            title = dict_cat_lang.get(channel_type, channel_type)
-            itemlist.append(Item(title=title, channel="channelselector", action="filterchannels", category=title,
-                                 channel_type= channel_type, viewmode="thumbnails",
-                                 thumbnail=urlparse.urljoin(get_thumbnail_path(preferred_thumb),
-                                                            "thumb_canales_"+channel_type+".png")))
+                         thumbnail=urlparse.urljoin(get_thumbnail_path(preferred_thumb), "thumb_canales_todos.png"),
+                         viewmode="thumbnails"))
+
+    for channel_type in channel_types:
+        logger.info("channel_type="+channel_type)
+        title = dict_types_lang.get(channel_type, channel_type)
+        itemlist.append(Item(title=title, channel="channelselector", action="filterchannels", category=title,
+                             channel_type=channel_type, viewmode="thumbnails",
+                             thumbnail=urlparse.urljoin(get_thumbnail_path(preferred_thumb),
+                                                        "thumb_canales_"+channel_type+".png")))
 
     return itemlist
 
 
-def filterchannels(category,preferred_thumb=""):
-    logger.info("channelselector.filterchannels")
+def filterchannels(category, preferred_thumb=""):
+    logger.info()
 
-    channelslist =[]
+    channelslist = []
 
     # Si category = "allchannelstatus" es que estamos activando/desactivando canales
     appenddisabledchannels = "false"
@@ -195,104 +129,114 @@ def filterchannels(category,preferred_thumb=""):
         appenddisabledchannels = "true"
 
     # Lee la lista de canales
-    channel_path = os.path.join( config.get_runtime_path() , "channels" , '*.xml' )
+    channel_path = os.path.join(config.get_runtime_path(), "channels", '*.xml')
     logger.info("channelselector.filterchannels channel_path="+channel_path)
 
     channel_files = glob.glob(channel_path)
     logger.info("channelselector.filterchannels channel_files encontrados "+str(len(channel_files)))
 
     channel_language = config.get_setting("channel_language")
-    logger.info("channelselector.filterchannels channel_language="+channel_language)
-    if channel_language=="":
+    logger.info("channel_language="+channel_language)
+    if channel_language == "":
         channel_language = "all"
-        logger.info("channelselector.filterchannels channel_language="+channel_language)
+        logger.info("channel_language="+channel_language)
 
-    for index, channel in enumerate(channel_files):
-        logger.info("channelselector.filterchannels channel="+channel)
-        if channel.endswith(".xml"):
+    for channel in channel_files:
+        logger.info("channel="+channel)
 
-            try:
-                channel_parameters = channeltools.get_channel_parameters(channel[:-4])
-                logger.info("channelselector.filterchannels channel_parameters="+repr(channel_parameters))
+        try:
+            channel_parameters = channeltools.get_channel_parameters(channel[:-4])
+            logger.info("channel_parameters="+repr(channel_parameters))
 
-                # Si prefiere el bannermenu y el canal lo tiene, cambia ahora de idea
-                if preferred_thumb=="bannermenu" and "bannermenu" in channel_parameters:
-                    channel_parameters["thumbnail"] = channel_parameters["bannermenu"]
+            # Si prefiere el bannermenu y el canal lo tiene, cambia ahora de idea
+            if preferred_thumb == "bannermenu" and "bannermenu" in channel_parameters:
+                channel_parameters["thumbnail"] = channel_parameters["bannermenu"]
 
-                # Se salta el canal si no está activo y no estamos activando/desactivando los canales
-                channel_status = None
-                if config.get_setting("enabled", channel_parameters["channel"]):
-                    channel_status = config.get_setting("enabled", channel_parameters["channel"])
-                else:
-                    channel_status = channel_parameters["active"]
+            # Se salta el canal si no está activo y no estamos activando/desactivando los canales
+            if config.get_setting("enabled", channel_parameters["channel"]):
+                channel_status = config.get_setting("enabled", channel_parameters["channel"])
+            else:
+                channel_status = channel_parameters["active"]
 
-                if channel_status != "true":
-                    if appenddisabledchannels != "true":
-                        continue
-
-                # Se salta el canal para adultos si el modo adultos está desactivado
-                if channel_parameters["adult"] == "true" and config.get_setting("adult_mode") != "true":
+            if channel_status != "true":
+                if appenddisabledchannels != "true":
                     continue
 
-                # Se salta el canal si está en un idioma filtrado
-                if channel_language!="all" and channel_parameters["language"]!=config.get_setting("channel_language"):
-                    continue
+            # Se salta el canal para adultos si el modo adultos está desactivado
+            if channel_parameters["adult"] == "true" and config.get_setting("adult_mode") != "true":
+                continue
 
-                # Se salta el canal si está en una categoria filtrado
-                if category!="all" and category not in channel_parameters["categories"]:
-                    continue
+            # Se salta el canal si está en un idioma filtrado
+            if channel_language != "all" \
+                    and channel_parameters["language"] != config.get_setting("channel_language"):
+                continue
 
-                # Si ha llegado hasta aquí, lo añade
-                channelslist.append(Item(title=channel_parameters["title"], channel=channel_parameters["channel"],
-                                         action="mainlist", thumbnail=channel_parameters["thumbnail"] ,
-                                         fanart=channel_parameters["fanart"],
-                                         category=channel_parameters["title"],
-                                         language=channel_parameters["language"], viewmode="list" ))
+            # Se salta el canal si está en una categoria filtrado
+            if category != "all" and category not in channel_parameters["categories"]:
+                continue
 
-            except:
-                logger.info("Se ha producido un error al leer los datos del canal " + channel)
-                import traceback
-                logger.info(traceback.format_exc())
+            # Si ha llegado hasta aquí, lo añade
+            channelslist.append(Item(title=channel_parameters["title"], channel=channel_parameters["channel"],
+                                     action="mainlist", thumbnail=channel_parameters["thumbnail"],
+                                     fanart=channel_parameters["fanart"], category=channel_parameters["title"],
+                                     language=channel_parameters["language"], viewmode="list",
+                                     context=channel_parameters["context"]))
+
+        except:
+            logger.error("Se ha producido un error al leer los datos del canal " + channel)
+            import traceback
+            logger.error(traceback.format_exc())
 
     channelslist.sort(key=lambda item: item.title.lower().strip())
 
-    if category=="all":
-        if config.get_setting("personalchannel5")=="true":
-            channelslist.insert( 0 , Item( title=config.get_setting("personalchannelname5") ,action="mainlist", channel="personal5" ,thumbnail=config.get_setting("personalchannellogo5") , type="generic" ,viewmode="list" ))
-        if config.get_setting("personalchannel4")=="true":
-            channelslist.insert( 0 , Item( title=config.get_setting("personalchannelname4") ,action="mainlist", channel="personal4" ,thumbnail=config.get_setting("personalchannellogo4") , type="generic" ,viewmode="list" ))
-        if config.get_setting("personalchannel3")=="true":
-            channelslist.insert( 0 , Item( title=config.get_setting("personalchannelname3") ,action="mainlist", channel="personal3" ,thumbnail=config.get_setting("personalchannellogo3") , type="generic" ,viewmode="list" ))
-        if config.get_setting("personalchannel2")=="true":
-            channelslist.insert( 0 , Item( title=config.get_setting("personalchannelname2") ,action="mainlist", channel="personal2" ,thumbnail=config.get_setting("personalchannellogo2") , type="generic" ,viewmode="list" ))
-        if config.get_setting("personalchannel")=="true":
-            channelslist.insert( 0 , Item( title=config.get_setting("personalchannelname")  ,action="mainlist", channel="personal"  ,thumbnail=config.get_setting("personalchannellogo") , type="generic" ,viewmode="list" ))
+    if category == "all":
+        if config.get_setting("personalchannel5") == "true":
+            channelslist.insert(0, Item(title=config.get_setting("personalchannelname5"), action="mainlist",
+                                        channel="personal5", thumbnail=config.get_setting("personalchannellogo5"),
+                                        type="generic", viewmode="list"))
+        if config.get_setting("personalchannel4") == "true":
+            channelslist.insert(0, Item(title=config.get_setting("personalchannelname4"), action="mainlist",
+                                        channel="personal4", thumbnail=config.get_setting("personalchannellogo4"),
+                                        type="generic", viewmode="list"))
+        if config.get_setting("personalchannel3") == "true":
+            channelslist.insert(0, Item(title=config.get_setting("personalchannelname3"), action="mainlist",
+                                        channel="personal3", thumbnail=config.get_setting("personalchannellogo3"),
+                                        type="generic", viewmode="list"))
+        if config.get_setting("personalchannel2") == "true":
+            channelslist.insert(0, Item(title=config.get_setting("personalchannelname2"), action="mainlist",
+                                        channel="personal2", thumbnail=config.get_setting("personalchannellogo2"),
+                                        type="generic", viewmode="list"))
+        if config.get_setting("personalchannel") == "true":
+            channelslist.insert(0, Item(title=config.get_setting("personalchannelname"), action="mainlist",
+                                        channel="personal", thumbnail=config.get_setting("personalchannellogo"),
+                                        type="generic", viewmode="list"))
 
         channel_parameters = channeltools.get_channel_parameters("tengourl")
         # Si prefiere el bannermenu y el canal lo tiene, cambia ahora de idea
-        if preferred_thumb=="bannermenu" and "bannermenu" in channel_parameters:
+        if preferred_thumb == "bannermenu" and "bannermenu" in channel_parameters:
             channel_parameters["thumbnail"] = channel_parameters["bannermenu"]
 
-        channelslist.insert( 0 , Item( title="Tengo una URL"  ,action="mainlist", channel="tengourl" , thumbnail=channel_parameters["thumbnail"], type="generic" ,viewmode="list" ))
+        channelslist.insert(0, Item(title="Tengo una URL", action="mainlist", channel="tengourl",
+                                    thumbnail=channel_parameters["thumbnail"], type="generic", viewmode="list"))
 
     return channelslist
 
+
 def get_thumbnail_path(preferred_thumb=""):
 
-    WEB_PATH = ""
+    web_path = ""
 
-    if preferred_thumb=="":
+    if preferred_thumb == "":
         thumbnail_type = config.get_setting("thumbnail_type")
-        if thumbnail_type=="":
-            thumbnail_type="2"
-
-        if thumbnail_type=="0":
-            WEB_PATH = "http://media.tvalacarta.info/pelisalacarta/posters/"
-        elif thumbnail_type=="1":
-            WEB_PATH = "http://media.tvalacarta.info/pelisalacarta/banners/"
-        elif thumbnail_type=="2":
-            WEB_PATH = "http://media.tvalacarta.info/pelisalacarta/squares/"
+        if thumbnail_type == "":
+            thumbnail_type = "2"
+        if thumbnail_type == "0":
+            web_path = "http://media.tvalacarta.info/pelisalacarta/posters/"
+        elif thumbnail_type == "1":
+            web_path = "http://media.tvalacarta.info/pelisalacarta/banners/"
+        elif thumbnail_type == "2":
+            web_path = "http://media.tvalacarta.info/pelisalacarta/squares/"
     else:
-        WEB_PATH = "http://media.tvalacarta.info/pelisalacarta/"+preferred_thumb+"/"
+        web_path = "http://media.tvalacarta.info/pelisalacarta/" + preferred_thumb + "/"
 
-    return WEB_PATH
+    return web_path

--- a/python/main-classic/channelselector.py
+++ b/python/main-classic/channelselector.py
@@ -42,7 +42,9 @@ def getmainlist(preferred_thumb=""):
 
     itemlist.append(Item(title=config.get_localized_string(30130), channel="novedades", action="mainlist",
                          thumbnail=get_thumb(preferred_thumb, "thumb_novedades.png"),
-                         category=config.get_localized_string(30119), viewmode="thumbnails"))
+                         category=config.get_localized_string(30119), viewmode="thumbnails",
+                         context=[{"title": "Configurar novedades", "channel": "novedades", "action": "menu_opciones",
+                                   "goto": True}]))
 
     itemlist.append(Item(title=config.get_localized_string(30118), channel="channelselector", action="getchanneltypes",
                          thumbnail=get_thumb(preferred_thumb, "thumb_canales.png"),
@@ -50,7 +52,9 @@ def getmainlist(preferred_thumb=""):
 
     itemlist.append(Item(title=config.get_localized_string(30103), channel="buscador", action="mainlist",
                          thumbnail=get_thumb(preferred_thumb, "thumb_buscar.png"),
-                         category=config.get_localized_string(30119), viewmode="list"))
+                         category=config.get_localized_string(30119), viewmode="list",
+                         context=[{"title": "Configurar buscador", "channel": "buscador", "action": "opciones",
+                                   "goto": True}]))
 
     itemlist.append(Item(title=config.get_localized_string(30102), channel="favoritos", action="mainlist",
                          thumbnail=get_thumb(preferred_thumb, "thumb_favoritos.png"),
@@ -60,10 +64,14 @@ def getmainlist(preferred_thumb=""):
 
         itemlist.append(Item(title=config.get_localized_string(30131), channel="biblioteca", action="mainlist",
                              thumbnail=get_thumb(preferred_thumb, "thumb_biblioteca.png"),
-                             category=config.get_localized_string(30119), viewmode="thumbnails"))
+                             category=config.get_localized_string(30119), viewmode="thumbnails",
+                             context=[{"title": "Configurar biblioteca", "channel": "biblioteca",
+                                       "action": "channel_config"}]))
 
     itemlist.append(Item(title=config.get_localized_string(30101), channel="descargas", action="mainlist",
-                         thumbnail=get_thumb(preferred_thumb, "thumb_descargas.png"), viewmode="list"))
+                         thumbnail=get_thumb(preferred_thumb, "thumb_descargas.png"), viewmode="list",
+                         context=[{"title": "Configurar descargas", "channel": "descargars",
+                                   "action": "channel_config"}]))
 
     thumb_configuracion = "thumb_configuracion_"+config.get_setting("plugin_updates_available")+".png"
 

--- a/python/main-classic/channelselector.py
+++ b/python/main-classic/channelselector.py
@@ -130,10 +130,10 @@ def filterchannels(category, preferred_thumb=""):
 
     # Lee la lista de canales
     channel_path = os.path.join(config.get_runtime_path(), "channels", '*.xml')
-    logger.info("channelselector.filterchannels channel_path="+channel_path)
+    logger.info("channel_path="+channel_path)
 
     channel_files = glob.glob(channel_path)
-    logger.info("channelselector.filterchannels channel_files encontrados "+str(len(channel_files)))
+    logger.info("channel_files encontrados "+str(len(channel_files)))
 
     channel_language = config.get_setting("channel_language")
     logger.info("channel_language="+channel_language)

--- a/python/main-classic/channelselector.py
+++ b/python/main-classic/channelselector.py
@@ -75,13 +75,9 @@ def getmainlist(preferred_thumb=""):
 
     thumb_configuracion = "thumb_configuracion_"+config.get_setting("plugin_updates_available")+".png"
 
-    if "xbmc-eden" in config.get_platform():
-        itemlist.append(Item(title=config.get_localized_string(30100), channel="configuracion", action="mainlist",
-                             thumbnail=get_thumb(preferred_thumb, thumb_configuracion), folder=False, viewmode="list"))
-    else:
-        itemlist.append(Item(title=config.get_localized_string(30100), channel="configuracion", action="mainlist",
-                             thumbnail=get_thumb(preferred_thumb, thumb_configuracion),
-                             category=config.get_localized_string(30100), viewmode="list"))
+    itemlist.append(Item(title=config.get_localized_string(30100), channel="configuracion", action="mainlist",
+                         thumbnail=get_thumb(preferred_thumb, thumb_configuracion),
+                         category=config.get_localized_string(30100), viewmode="list"))
 
     itemlist.append(Item(title=config.get_localized_string(30104), channel="ayuda", action="mainlist",
                          thumbnail=get_thumb(preferred_thumb, "thumb_ayuda.png"),

--- a/python/main-classic/channelselector.py
+++ b/python/main-classic/channelselector.py
@@ -175,12 +175,18 @@ def filterchannels(category, preferred_thumb=""):
             if category != "all" and category not in channel_parameters["categories"]:
                 continue
 
+            # Si tiene configuración añadimos un item en el contexto
+            context = []
+            if channel_parameters["has_settings"]:
+                context.append({"title": "Configurar canal", "channel": "configuracion", "action": "channel_config",
+                                "config": channel_parameters["channel"]})
+
             # Si ha llegado hasta aquí, lo añade
             channelslist.append(Item(title=channel_parameters["title"], channel=channel_parameters["channel"],
                                      action="mainlist", thumbnail=channel_parameters["thumbnail"],
                                      fanart=channel_parameters["fanart"], category=channel_parameters["title"],
                                      language=channel_parameters["language"], viewmode="list",
-                                     context=channel_parameters["context"]))
+                                     context=context))
 
         except:
             logger.error("Se ha producido un error al leer los datos del canal " + channel)

--- a/python/main-classic/core/channeltools.py
+++ b/python/main-classic/core/channeltools.py
@@ -89,21 +89,16 @@ def get_channel_parameters(channel_name):
 
         channel_parameters["categories"] = category_list
 
-        # Obtenemos si el canal tiene opciones de configuración y lo añadimos al contexto
-        context = ""
+        # Obtenemos si el canal tiene opciones de configuración
+        channel_parameters["has_settings"] = False
         # esta regex devuelve 2 valores por elemento <settings>, el contenido del propio nodo y un \t, por lo que hay
         # posteriormente coger solo el valor del indice 0.
         matches = scrapertools.find_multiple_matches(data, "<settings>((.|\n)*?)<\/settings>")
         for match in matches:
             _id = scrapertools.find_single_match(match[0], "<id>([^<]*)</id>")
             if _id and "include_in_" not in _id:
-                context = [{"title": "Configurar canal",
-                            "channel": "configuracion",
-                            "action": "channel_config",
-                            "config": channel_parameters["channel"]}]
+                channel_parameters["has_settings"] = True
                 break
-
-        channel_parameters["context"] = context
 
         logger.info(channel_name+" -> "+repr(channel_parameters))
 

--- a/python/main-classic/core/channeltools.py
+++ b/python/main-classic/core/channeltools.py
@@ -105,6 +105,7 @@ def get_channel_parameters(channel_name):
                             "channel": "configuracion",
                             "action": "channel_config",
                             "config": channel_parameters["channel"]}]
+                break
 
         channel_parameters["context"] = context
 

--- a/python/main-classic/core/channeltools.py
+++ b/python/main-classic/core/channeltools.py
@@ -91,7 +91,6 @@ def get_channel_parameters(channel_name):
 
         # Obtenemos si el canal tiene opciones de configuración y lo añadimos al contexto
         context = ""
-        settings_list = []
         # esta regex devuelve 2 valores por elemento <settings>, el contenido del propio nodo y un \t, por lo que hay
         # posteriormente coger solo el valor del indice 0.
         matches = scrapertools.find_multiple_matches(data, "<settings>((.|\n)*?)<\/settings>")

--- a/python/main-classic/core/channeltools.py
+++ b/python/main-classic/core/channeltools.py
@@ -96,10 +96,7 @@ def get_channel_parameters(channel_name):
         # posteriormente coger solo el valor del indice 0.
         matches = scrapertools.find_multiple_matches(data, "<settings>((.|\n)*?)<\/settings>")
         for match in matches:
-            settings_list.append(match[0])
-
-        for setting in settings_list:
-            _id = scrapertools.find_single_match(setting, "<id>([^<]*)</id>")
+            _id = scrapertools.find_single_match(match[0], "<id>([^<]*)</id>")
             if _id and "include_in_" not in _id:
                 context = [{"title": "Configurar canal",
                             "channel": "configuracion",

--- a/python/main-classic/core/item.py
+++ b/python/main-classic/core/item.py
@@ -126,8 +126,6 @@ class InfoLabels(dict):
     def tostring(self, separador=', '):
         ls = []
         dic = dict(super(InfoLabels, self).items())
-        if 'mediatype' not in dic.keys():
-            dic['mediatype'] = self.__missing__('mediatype')
 
         for i in sorted(dic.items()):
             i_str = str(i)[1:-1]
@@ -191,14 +189,14 @@ class Item(object):
             value = self.decode_html(value)
 
         # Al modificar cualquiera de estos atributos content...
-        if name in ["contentTitle", "contentPlot", "contentSerieName", "contentType", "contentEpisodeTitle",
+        if name in ["contentTitle", "contentPlot", "plot", "contentSerieName", "contentType", "contentEpisodeTitle",
                     "contentSeason", "contentEpisodeNumber", "contentThumbnail", "show", "contentQuality"]:
             # ... marcamos hasContentDetails como "true"...
             self.__dict__["hasContentDetails"] = "true"
             # ...y actualizamos infoLables
             if name == "contentTitle":
                 self.__dict__["infoLabels"]["title"] = value
-            elif name == "contentPlot":
+            elif name == "contentPlot" or name == "plot":
                 self.__dict__["infoLabels"]["plot"] = value
             elif name == "contentSerieName" or name == "show":
                 self.__dict__["infoLabels"]["tvshowtitle"] = value
@@ -214,9 +212,6 @@ class Item(object):
                 self.__dict__["infoLabels"]["thumbnail"] = value
             elif name == "contentQuality":
                 self.__dict__["infoLabels"]["quality"] = value
-
-        elif name == "plot":
-            self.__dict__["infoLabels"]["plot"] = value
 
         elif name == "duration":
             # String q representa la duracion del video en segundos
@@ -326,11 +321,14 @@ class Item(object):
         dic = self.__dict__.copy()
 
         # Añadimos los campos content... si tienen algun valor
-        for key in ["contentTitle", "contentPlot", "contentSerieName", "contentType", "contentEpisodeTitle",
-                    "contentSeason", "contentEpisodeNumber", "contentThumbnail", "plot"]:
+        for key in ["contentTitle", "contentPlot", "contentSerieName", "contentEpisodeTitle",
+                    "contentSeason", "contentEpisodeNumber", "contentThumbnail"]:
             value = self.__getattr__(key)
             if value:
                 dic[key] = value
+
+        if 'mediatype' in self.__dict__["infoLabels"]:
+            dic["contentType"] = self.__dict__["infoLabels"]['mediatype']
 
         ls = []
         for var in sorted(dic):

--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -282,7 +282,7 @@ def run():
                     # TODO revisar 'personal.py' porque no tiene función search y daría problemas
                     itemlist = channel.search(item, tecleado)
                 else:
-                    itemlist = []
+                    return
 
                 platformtools.render_items(itemlist, item)
 

--- a/python/main-classic/platformcode/platformtools.py
+++ b/python/main-classic/platformcode/platformtools.py
@@ -344,8 +344,13 @@ def set_context_commands(item, parent_item):
                 command["from_action"] = item.action
             if "channel" in command:
                 command["from_channel"] = item.channel
-            context_commands.append(
-                (command["title"], "XBMC.RunPlugin(%s?%s)" % (sys.argv[0], item.clone(**command).tourl())))
+
+            if "goto" in command:
+                context_commands.append((command["title"], "XBMC.Container.Refresh (%s?%s)" %
+                                         (sys.argv[0], item.clone(**command).tourl())))
+            else:
+                context_commands.append(
+                    (command["title"], "XBMC.RunPlugin(%s?%s)" % (sys.argv[0], item.clone(**command).tourl())))
 
     # Opciones segun criterios, solo si el item no es un tag (etiqueta), ni es "Añadir a la biblioteca", etc...
     if item.action and item.action not in ["add_pelicula_to_library", "add_serie_to_library", "buscartrailer"]:

--- a/python/main-classic/platformcode/platformtools.py
+++ b/python/main-classic/platformcode/platformtools.py
@@ -350,7 +350,7 @@ def set_context_commands(item, parent_item):
     # Opciones segun criterios, solo si el item no es un tag (etiqueta), ni es "Añadir a la biblioteca", etc...
     if item.action and item.action not in ["add_pelicula_to_library", "add_serie_to_library", "buscartrailer"]:
         # Mostrar informacion: si el item tiene plot suponemos q es una serie, temporada, capitulo o pelicula
-        if item.infoLabels['plot'] and not item.contentType:
+        if item.infoLabels['plot'] and not item.viewmode:
             context_commands.append(("Información", "XBMC.Action(Info)"))
 
         # ExtendedInfo: Si esta instalado el addon y se cumplen una serie de condiciones

--- a/python/main-classic/platformcode/platformtools.py
+++ b/python/main-classic/platformcode/platformtools.py
@@ -265,21 +265,22 @@ def set_infolabels(listitem, item, player=False):
     @param item: objeto Item que representa a una pelicula, serie o capitulo
     @type item: item
     """
-    if item.infoLabels:
-      listitem.setInfo("video", item.infoLabels)
+    if 'mediatype' not in item.infoLabels:
+        item.infoLabels['mediatype'] = item.contentType
+        listitem.setInfo("video", item.infoLabels)
       
     if player and not item.contentTitle:
         if item.fulltitle:
-          listitem.setInfo("video", {"Title": item.fulltitle})
+            listitem.setInfo("video", {"Title": item.fulltitle})
         else:
-          listitem.setInfo("video", {"Title": item.title})
+            listitem.setInfo("video", {"Title": item.title})
           
     elif not player:
         listitem.setInfo("video", {"Title": item.title})
         
     # Añadido para Kodi Krypton (v17)
     if config.get_platform(True)['num_version'] >= 17.0:
-      listitem.setArt({"poster": item.thumbnail})
+        listitem.setArt({"poster": item.thumbnail})
 
 
 def set_context_commands(item, parent_item):
@@ -355,7 +356,7 @@ def set_context_commands(item, parent_item):
     # Opciones segun criterios, solo si el item no es un tag (etiqueta), ni es "Añadir a la biblioteca", etc...
     if item.action and item.action not in ["add_pelicula_to_library", "add_serie_to_library", "buscartrailer"]:
         # Mostrar informacion: si el item tiene plot suponemos q es una serie, temporada, capitulo o pelicula
-        if item.infoLabels['plot'] and not item.viewmode:
+        if item.infoLabels['plot'] and (num_version_xbmc < 17.0 or item.contentType == 'season'):
             context_commands.append(("Información", "XBMC.Action(Info)"))
 
         # ExtendedInfo: Si esta instalado el addon y se cumplen una serie de condiciones

--- a/python/main-classic/platformcode/platformtools.py
+++ b/python/main-classic/platformcode/platformtools.py
@@ -350,11 +350,12 @@ def set_context_commands(item, parent_item):
     # Opciones segun criterios, solo si el item no es un tag (etiqueta), ni es "Añadir a la biblioteca", etc...
     if item.action and item.action not in ["add_pelicula_to_library", "add_serie_to_library", "buscartrailer"]:
         # Mostrar informacion: si el item tiene plot suponemos q es una serie, temporada, capitulo o pelicula
-        if item.infoLabels['plot']:
+        if item.infoLabels['plot'] and not item.contentType:
             context_commands.append(("Información", "XBMC.Action(Info)"))
 
         # ExtendedInfo: Si esta instalado el addon y se cumplen una serie de condiciones
-        if xbmc.getCondVisibility('System.HasAddon(script.extendedinfo)') and config.get_setting("extended_info") == "true":
+        if xbmc.getCondVisibility('System.HasAddon(script.extendedinfo)') \
+                and config.get_setting("extended_info") == "true":
             if item.contentType == "episode" and item.contentEpisodeNumber and item.contentSeason \
                     and (item.infoLabels['tmdb_id'] or item.contentSerieName):
                 param = "tvshow_id =%s, tvshow=%s, season=%s, episode=%s" \
@@ -403,7 +404,8 @@ def set_context_commands(item, parent_item):
                                     item.action in ["update_biblio"]) and not parent_item.channel == "favoritos"):
             context_commands.append((config.get_localized_string(30155), "XBMC.RunPlugin(%s?%s)" %
                                      (sys.argv[0], item.clone(channel="favoritos", action="addFavourite",
-                                                              from_channel=item.channel, from_action=item.action).tourl())))
+                                                              from_channel=item.channel,
+                                                              from_action=item.action).tourl())))
 
         if item.channel != "biblioteca":
             # Añadir Serie a la biblioteca
@@ -422,26 +424,30 @@ def set_context_commands(item, parent_item):
             if item.contentType == "movie" and item.contentTitle:
                 context_commands.append(("Descargar Pelicula", "XBMC.RunPlugin(%s?%s)" %
                                          (sys.argv[0], item.clone(channel="descargas", action="save_download",
-                                                            from_channel=item.channel, from_action=item.action).tourl())))
+                                                                  from_channel=item.channel, from_action=item.action)
+                                          .tourl())))
 
             elif item.contentSerieName:
                 # Descargar serie
                 if item.contentType == "tvshow":
                     context_commands.append(("Descargar Serie", "XBMC.RunPlugin(%s?%s)" %
                                              (sys.argv[0], item.clone(channel="descargas", action="save_download",
-                                                                from_channel=item.channel, from_action=item.action).tourl())))
+                                                                      from_channel=item.channel,
+                                                                      from_action=item.action).tourl())))
 
                 # Descargar episodio
                 if item.contentType == "episode":
                     context_commands.append(("Descargar Episodio", "XBMC.RunPlugin(%s?%s)" %
                                              (sys.argv[0], item.clone(channel="descargas", action="save_download",
-                                                                 from_channel=item.channel, from_action=item.action).tourl())))
+                                                                      from_channel=item.channel,
+                                                                      from_action=item.action).tourl())))
 
                 # Descargar temporada
                 if item.contentType == "season":
                     context_commands.append(("Descargar Temporada", "XBMC.RunPlugin(%s?%s)" %
                                              (sys.argv[0], item.clone(channel="descargas", action="save_download",
-                                                                from_channel=item.channel, from_action=item.action).tourl())))
+                                                                      from_channel=item.channel,
+                                                                      from_action=item.action).tourl())))
 
         # Abrir configuración
         if parent_item.channel not in ["configuracion", "novedades", "buscador"]:
@@ -455,7 +461,6 @@ def set_context_commands(item, parent_item):
         context_commands.append(("Super Favourites Menu",
                                  "XBMC.RunScript(special://home/addons/plugin.program.super.favourites/LaunchSFMenu.py)"))
 
-    #context_commands.append((item.contentType, "XBMC.Action(Info)")) # For debug
     return sorted(context_commands, key=lambda comand: comand[0])
 
 
@@ -465,7 +470,7 @@ def is_playing():
 
 def play_video(item, strm=False):
     logger.info("pelisalacarta.platformcode.platformtools play_video")
-    #logger.debug(item.tostring('\n'))
+    # logger.debug(item.tostring('\n'))
 
     if item.channel == 'descargas':
         logger.info("Reproducir video local: %s [%s]" % (item.title, item.url))

--- a/python/main-classic/platformcode/platformtools.py
+++ b/python/main-classic/platformcode/platformtools.py
@@ -265,8 +265,9 @@ def set_infolabels(listitem, item, player=False):
     @param item: objeto Item que representa a una pelicula, serie o capitulo
     @type item: item
     """
-    if 'mediatype' not in item.infoLabels:
-        item.infoLabels['mediatype'] = item.contentType
+    if item.infoLabels:
+        if 'mediatype' not in item.infoLabels:
+            item.infoLabels['mediatype'] = item.contentType
         listitem.setInfo("video", item.infoLabels)
       
     if player and not item.contentTitle:
@@ -1090,7 +1091,6 @@ def play_torrent(item, xlistitem, mediaurl):
                 import traceback
                 logger.info(traceback.format_exc())
                 break
-            
 
         progreso.update(100, "Terminando y eliminando datos", " ", " ")
 


### PR DESCRIPTION
Añadida opción para permitir configurar canales desde el menú contextual (Atajo) y no tener que ir a la parte de configuración del addon.

## Canal con opción:
![image](https://cloud.githubusercontent.com/assets/11775029/23405158/4a2bb256-fdb9-11e6-9d06-39007332febe.png)

## Si el canal no tiene esa opción no se muestra:
![image](https://cloud.githubusercontent.com/assets/11775029/23405172/54162274-fdb9-11e6-8e0a-609bfcc2fddd.png)

Gracias a @superberny70 por la sugerencia.