### PR TITLE
fix biblioteca xbmc 12

### DIFF
--- a/python/main-classic/core/library.py
+++ b/python/main-classic/core/library.py
@@ -214,9 +214,9 @@ def save_library_movie(item):
 
     if not strm_exists:
         # Crear base_name.strm si no existe
-        item_strm = item.clone(channel='biblioteca', action='play_from_library',
+        item_strm = Item(channel='biblioteca', action='play_from_library',
                                strm_path=strm_path.replace(MOVIES_PATH, ""), contentType='movie',
-                               infoLabels={'title': item.contentTitle})
+                               contentTitle = item.contentTitle})
         strm_exists = filetools.write(strm_path, '%s?%s' % (addon_name, item_strm.tourl()))
         item_nfo.strm_path = strm_path.replace(MOVIES_PATH, "")
 

--- a/python/main-classic/core/library.py
+++ b/python/main-classic/core/library.py
@@ -216,7 +216,7 @@ def save_library_movie(item):
         # Crear base_name.strm si no existe
         item_strm = Item(channel='biblioteca', action='play_from_library',
                                strm_path=strm_path.replace(MOVIES_PATH, ""), contentType='movie',
-                               contentTitle = item.contentTitle})
+                               contentTitle = item.contentTitle)
         strm_exists = filetools.write(strm_path, '%s?%s' % (addon_name, item_strm.tourl()))
         item_nfo.strm_path = strm_path.replace(MOVIES_PATH, "")
 

--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -519,7 +519,7 @@ def play_from_library(item):
     import xbmc
     # Intentamos reproducir una imagen (esto no hace nada y ademas no da error)
     xbmcplugin.setResolvedUrl(int(sys.argv[1]), True,
-                              xbmcgui.ListItem(path=os.path.join(config.get_runtime_path(), "icon.png")))
+                              xbmcgui.ListItem(path=os.path.join(config.get_runtime_path(), "resources", "subtitle.mp4")))
 
     # Por si acaso la imagen hiciera (en futuras versiones) le damos a stop para detener la reproduccion
     xbmc.Player().stop()

--- a/python/main-classic/platformcode/platformtools.py
+++ b/python/main-classic/platformcode/platformtools.py
@@ -76,9 +76,13 @@ def dialog_progress(heading, line1, line2=" ", line3=" "):
 
 
 def dialog_progress_bg(heading, message=""):
-    dialog = xbmcgui.DialogProgressBG()
-    dialog.create(heading, message)
-    return dialog
+    try:
+      dialog = xbmcgui.DialogProgressBG()
+      dialog.create(heading, message)
+      return dialog
+    except:
+      return dialog_progress(heading, message)
+      
 
 
 def dialog_input(default="", heading="", hidden=False):

--- a/python/main-classic/platformcode/xbmc_info_window.py
+++ b/python/main-classic/platformcode/xbmc_info_window.py
@@ -239,7 +239,7 @@ class InfoWindow(xbmcgui.WindowXMLDialog):
         focus = self.getFocusId()
 
         # Accion 1: Flecha izquierda
-        if action == xbmcgui.ACTION_MOVE_LEFT:
+        if action == 1:
 
             if focus == ID_BUTTON_OK:
                 self.setFocus(self.getControl(ID_BUTTON_CANCEL))
@@ -258,7 +258,7 @@ class InfoWindow(xbmcgui.WindowXMLDialog):
                     self.setFocus(self.getControl(ID_BUTTON_PREVIOUS))
 
         # Accion 2: Flecha derecha
-        elif action == xbmcgui.ACTION_MOVE_RIGHT:
+        elif action == 2:
 
             if focus == ID_BUTTON_PREVIOUS:
                 if self.indexList + 1 != len(self.listData):
@@ -275,5 +275,5 @@ class InfoWindow(xbmcgui.WindowXMLDialog):
                 self.setFocus(self.getControl(ID_BUTTON_OK))
 
         # Pulsa ESC o Atrás, simula click en boton cancelar
-        if action in [xbmcgui.ACTION_PREVIOUS_MENU, xbmcgui.ACTION_NAV_BACK]:
+        if action in [10, 92]:
             self.onClick(ID_BUTTON_CANCEL)


### PR DESCRIPTION
Corregido problema que comentaba un usuario en :
http://www.mimediacenter.info/foro/viewtopic.php?f=22&t=8527&start=250#p40465

- Se ha puesto un try except en dialog_progress_bg que en caso de fallo muestra un dialog_progress porque en versiones antiguas el primero no esta disponible
- Se usan números absolutos para los ID de las acciones en info_window porque en versiones antiguas las constantes definidas en xbmcgui no existen
- Se limita la cantidad de información en el .strm (para películas) ya que .strm mas grande de 1kb no se cargan en versiones antiguas
- Modificado el sistema para "engañar" a xbmc al reproducir un strm (antes se intentaba reproducir un archivo de imagen para que xbmc se callara) pero en versiones antiguas muestra un mensaje de error, así que modifico la ruta para que reproduzca el archivo "subtitle.mp4" que se encuentra en resources y de este modo no da error.