### PR TITLE
Comprobacion y creación de carpetas para los xml según el skin

### DIFF
--- a/python/build.xml
+++ b/python/build.xml
@@ -188,44 +188,6 @@
             </fileset>
         </copy>
 
-        <!-- Duplicate skin files in other resolutions -->
-        <mkdir dir="${target_base_folder}/${target_platform_folder}/plugin.video.pelisalacarta/resources/skins/Default/1080i"/>
-        <mkdir dir="${target_base_folder}/${target_platform_folder}/plugin.video.pelisalacarta/resources/skins/Default/NTSC16x9"/>
-        <mkdir dir="${target_base_folder}/${target_platform_folder}/plugin.video.pelisalacarta/resources/skins/Default/NTSC"/>
-        <mkdir dir="${target_base_folder}/${target_platform_folder}/plugin.video.pelisalacarta/resources/skins/Default/PAL16x9"/>
-        <mkdir dir="${target_base_folder}/${target_platform_folder}/plugin.video.pelisalacarta/resources/skins/Default/PAL"/>
-        <mkdir dir="${target_base_folder}/${target_platform_folder}/plugin.video.pelisalacarta/resources/skins/Default/xml"/>
-
-        <copy todir="${target_base_folder}/${target_platform_folder}/plugin.video.pelisalacarta/resources/skins/Default/1080i">
-            <fileset dir="main-classic/resources/skins/Default/720p">
-            </fileset>
-        </copy>
-
-        <copy todir="${target_base_folder}/${target_platform_folder}/plugin.video.pelisalacarta/resources/skins/Default/NTSC16x9">
-            <fileset dir="main-classic/resources/skins/Default/720p">
-            </fileset>
-        </copy>
-
-        <copy todir="${target_base_folder}/${target_platform_folder}/plugin.video.pelisalacarta/resources/skins/Default/NTSC">
-            <fileset dir="main-classic/resources/skins/Default/720p">
-            </fileset>
-        </copy>
-
-        <copy todir="${target_base_folder}/${target_platform_folder}/plugin.video.pelisalacarta/resources/skins/Default/PAL16x9">
-            <fileset dir="main-classic/resources/skins/Default/720p">
-            </fileset>
-        </copy>
-
-        <copy todir="${target_base_folder}/${target_platform_folder}/plugin.video.pelisalacarta/resources/skins/Default/PAL">
-            <fileset dir="main-classic/resources/skins/Default/720p">
-            </fileset>
-        </copy>
-     
-        <copy todir="${target_base_folder}/${target_platform_folder}/plugin.video.pelisalacarta/resources/skins/Default/xml">
-            <fileset dir="main-classic/resources/skins/Default/720p">
-            </fileset>
-        </copy>
-
         <!-- Builds zip file -->
         <zip destfile="${target_base_folder}/pelisalacarta-${target_platform_name}-${version}.zip" basedir="${target_base_folder}/${target_platform_folder}"/>
 


### PR DESCRIPTION
Se realiza en cada inicio junto con la comprobación de carpetas predefinidas del addon. Se consulta la carpeta por defecto que indique el skin activo y si no existe o los archivos en su interior no concuerdan con la carpeta 720p, se crea/copian.

Comentado en el foro: http://www.mimediacenter.info/foro/viewtopic.php?f=6&t=12234&p=46493#p46474