### PR TITLE
Reparado descargasmix y gamovideo

### DIFF
--- a/python/main-classic/channels/descargasmix.py
+++ b/python/main-classic/channels/descargasmix.py
@@ -301,8 +301,9 @@ def epienlaces(item):
 
 def findvideos(item):
     logger.info()
-    if item.extra and item.extra != "findvideos":
+    if (item.extra and item.extra != "findvideos") or item.path:
         return epienlaces(item)
+
     itemlist = []
     item.text_color = color3
 
@@ -502,7 +503,7 @@ def get_data(url_orig):
     except:
         import random
         server_random = ['nl', 'de', 'us']
-        url = "https://proxy-%s.hideproxy.me/includes/process.php?action=update" % server_random[random.randint(0, 2)]
+        url = "https://%s.hideproxy.me/includes/process.php?action=update" % server_random[random.randint(0, 2)]
         post = "u=%s&proxy_formdata_server=%s&allowCookies=1&encodeURL=0&encodePage=0&stripObjects=0&stripJS=0&go=" \
                % (url_orig, server_random[random.randint(0, 2)])
         while True:

--- a/python/main-classic/channels/descargasmix.xml
+++ b/python/main-classic/channels/descargasmix.xml
@@ -6,7 +6,7 @@
 	<update_url></update_url>
 	<active>true</active>
 		
-	<version>6</version>
+	<version>7</version>
 	<adult>false</adult>
 
 	<changes>

--- a/python/main-classic/servers/gamovideo.py
+++ b/python/main-classic/servers/gamovideo.py
@@ -12,10 +12,12 @@ from core import logger
 from core import scrapertools
 from lib import jsunpack
 
+headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:51.0) Gecko/20100101 Firefox/51.0'}
+
 
 def test_video_exists(page_url):
     logger.info("(page_url='%s')" % page_url)
-    data = httptools.downloadpage(page_url).data
+    data = httptools.downloadpage(page_url, headers=headers).data
 
     if ("File was deleted" or "Not Found" or "File was locked by administrator") in data:
         return False, "[Gamovideo] El archivo no existe o ha sido borrado"
@@ -25,8 +27,8 @@ def test_video_exists(page_url):
 
 def get_video_url(page_url, premium=False, user="", password="", video_password=""):
     logger.info("(page_url='%s')" % page_url)
+    data = httptools.downloadpage(page_url, headers=headers).data
 
-    data = httptools.downloadpage(page_url).data
     packer = scrapertools.find_single_match(data,
                                             "<script type='text/javascript'>(eval.function.p,a,c,k,e,d..*?)</script>")
     if packer != "":
@@ -37,13 +39,13 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
 
     data = re.sub(r'\n|\t|\s+', '', data)
 
-    host = scrapertools.get_match(data, '\[\{image:"(http://[^/]+/)')
-    mediaurl = scrapertools.get_match(data, ',\{file:"([^"]+)"')
+    host = scrapertools.find_single_match(data, '\[\{image:"(http://[^/]+/)')
+    mediaurl = scrapertools.find_single_match(data, ',\{file:"([^"]+)"')
     if not mediaurl.startswith(host):
         mediaurl = host + mediaurl
-
-    rtmp_url = scrapertools.get_match(data, 'file:"(rtmp[^"]+)"')
-    playpath = scrapertools.get_match(rtmp_url, 'vod\?h=[\w]+/(.*$)')
+   
+    rtmp_url = scrapertools.find_single_match(data, 'file:"(rtmp[^"]+)"')
+    playpath = scrapertools.find_single_match(rtmp_url, 'vod\?h=[\w]+/(.*$)')
     rtmp_url = rtmp_url.split(playpath)[
                    0] + " playpath=" + playpath + " swfUrl=http://gamovideo.com/player61/jwplayer.flash.swf"
 

--- a/python/main-classic/servers/gamovideo.xml
+++ b/python/main-classic/servers/gamovideo.xml
@@ -1,13 +1,24 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Modificado orden de los videos</changes>
-	<date>07/11/2016</date>
+	<version>3</version>
+	<changes>
+		<change>
+			<date>23/03/17</date>
+			<autor>Cmos</autor>
+			<description>Arreglado con el cambio de user agent</description>
+		</change>
+		<change>
+			<date>07/11/16</date>
+			<autor>Cmos</autor>
+			<description>Modificado orden de los videos</description>
+		</change>
+	</changes>
+
 	<free>true</free>
 	<id>gamovideo</id>
 	<name>gamovideo</name>
 	<premium></premium>
 	<thumbnail>http://media.tvalacarta.info/servers/server_gamovideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>2</version>
 </server>


### PR DESCRIPTION
- Descargasmix: cambios en el proxy que usa para versiones no compatibles con https
- Gamovideo: actualizado user-agent ya que falla con el que trae por defecto httptools