### PR TITLE
Continuacion de #669

### DIFF
--- a/python/main-classic/core/config.py
+++ b/python/main-classic/core/config.py
@@ -280,6 +280,6 @@ def verify_directories_created():
         content_path = filetools.join(get_library_path(), saved_path)
         if not filetools.exists(content_path):
             logger.debug("Creating %s: %s" % (path, content_path))
-            if filetools.mkdir(content_path):
-                xbmc_library.establecer_contenido(default, saved_path)
+            if filetools.mkdir(content_path) and get_setting("set_content")== "true":
+                xbmc_library.set_content(default, saved_path)
 

--- a/python/main-classic/platformcode/xbmc_library.py
+++ b/python/main-classic/platformcode/xbmc_library.py
@@ -340,7 +340,7 @@ def search_library_path():
     return None
 
 
-def establecer_contenido(content_type, silent=False):
+def set_content(content_type, silent=False):
     """
     Procedimiento para auto-configurar la biblioteca de kodi con los valores por defecto
     @type content_type: str ('CINE' o 'SERIES')
@@ -461,10 +461,13 @@ def establecer_contenido(content_type, silent=False):
                 idPath = records[0][0] + 1
 
             sql_librarypath = librarypath
-            sep = os.sep
             if sql_librarypath.startswith("special://"):
-                sql_librarypath = librarypath.replace('/profile/', '/%/').replace('/home/userdata/', '/%/')
+                sql_librarypath = sql_librarypath.replace('/profile/', '/%/').replace('/home/userdata/', '/%/')
                 sep = '/'
+            elif sql_librarypath.startswith("smb://"):
+                sep = '/'
+            else:
+                sep = os.sep
 
             if not sql_librarypath.endswith(sep):
                 sql_librarypath += sep

--- a/python/main-classic/resources/settings.xml
+++ b/python/main-classic/resources/settings.xml
@@ -124,6 +124,7 @@
         <setting label="Nombre de carpetas" type="lsep"/>
         <setting id="folder_tvshows" type="text" label="Series" default="SERIES"/>
         <setting id="folder_movies" type="text" label="Peliculas" default="CINE"/>
+        <setting id="set_content" type="bool" label="Autoconfigurar la biblioteca" default="true"/>
     </category>
 
     <category label="Otros"><!--30503 -->


### PR DESCRIPTION
Disculpar pero se me habia quedado un commit sin enviar...
- cambio de nombre establecer_contenido por set_content
- Añadida opcion en Preferencias - Rutas para deshabilitar el autoconfigurador de la biblioteca (para casos especiales)
- Ahora el autoconfigurador tambien funciona con rutas samba