### PR TITLE
Fix para enlaces directo en formato list

### DIFF
--- a/python/main-classic/channels/biblioteca.py
+++ b/python/main-classic/channels/biblioteca.py
@@ -432,6 +432,11 @@ def play(item):
     else:
         itemlist = [item.clone(url=item.strm_path, server="local")]
 
+    # Para enlaces directo en formato lista
+    if isinstance(itemlist[0], list):
+        item.video_urls = itemlist
+        itemlist = [item]
+
     # Esto es necesario por si el play del canal elimina los datos
     for v in itemlist:
         if isinstance(v, Item):


### PR DESCRIPTION
Y que se reproducen directamente desde el widget del Home del skin (ej. Xonfluence) en canales como inkapelis, peliculasnu, etc... Antes daba error al pasarle el list con los enlaces sin convertirlo a Item.

http://www.mimediacenter.info/foro/viewtopic.php?f=22&t=8803