### PR TITLE
Servertools

### DIFF
--- a/python/main-classic/channels/allpeliculas.py
+++ b/python/main-classic/channels/allpeliculas.py
@@ -265,8 +265,12 @@ def findvideos(item):
     matches = scrapertools.find_multiple_matches(data, patron)
     for calidad, servidor_num, language, url in matches:
 
-        if servidor_num == '94':
+        if servidor_num == '94' and not 'stormo.tv' in url:
             url = "http://tusfiles.org/?%s" % url
+            
+        if 'vimeo' in url:
+            url += "|" + item.url
+                
                 
         idioma = IDIOMAS.get(idiomas_videos.get(language))
         titulo = "%s  ["+idioma+"] ["+calidad_videos.get(calidad)+"]"
@@ -386,9 +390,12 @@ def findvideostv(item):
     matches = scrapertools.find_multiple_matches(data, patron)
     for quality, servidor_num, language, url in matches:
     
-        if servidor_num == '94':
+        if servidor_num == '94' and not 'stormo.tv' in url:
             url = "http://tusfiles.org/?%s" % url
             
+        if 'vimeo' in url:
+                url += "|" + item.url
+                
         idioma = IDIOMAS.get(idiomas_videos.get(language))
         titulo = "%s ["+idioma+"] ("+calidad_videos.get(quality)+")"
 

--- a/python/main-classic/channels/ayuda.py
+++ b/python/main-classic/channels/ayuda.py
@@ -122,8 +122,8 @@ def mainlist(item):
         from core import channeltools
         title = "Activar cuenta real-debrid (No activada)"
         action = "realdebrid"
-        token_auth = channeltools.get_channel_setting("realdebrid_token", "realdebrid")
-        if config.get_setting("realdebridpremium") == False:
+        token_auth = config.get_setting("token", server="realdebrid")
+        if not config.get_setting("premium", server="realdebrid"):
             title = "Activar cuenta real-debrid (Marca la casilla en la ventana de configuración de pelisalacarta para continuar)"
             action = ""
         elif token_auth:
@@ -627,10 +627,10 @@ def authentication(item):
         token = data["access_token"]
         refresh = data["refresh_token"]
 
-        channeltools.set_channel_setting("realdebrid_id", debrid_id, "realdebrid")
-        channeltools.set_channel_setting("realdebrid_secret", secret, "realdebrid")
-        channeltools.set_channel_setting("realdebrid_token", token, "realdebrid")
-        channeltools.set_channel_setting("realdebrid_refresh", refresh, "realdebrid")
+        config.set_setting("id", debrid_id, server="realdebrid")
+        config.set_setting("secret", secret, server="realdebrid")
+        config.set_setting("token", token, server="realdebrid")
+        config.set_setting("refresh", refresh, server="realdebrid")
 
     except:
         import traceback

--- a/python/main-classic/channels/biblioteca.py
+++ b/python/main-classic/channels/biblioteca.py
@@ -377,6 +377,7 @@ def findvideos(item):
             # Ejecutamos find_videos, del canal o común
             if hasattr(channel, 'findvideos'):
                 list_servers = getattr(channel, 'findvideos')(item_json)
+                list_servers = servertools.filter_servers(list_servers)
             else:
                 from core import servertools
                 list_servers = servertools.find_video_items(item_json)

--- a/python/main-classic/channels/cinetux.py
+++ b/python/main-classic/channels/cinetux.py
@@ -315,39 +315,23 @@ def bloque_enlaces(data, filtro_idioma, dict_idiomas, type, item):
     for match in matches:
         scrapedurl = match[0]
         language = match[2].strip()
-        if not match[1]:
-            server = servertools.get_server_from_url(scrapedurl)
-            title = "   Mirror en " + server + " (" + language + ")"
-        else:
-            server = match[1].lower()
-            if server == "uploaded":
-                server = "uploadedto"
-            elif server == "streamin":
-                server = "streaminto"
-            elif server == "netu":
-                server = "netutv"
-            mostrar_server = True
-            if config.get_setting("hidepremium"):
-                mostrar_server = servertools.is_server_enabled(server)
-            if mostrar_server:
-                try:
-                    servers_module = __import__("servers." + server)
-                except:
-                    pass
-            title = "   Mirror en " + server + " (" + language + ") (Calidad " + match[3].strip() + ")"
+        title = "   Mirror en %s (" + language + ")"
+        if len(match) == 4:
+            title += " (Calidad " + match[3].strip() + ")"
 
         if filtro_idioma == 3 or item.filtro:
-            lista_enlaces.append(item.clone(title=title, action="play", server=server, text_color=color2,
+            lista_enlaces.append(item.clone(title=title, action="play", text_color=color2,
                                             url=scrapedurl, idioma=language, extra=item.url))
         else:
             idioma = dict_idiomas[language]
             if idioma == filtro_idioma:
                 lista_enlaces.append(item.clone(title=title, text_color=color2, action="play",  url=scrapedurl,
-                                                server=server, extra=item.url))
+                                                extra=item.url))
             else:
                 if language not in filtrados:
                     filtrados.append(language)
-
+    
+    lista_enlaces = servertools.get_servers_itemlist(lista_enlaces, lambda i: i.title % i.server)
     if filtro_idioma != 3:
         if len(filtrados) > 0:
             title = "Mostrar enlaces filtrados en %s" % ", ".join(filtrados)
@@ -374,8 +358,5 @@ def play(item):
             for v in video_urls:
                 itemlist.append([v[0], v[1]])
     else:
-        enlace = servertools.findvideosbyserver(item.url, item.server)
-        url = enlace[0][1]
-        itemlist.append(item.clone(url=url))
-
+        return [item]
     return itemlist

--- a/python/main-classic/channels/configuracion.py
+++ b/python/main-classic/channels/configuracion.py
@@ -61,6 +61,10 @@ def mainlist(item):
 
     itemlist.append(Item(channel=CHANNELNAME, title="Ajustes especiales", action="", folder=False,
                          thumbnail=get_thumbnail_path("thumb_configuracion_0.png")))
+    itemlist.append(Item(channel=CHANNELNAME, title="   Ajustes de Canales", action="menu_channels",
+                         folder=True, thumbnail=get_thumbnail_path("thumb_canales.png")))
+    itemlist.append(Item(channel=CHANNELNAME, title="   Ajustes de Servidores", action="menu_servers",
+                         folder=True, thumbnail=get_thumbnail_path("thumb_canales.png")))
     itemlist.append(Item(channel="novedades", title="   Ajustes de la sección 'Novedades'", action="menu_opciones",
                          folder=True, thumbnail=get_thumbnail_path("thumb_novedades.png")))
     itemlist.append(Item(channel="buscador", title="   Ajustes del buscador global", action="opciones", folder=True,
@@ -72,18 +76,27 @@ def mainlist(item):
         itemlist.append(Item(channel="biblioteca", title="   Ajustes de la biblioteca",
                              action="channel_config", folder=True,
                              thumbnail=get_thumbnail_path("thumb_biblioteca.png")))
-        itemlist.append(Item(channel="biblioteca", action="update_biblio", folder=False,
-                             thumbnail=get_thumbnail_path("thumb_biblioteca.png"),
-                             title="   Buscar nuevos episodios y actualizar biblioteca"))
 
     itemlist.append(Item(channel=CHANNELNAME, title="   Añadir o Actualizar canal/conector desde una URL",
                          action="menu_addchannels"))
     itemlist.append(Item(channel=CHANNELNAME, action="", title="", folder=False,
                          thumbnail=get_thumbnail_path("thumb_configuracion_0.png")))
+    itemlist.append(Item(channel=CHANNELNAME, title="Otras herramientas", action="submenu_tools",
+                         folder=True, thumbnail=get_thumbnail_path("thumb_configuracion_0.png")))
+    
+
+    return itemlist
+
+
+
+def menu_channels(item):
+    logger.info()
+    itemlist = list()
 
     itemlist.append(Item(channel=CHANNELNAME, title="Activar/desactivar canales",
                          action="conf_tools", folder=False, extra="channels_onoff",
                          thumbnail=get_thumbnail_path("thumb_configuracion_0.png")))
+
     itemlist.append(Item(channel=CHANNELNAME, title="Ajustes por canales",
                          action="", folder=False,
                          thumbnail=get_thumbnail_path("thumb_configuracion_0.png")))
@@ -91,6 +104,7 @@ def mainlist(item):
     # Inicio - Canales configurables
     import channelselector
     from core import channeltools
+
     channel_list = channelselector.filterchannels("all")
 
     for channel in channel_list:
@@ -104,8 +118,14 @@ def mainlist(item):
 
     itemlist.append(Item(channel=CHANNELNAME, action="", title="", folder=False,
                          thumbnail=get_thumbnail_path("thumb_configuracion_0.png")))
-    itemlist.append(Item(channel=CHANNELNAME, title="Otras herramientas", action="submenu_tools",
-                         folder=True, thumbnail=get_thumbnail_path("thumb_configuracion_0.png")))
+
+    itemlist.append(Item(channel=CHANNELNAME, title="Herramientas de canales", action="",
+                         folder=False, thumbnail=get_thumbnail_path("thumb_canales.png")))
+    itemlist.append(Item(channel=CHANNELNAME, title="   Comprobar archivos *_data.json",
+                         action="conf_tools", folder=True, extra="lib_check_datajson",
+                         thumbnail=get_thumbnail_path("thumb_canales.png")))
+
+    
 
     return itemlist
 
@@ -114,7 +134,134 @@ def channel_config(item):
     return platformtools.show_channel_settings(channelpath=filetools.join(config.get_runtime_path(), "channels",
                                                                           item.config))
 
+def menu_servers(item):
+    logger.info()
+    itemlist = list()
 
+    itemlist.append(Item(channel=CHANNELNAME, title="Sevidores bloqueados",
+                         action="servers_blacklist", folder=False,
+                         thumbnail=get_thumbnail_path("thumb_configuracion_0.png")))
+                         
+    itemlist.append(Item(channel=CHANNELNAME, title="Servidores favoritos",
+                         action="servers_whitelist", folder=False,
+                         thumbnail=get_thumbnail_path("thumb_configuracion_0.png")))
+    
+    itemlist.append(Item(channel=CHANNELNAME, title="Ajustes de debriders:",
+                         action="", folder=False,
+                         thumbnail=get_thumbnail_path("thumb_configuracion_0.png")))
+
+    
+    # Inicio - Servidores configurables
+    from core import servertools
+
+    server_list = servertools.get_debriders_list().keys()
+    for server in server_list:
+        server_parameters = servertools.get_server_parameters(server)
+        if server_parameters["has_settings"]:
+            itemlist.append(Item(channel=CHANNELNAME, title="   Configuración del servidor '%s'" % server_parameters["name"],
+                                 action="server_config", config=server, folder=False,
+                                 thumbnail=""))
+                                 
+    itemlist.append(Item(channel=CHANNELNAME, title="Ajustes de servidores",
+                         action="", folder=False,
+                         thumbnail=get_thumbnail_path("thumb_configuracion_0.png")))
+
+    server_list = servertools.get_servers_list().keys()
+
+    for server in server_list:
+        server_parameters = servertools.get_server_parameters(server)
+        logger.info(server_parameters)
+        if server_parameters["has_settings"] and filter(lambda x: x["id"] not in ["black_list", "white_list"], server_parameters["settings"]):
+            itemlist.append(Item(channel=CHANNELNAME, title="   Configuración del servidor '%s'" % server_parameters["name"],
+                                 action="server_config", config=server, folder=False,
+                                 thumbnail=""))
+                                 
+    # Fin - Servidores configurables
+
+    return itemlist
+    
+                                                                          
+def server_config(item):
+    return platformtools.show_channel_settings(channelpath=filetools.join(config.get_runtime_path(), "servers",
+                                                                          item.config))
+def servers_blacklist(item):
+    from core import servertools
+    server_list = servertools.get_servers_list().keys()
+    list_controls = []
+    dict_values = {}
+    for server in sorted(server_list):
+        server_parameters = servertools.get_server_parameters(server)
+        controls, defaults = servertools.get_server_controls_settings(server)
+        dict_values[server] = config.get_setting("black_list",server=server)
+        
+        control = {'id': server,
+                   'type': "bool",
+                   'label': server_parameters["name"],
+                   'default': defaults.get("black_list", False),
+                   'enabled': True,
+                   'visible': True}
+        list_controls.append(control)
+
+
+    return platformtools.show_channel_settings(list_controls=list_controls, dict_values=dict_values,
+                                               caption="Servidores bloqueados",
+                                               callback="cb_servers_blacklist")
+
+def cb_servers_blacklist(item, dict_values):
+    for k,v in dict_values.items():
+        config.set_setting("black_list", v,server=k)
+        
+def servers_whitelist(item):
+    from core import servertools
+    server_list = servertools.get_servers_list().keys()
+    list_controls = []
+    dict_values = {}
+    server_names = [['Ninguno', None]]
+    
+    for server in sorted(server_list):
+        if config.get_setting("black_list",server=server):
+            continue
+        
+        server_parameters = servertools.get_server_parameters(server)
+        server_names.append([server_parameters['name'], server])
+        
+        if config.get_setting("white_list",server=server):
+            dict_values[config.get_setting("white_list",server=server)] = len(server_names) -1
+        
+    
+    for x in range(1,6):
+        control = {'id': x,
+                   'type': "list",
+                   'label': "Servidor #%s" %(x),
+                   'lvalues': [s[0] for s in server_names],
+                   'default': 0,
+                   'enabled': True,
+                   'visible': True}
+        list_controls.append(control)
+
+
+    return platformtools.show_channel_settings(list_controls=list_controls, dict_values=dict_values, item=[s[1] for s in server_names],
+                                               caption="Servidores favoritos",
+                                               callback="cb_servers_whitelist")
+
+def cb_servers_whitelist(server_names, dict_values):
+    for index, server in enumerate(server_names):
+        if index == 0: #Ninguno
+            continue
+            
+        #Els servidor está seleccionado
+        if index in dict_values.values():
+            #Buscamos la posicion
+            for pos, value in dict_values.items():
+                if index == value:
+                    config.set_setting("white_list", pos, server=server)
+                    break
+        
+        #El Servidor no está seleccionado
+        else:
+            config.set_setting("white_list", False, server=server)
+        
+        
 def get_all_versions(item):
     logger.info()
 
@@ -385,11 +532,16 @@ def submenu_tools(item):
                          thumbnail=get_thumbnail_path("thumb_canales.png")))
 
     if config.get_library_support():
+        itemlist.append(Item(channel=CHANNELNAME, action="", title="", folder=False,
+                             thumbnail=get_thumbnail_path("thumb_configuracion_0.png")))
         itemlist.append(Item(channel=CHANNELNAME, title="Herramientas de biblioteca", action="",
                              folder=False, thumbnail=get_thumbnail_path("thumb_biblioteca.png")))
         itemlist.append(Item(channel=CHANNELNAME, action="overwrite_tools", folder=False,
                              thumbnail=get_thumbnail_path("thumb_biblioteca.png"),
                              title="   Sobreescribir toda la biblioteca (strm, nfo y json)"))
+        itemlist.append(Item(channel="biblioteca", action="update_biblio", folder=False,
+                             thumbnail=get_thumbnail_path("thumb_biblioteca.png"),
+                             title="   Buscar nuevos episodios y actualizar biblioteca"))
 
     return itemlist
 

--- a/python/main-classic/channels/cultmoviez.py
+++ b/python/main-classic/channels/cultmoviez.py
@@ -275,10 +275,7 @@ def findvideos(item):
 
     for server_id, video_id in servers_data_list:
         if server_id != "oid": server = server_label(server_id)
-        mostrar_server = True
-        if config.get_setting("hidepremium")==True:
-            mostrar_server= servertools.is_server_enabled (server)
-        if mostrar_server:
+        if servertools.is_server_enabled(server):
             try:
                 if server != "uptostream": servers_module = __import__("servers."+server)
                 video_link = server_link(server_id) % (video_id.replace("|","&"))

--- a/python/main-classic/channels/descargas.py
+++ b/python/main-classic/channels/descargas.py
@@ -568,12 +568,6 @@ def download_from_best_server(item, ask = False):
     play_items = filter(lambda x: x.action == "play", play_items)
 
     progreso.update(100, "Obteniendo lista de servidores disponibles.", "Servidores disponibles: %s" % len(play_items), "Identificando servidores...")
-    
-    for i in play_items:
-      if not i.server:
-        i.server = servertools.get_server_from_url(i.url)
-        if progreso.iscanceled():
-          return {"downloadStatus": STATUS_CODES.canceled}
         
     play_items.sort(key=sort_method)
     

--- a/python/main-classic/channels/descargasmix.py
+++ b/python/main-classic/channels/descargasmix.py
@@ -288,10 +288,7 @@ def epienlaces(item):
         if scrapedserver == "magnet":
             itemlist.insert(0, item.clone(action="play", title=titulo, server="torrent", url=scrapedurl, extra=item.url))
         else:
-            mostrar_server = True
-            if config.get_setting("hidepremium") == True:
-                mostrar_server = servertools.is_server_enabled(scrapedserver)
-            if mostrar_server:
+            if servertools.is_server_enabled(scrapedserver):
                 try:
                     servers_module = __import__("servers." + scrapedserver)
                     lista_enlaces.append(item.clone(action="play", title=titulo, server=scrapedserver, url=scrapedurl,
@@ -424,10 +421,7 @@ def findvideos(item):
                 itemlist.append(item.clone(action="play", server="torrent", title=title, url=scrapedurl,
                                            text_color="green"))
                 continue
-            mostrar_server = True
-            if config.get_setting("hidepremium") == True:
-                mostrar_server = servertools.is_server_enabled(scrapedserver)
-            if mostrar_server:
+            if servertools.is_server_enabled(scrapedserver):
                 try:
                     servers_module = __import__("servers." + scrapedserver)
                     # Saca numero de enlaces

--- a/python/main-classic/channels/newpct1.py
+++ b/python/main-classic/channels/newpct1.py
@@ -428,10 +428,7 @@ def findvideos(item):
     for logo, servidor, idioma, calidad, enlace, titulo in enlaces_ver:
         servidor = servidor.replace("streamin","streaminto")
         titulo = titulo+" ["+servidor+"]"
-        mostrar_server= True
-        if config.get_setting("hidepremium")=="true":
-            mostrar_server= servertools.is_server_enabled (servidor)
-        if mostrar_server:
+        if servertools.is_server_enabled(servidor):
             try:
                 servers_module = __import__("servers."+servidor)
                 server_module = getattr(servers_module,servidor)
@@ -449,10 +446,7 @@ def findvideos(item):
         for enlace in partes:
             parte_titulo = titulo+" (%s/%s)" % (p,len(partes)) + " ["+servidor+"]"
             p+= 1
-            mostrar_server= True
-            if config.get_setting("hidepremium")=="true":
-                mostrar_server= servertools.is_server_enabled (servidor)
-            if mostrar_server:
+            if servertools.is_server_enabled(servidor):
                 try:
                     servers_module = __import__("servers."+servidor)
                     server_module = getattr(servers_module,servidor)

--- a/python/main-classic/channels/peliculasnu.py
+++ b/python/main-classic/channels/peliculasnu.py
@@ -211,18 +211,12 @@ def findvideos(item):
         headers = {'X-Requested-With': 'XMLHttpRequest', 'Referer': item.url}
         data_url = httptools.downloadpage(host+'wp-admin/admin-ajax.php', post, headers=headers).data
         url = jsontools.load_json(data_url).get("url")
-        if "online.desmix" in url or "metiscs" in url:
-            server = "directo"
-        elif "openload" in url:
-            server = "openload"
-            url += "|Referer=" + item.url
-        else:
-            server = servertools.get_server_from_url(url)
-            if server == "directo":
-                continue
-        title = "%s - %s" % (unicode(server, "utf8").capitalize().encode("utf8"), title)
-        itemlist.append(item.clone(action="play", url=url, title=title, server=server, text_color=color3))
-
+        
+        title = "%s - %s" % ('%s', title)
+        itemlist.append(item.clone(action="play", url=url, title=title, text_color=color3))
+    
+    itemlist = servertools.get_servers_itemlist(itemlist, lambda i: i.title % i.server.capitalize())
+    
     if item.extra != "findvideos" and config.get_library_support():
         itemlist.append(item.clone(title="Añadir película a la biblioteca", action="add_pelicula_to_library",
                                    extra="findvideos", text_color="green"))
@@ -273,8 +267,6 @@ def play(item):
             title = ".%s %s [directo]" % (extension, calidad)
             itemlist.insert(0, [title, url, 0, subtitle])
     else:
-        enlaces = servertools.findvideosbyserver(item.url, item.server)[0]
-        if len(enlaces) > 0:
-            itemlist.append(item.clone(action="play", server=enlaces[2], url=enlaces[1]))
+        return [item]
     
     return itemlist

--- a/python/main-classic/channels/peliculasnu.py
+++ b/python/main-classic/channels/peliculasnu.py
@@ -212,6 +212,9 @@ def findvideos(item):
         data_url = httptools.downloadpage(host+'wp-admin/admin-ajax.php', post, headers=headers).data
         url = jsontools.load_json(data_url).get("url")
         
+        if 'openload' in url:
+            url = url + '|' + item.url
+            
         title = "%s - %s" % ('%s', title)
         itemlist.append(item.clone(action="play", url=url, title=title, text_color=color3))
     

--- a/python/main-classic/channels/trailertools.py
+++ b/python/main-classic/channels/trailertools.py
@@ -409,7 +409,7 @@ def search_links_filmaff(item):
                 code = scrapertools.find_single_match(trailer_url, 'v=([A-z0-9\-_]+)')
                 thumbnail = "https://img.youtube.com/vi/%s/0.jpg" % code
             else:
-                server = servertools.get_server_from_url(trailer_url)
+                server = ""
                 thumbnail = item.thumbnail
             scrapedtitle = unicode(scrapedtitle, encoding="utf-8", errors="ignore")
             scrapedtitle = scrapertools.htmlclean(scrapedtitle)
@@ -418,7 +418,8 @@ def search_links_filmaff(item):
                 scrapedtitle = "[COLOR white]%s[/COLOR]" % scrapedtitle
             itemlist.append(item.clone(title=scrapedtitle, url=trailer_url, server=server, action="play",
                                        thumbnail=thumbnail, text_color="white"))
-
+    
+    itemlist = servertools.get_servers_itemlist(itemlist)
     if keyboard:
         if item.contextual:
             title = "[COLOR green]%s[/COLOR]"

--- a/python/main-classic/channels/verpeliculasnuevas.py
+++ b/python/main-classic/channels/verpeliculasnuevas.py
@@ -232,16 +232,8 @@ def findvideos(item):
     	calidad = tcalidad[scrapedcalidad.lower()]
     	url = scrapedurl
     	itemlist.append( Item(channel=item.channel, action='play' , idioma=idioma, calidad=calidad, url=url))
-
-    for videoitem in itemlist:
-        videoitem.infoLabels=item.infoLabels
-        videoitem.channel = item.channel
-        videoitem.folder = False
-        videoitem.thumbnail = servertools.guess_server_thumbnail(videoitem.url)
-        videoitem.fulltitle = item.title
-        videoitem.server = servertools.get_server_from_url(videoitem.url)
-        videoitem.title = item.contentTitle+' | '+videoitem.calidad+' | '+videoitem.idioma+' ('+videoitem.server+')'
-
+    
+    itemlist = servertools.get_servers_itemlist(itemlist, lambda i: item.contentTitle+' | '+i.calidad+' | '+i.idioma+' ('+i.server+')')
        
 
     if config.get_library_support() and len(itemlist) > 0 and item.extra !='findvideos' :

--- a/python/main-classic/channels/vixto.py
+++ b/python/main-classic/channels/vixto.py
@@ -345,10 +345,8 @@ def bloque_enlaces(data, filtro_idioma, dict_idiomas, tipo, item):
             server = "streaminto"
         if server == "waaw":
             server = "netutv"
-        mostrar_server = True
-        if config.get_setting("hidepremium")==True:
-            mostrar_server = servertools.is_server_enabled(server)
-        if mostrar_server:
+
+        if servertools.is_server_enabled(server):
             try:
                 servers_module = __import__("servers." + server)
                 title = "   Mirror en " + server + " (" + language + ") (Calidad " + calidad.strip() + ")"

--- a/python/main-classic/core/config.py
+++ b/python/main-classic/core/config.py
@@ -168,7 +168,7 @@ def open_settings():
 
 
 
-def get_setting(name, channel=""):
+def get_setting(name, channel="", server=""):
     """
     Retorna el valor de configuracion del parametro solicitado.
 
@@ -199,6 +199,14 @@ def get_setting(name, channel=""):
 
         return value
 
+    elif server:
+        # logger.info("config.get_setting reading server setting '"+name+"' from server xml")
+        from core import servertools
+        value = servertools.get_server_setting(name, server)
+        # logger.info("config.get_setting -> '"+repr(value)+"'")
+
+        return value
+
     # Global setting
     else:
         # logger.info("config.get_setting reading main setting '"+name+"'")
@@ -222,7 +230,7 @@ def get_setting(name, channel=""):
             return value
 
 
-def set_setting(name, value, channel=""):
+def set_setting(name, value, channel="", server=""):
     """
     Fija el valor de configuracion del parametro indicado.
 
@@ -249,6 +257,9 @@ def set_setting(name, value, channel=""):
     if channel:
         from core import channeltools
         return channeltools.set_channel_setting(name, value, channel)
+    elif server:
+        from core import servertools
+        return servertools.set_server_setting(name, value, server)
     else:
         try:
             if isinstance(value, bool):

--- a/python/main-classic/core/servertools.py
+++ b/python/main-classic/core/servertools.py
@@ -760,6 +760,7 @@ def save_server_stats(stats, type="find_videos"):
     open(stats_file, "wb").write(jsontools.dump_json(server_stats))
     
     #Enviamos al servidor
+    return
     if time.time() - server_stats["created"] > 86400: #86400: #1 Dia
         from core import httptools
         if httptools.downloadpage("url servidor", headers= {'Content-Type': 'application/json'}, post=jsontools.dump_json(server_stats)).sucess:

--- a/python/main-classic/core/servertools.py
+++ b/python/main-classic/core/servertools.py
@@ -78,7 +78,7 @@ def find_video_items(item=None, data=None):
     return itemlist
 
 
-def get_servers_itemlist(itemlist, fnc=None):
+def get_servers_itemlist(itemlist, fnc=None, sort=False):
     """
     Obtiene el servidor para cada uno de los items, en funcion de su url.
      - Asigna el servidor, la url modificada, el thumbnail (si el item no contiene contentThumbnail se asigna el del thumbnail)
@@ -102,7 +102,7 @@ def get_servers_itemlist(itemlist, fnc=None):
         for pattern in server_parameters.get("find_videos", {}).get("patterns", []):
             logger.info(pattern["pattern"])
             #Recorre los resultados
-            for match in re.compile(pattern["pattern"], re.DOTALL).finditer("\n".join([item.url for item in itemlist if not item.server])):
+            for match in re.compile(pattern["pattern"], re.DOTALL).finditer("\n".join([item.url.split('|')[0] for item in itemlist if not item.server])):
                 url= pattern["url"]
                 for x in range(len(match.groups())):
                     url = url.replace("\\%s" % (x+1), match.groups()[x])
@@ -114,7 +114,10 @@ def get_servers_itemlist(itemlist, fnc=None):
                             item.contentThumbnail = item.thumbnail
                         item.thumbnail = server_parameters.get("thumbnail", "")
                         item.server = serverid
-                        item.url = url
+                        if '|' in item.url:
+                            item.url = url + '|' + item.url.split('|')[1]
+                        else:
+                            item.url = url
                         
     save_server_stats(server_stats, "find_videos")
     
@@ -131,9 +134,10 @@ def get_servers_itemlist(itemlist, fnc=None):
 
     # Filtrar si es necesario
     itemlist = filter_servers(itemlist)
-
+    
     # Ordenar segun favoriteslist si es necesario
-    itemlist = sort_servers(itemlist)
+    if sort:
+        itemlist = sort_servers(itemlist)
     
     return itemlist
 

--- a/python/main-classic/core/servertools.py
+++ b/python/main-classic/core/servertools.py
@@ -23,137 +23,207 @@
 # along with pelisalacarta 4.  If not, see <http://www.gnu.org/licenses/>.
 # --------------------------------------------------------------------------------
 # Server management
-# ------------------------------------------------------------
+#------------------------------------------------------------
 
 import os
-
+import re
+import time
+import datetime
+from core import jsontools
 from core import config
 from core import logger
-from core import scrapertools
+from core import httptools
+from core.item import Item
+from platformcode import platformtools
+import urlparse
 
+dict_servers_parameters = {}
 
-# Funciónn genérica para encontrar ídeos en una página
-def find_video_items(item=None, data=None, channel=""):
+def find_video_items(item=None, data=None):
+    """
+    Función genérica para buscar vídeos en una página, devolviendo un itemlist con los items listos para usar.
+     - Si se pasa un Item como argumento, a los items resultantes mantienen los parametros del item pasado
+     - Si no se pasa un Item, se crea uno nuevo, pero no contendra ningun parametro mas que los propios del servidor.
+
+    @param item: Item al cual se quieren buscar vídeos, este debe contener la url válida
+    @type item: Item
+    @param data: Cadena con el contendio de la página ya descargado (si no se pasa item)
+    @type data: str
+
+    @return: devuelve el itemlist con los resultados
+    @rtype: list
+    """
     logger.info()
-
+    itemlist = []
+    
     # Descarga la página
     if data is None:
-        from core import scrapertools
-        data = scrapertools.cache_page(item.url)
-        #logger.info(data)
-
-    # Busca los enlaces a los videos
-    from core.item import Item
-    listavideos = findvideos(data)
-
+        data = httptools.downloadpage(item.url).data
+    
+    #Crea un item si no hay item    
     if item is None:
         item = Item()
+    #Pasa los campos thumbnail y title a contentThumbnail y contentTitle
+    else:
+        if not item.contentThumbnail:
+            item.contentThumbnail = item.thumnail
+        if not item.contentTitle:
+            item.contentTitle = item.title
 
-    itemlist = []
-    for video in listavideos:
-        scrapedtitle = "Enlace encontrado en "+video[2]
-        scrapedurl = video[1]
-        server = video[2]
-        if get_server_parameters(server)["thumbnail"]:
-            thumbnail = get_server_parameters(server)["thumbnail"]
-        else:
-            thumbnail = "http://media.tvalacarta.info/servers/server_"+server+".png"
-        
-        itemlist.append( Item(channel=item.channel, title=scrapedtitle , action="play" , server=server, url=scrapedurl, thumbnail=thumbnail, show=item.show , plot=item.plot , parentContent=item, folder=False) )
+    # Busca los enlaces a los videos
+    for label, url, server, thumbnail in findvideos(data):
+        title = "Enlace encontrado en %s" % label
+        itemlist.append(item.clone(title=title, action="play", url=url, thumbnail=thumbnail, server=server, folder=False))
 
     return itemlist
 
-def guess_server_thumbnail(title):
-    logger.info("title="+title)
 
-    lowcase_title = title.lower()
+def get_servers_itemlist(itemlist, fnc=None):
+    """
+    Obtiene el servidor para cada uno de los items, en funcion de su url.
+     - Asigna el servidor, la url modificada, el thumbnail (si el item no contiene contentThumbnail se asigna el del thumbnail)
+     - Si se pasa una funcion por el argumento fnc, esta se ejecuta pasando el item como argumento,
+       el resultado de esa funcion se asigna al titulo del item
+       - En esta funcion podemos modificar cualquier cosa del item
+       - Esta funcion siempre tiene que devolver el item.title como resultado
+     - Si no se encuentra servidor para una url, se asigna "directo"
+     
+    @param itemlist: listado de items
+    @type itemlist: list
+    @param fnc: función para ejecutar con cada item (para asignar el titulo)
+    @type fnc: function
+    """
+    server_stats = {}
+    #Recorre los servidores
+    for serverid in get_servers_list().keys():
+        server_parameters = get_server_parameters(serverid)
+        
+        #Recorre los patrones
+        for pattern in server_parameters.get("find_videos", {}).get("patterns", []):
+            logger.info(pattern["pattern"])
+            #Recorre los resultados
+            for match in re.compile(pattern["pattern"], re.DOTALL).finditer("\n".join([item.url for item in itemlist if not item.server])):
+                url= pattern["url"]
+                for x in range(len(match.groups())):
+                    url = url.replace("\\%s" % (x+1), match.groups()[x])
+                    
+                server_stats[serverid] = "found"
+                for item in itemlist:
+                    if match.group() in item.url:
+                        if not item.contentThumbnail:
+                            item.contentThumbnail = item.thumbnail
+                        item.thumbnail = server_parameters.get("thumbnail", "")
+                        item.server = serverid
+                        item.url = url
+                        
+    save_server_stats(server_stats, "find_videos")
+    
+    #Eliminamos los servidores desactivados
+    itemlist = filter(lambda i: not i.server or is_server_enabled(i.server), itemlist)
+    
+    for item in itemlist:
+        #Asignamos "directo" en caso de que el server no se encuentre en pelisalcarta
+        if not item.server and item.url:
+            item.server = "directo"
+                
+        if fnc:
+            item.title = fnc(item)
 
-    if "netu" in lowcase_title:
-        logger.info("caso especial netutv")
-        return "http://media.tvalacarta.info/servers/server_netutv.png"
+    # Filtrar si es necesario
+    itemlist = filter_servers(itemlist)
 
-    if "ul.to" in lowcase_title:
-        logger.info("caso especial ul.to")
-        return "http://media.tvalacarta.info/servers/server_uploadedto.png"
+    # Ordenar segun favoriteslist si es necesario
+    itemlist = sort_servers(itemlist)
+    
+    return itemlist
 
-    if "waaw" in lowcase_title:
-        logger.info("caso especial waaw")
-        return "http://media.tvalacarta.info/servers/server_waaw.png"
+def findvideos(data, skip=False):
+    """
+    Recorre la lista de servidores disponibles y ejecuta la funcion findvideosbyserver para cada uno de ellos
+    :param data: Texto donde buscar los enlaces
+    :param skip: Indica un limite para dejar de recorrer la lista de servidores. Puede ser un booleano en cuyo caso
+    seria False para recorrer toda la lista (valor por defecto) o True para detenerse tras el primer servidor que
+    retorne algun enlace. Tambien puede ser un entero mayor de 1, que representaria el numero maximo de enlaces a buscar.
+    :return:
+    """
+    logger.info()
+    devuelve = []
+    skip = int(skip)
+    servers_list = get_servers_list().keys()
 
-    if "streamin" in lowcase_title:
-        logger.info("caso especial streamin")
-        return "http://media.tvalacarta.info/servers/server_streaminto.png"
+    # Ordenar segun favoriteslist si es necesario
+    servers_list = sort_servers(servers_list)
+    is_filter_servers = False
+    
+    # Ejecuta el findvideos en cada servidor activo
+    for serverid in servers_list:
+        if not is_server_enabled(serverid):
+            continue
+        if  config.get_setting("black_list", server=serverid):
+            is_filter_servers = True
+            continue
 
-    servers = get_servers_list()
-    for serverid in servers:
-        if serverid in lowcase_title:
-            logger.info("encontrado "+serverid)
-            return "http://media.tvalacarta.info/servers/server_"+serverid+".png"
+        devuelve.extend(findvideosbyserver(data, serverid))
+        if skip and len(devuelve) >= skip:
+            devuelve = devuelve[:skip]
+            break
 
-    return ""
+    if not devuelve and is_filter_servers:
+        platformtools.dialog_ok("Filtrar servidores (Lista Negra)",
+                                "No hay enlaces disponibles que cumplan los requisitos de su Lista Negra.",
+                                "Pruebe de nuevo modificando el fíltro en 'Configuracíon Servidores")
+
+    return devuelve
 
 
 def findvideosbyserver(data, serverid):
-    logger.info()
+    serverid = get_server_name(serverid)
+    server_parameters = get_server_parameters(serverid)
     devuelve = []
-    try:
-        exec "from servers import "+serverid
-        exec "devuelve.extend("+serverid+".find_videos(data))"
-    except ImportError:
-        logger.error("No existe conector para #"+serverid+"#")
-        #import traceback
-        #logger.info(traceback.format_exc())
-    except:
-        logger.error("Error en el conector #"+serverid+"#")
-        import traceback
-        logger.error(traceback.format_exc())
-
-    return devuelve
-
-
-def findvideos(data, skip=False):
-    logger.info()
-    devuelve = []
-
-    # Ejecuta el findvideos en cada servidor
-    server_list = get_servers_list()
-    for serverid in server_list:
+    
+    if server_parameters.has_key("find_videos"):
+        #Recorre los patrones
+        for pattern in server_parameters["find_videos"].get("patterns", {}):
+            msg = "%s\npattern: %s" % (serverid, pattern["pattern"])
+            #Recorre los resultados
+            for match in re.compile(pattern["pattern"], re.DOTALL).finditer(data):
+                url= pattern["url"]
+                #Crea la url con los datos
+                for x in range(len(match.groups())):
+                    url = url.replace("\\%s" % (x+1), match.groups()[x])
+                msg += "\nurl encontrada: %s" % url
+                value = server_parameters["name"], url, serverid, server_parameters.get("thumbnail", "")
+                if not value in devuelve and not url in server_parameters["find_videos"].get("ignore_urls", []):
+                    devuelve.append(value)
+                logger.info(msg)
+                
+    else: # TODO eliminar esto cuando todos los xml esten actualizados
+        # Sistema antiguo find_videos en py
         try:
-            # Sustituye el código por otro "Plex compatible"
-            #exec "from servers import "+serverid
-            #exec "devuelve.extend("+serverid+".find_videos(data))"
-            servers_module = __import__("servers."+serverid)
-            server_module = getattr(servers_module,serverid)
+            servers_module = __import__("servers." + serverid)
+            server_module = getattr(servers_module, serverid)
             result = server_module.find_videos(data)
-            if result and skip: return result
+            devuelve = [[server_parameters["name"], d[1], d[2], server_parameters.get("thumbnail", "")] for d in devuelve]
             devuelve.extend(result)
         except ImportError:
-            logger.error("No existe conector para #"+serverid+"#")
-            #import traceback
-            #logger.info(traceback.format_exc())
+            logger.info("No existe conector para #" + serverid + "#")
         except:
-            logger.error("Error en el conector #"+serverid+"#")
+            logger.info("Error en el conector #" + serverid + "#")
             import traceback
-            logger.error(traceback.format_exc())
-
+            logger.info(traceback.format_exc())
+    
+    #Guardar estadisticas
+    if devuelve:
+        save_server_stats({serverid: "found"}, "find_videos")
+        
     return devuelve
 
-def get_video_urls(server,url):
-    '''
-    servers_module = __import__("servers."+server)
-    server_module = getattr(servers_module,server)
-    return server_module.get_video_url( page_url=url)
-    '''
 
-    video_urls,puede,motivo = resolve_video_urls_for_playing(server,url)
-    return video_urls
+def guess_server_thumbnail(serverid):
+    server = get_server_name(serverid)
+    server_parameters = get_server_parameters(server)
+    return server_parameters.get('thumbnail', "")
 
-def get_channel_module(channel_name):
-    if not "." in channel_name:
-      channel_module = __import__('channels.%s' % channel_name, None, None, ["channels.%s" % channel_name])
-    else:
-      channel_module = __import__(channel_name, None, None, [channel_name])
-    return channel_module
 
 def get_server_from_url(url):
     encontrado = findvideos(url, True)
@@ -164,223 +234,537 @@ def get_server_from_url(url):
 
     return devuelve
 
-def resolve_video_urls_for_playing(server,url,video_password="",muestra_dialogo=False):
-    logger.info("server="+server+", url="+url)
-    video_urls = []
-    torrent = False
 
+def resolve_video_urls_for_playing(server, url, video_password="", muestra_dialogo=False):
+    """
+    Función para obtener la url real del vídeo
+    @param server: Servidor donde está alojado el vídeo
+    @type server: str
+    @param url: url del vídeo
+    @type url: str
+    @param video_password: Password para el vídeo
+    @type video_password: str
+    @param muestra_dialogo: Muestra el diálogo de progreso
+    @type muestra_dialogo: bool
+
+    @return: devuelve la url del video
+    @rtype: list
+    """
+    logger.info("Server: %s, Url: %s" % (server, url))
+    
     server = server.lower()
-
-    # Si el vídeo es "directo", no hay que buscar más
+    
+    video_urls = []
+    video_exists = True
+    error_messages = []
+    
+    # Si el vídeo es "directo" o "local", no hay que buscar más
     if server=="directo" or server=="local":
-        logger.info("server=directo, la url es la buena")
+        logger.info("Server: %s, la url es la buena" % server)
+        video_urls.append([ "%s [%s]" % (urlparse.urlparse(url)[2][-4:], server) , url ])
 
-        try:
-            import urlparse
-            parsed_url = urlparse.urlparse(url)
-            logger.info("parsed_url="+str(parsed_url))
-            extension = parsed_url.path[-4:]
-        except:
-            extension = url[-4:]
-
-        video_urls = [[ "%s [%s]" % (extension,server) , url ]]
-        return video_urls,True,""
-
-    # Averigua las URL de los vídeos
+    # Averigua la URL del vídeo
     else:
+        server_parameters = get_server_parameters(server)
+        
+        # Muestra un diágo de progreso
+        if muestra_dialogo:
+            progreso = platformtools.dialog_progress("pelisalacarta", "Conectando con %s" % server_parameters["name"])
 
-        # Carga el conector
+        #Cuenta las opciones disponibles, para calcular el porcentaje
+        opciones = []
+        orden = [["free"] + [server] + [premium for premium in server_parameters["premium"] if not premium == server],
+                 [server] + [premium for premium in server_parameters["premium"] if not premium == server] + ["free"],
+                 [premium for premium in server_parameters["premium"] if not premium == server] + [server] + ["free"]
+                ]
+        
+        if server_parameters:
+            if server_parameters["free"] == "true": opciones.append("free")
+            opciones.extend([premium for premium in server_parameters["premium"] if config.get_setting("premium",server=premium)])
+            
+            priority = int(config.get_setting("resolve_priority"))
+            opciones = sorted(opciones, key=lambda x: orden[priority].index(x))
+            
+            
+            logger.info("Opciones disponibles: %s | %s"  % (len(opciones), opciones))
+        else:
+            logger.error("No existe conector para el servidor %s" % server)
+            error_messages.append("No existe conector para el servidor %s" % server)
+
+        #Importa el server
         try:
-            # Muestra un diágo de progreso
-            if muestra_dialogo:
-                from platformcode import platformtools
-                progreso = platformtools.dialog_progress( "pelisalacarta", "Conectando con "+server)
-            server_parameters = get_server_parameters(server)
-
-            #Cuenta las opciones disponibles, para calcular el porcentaje
-            opciones = []
-            if server_parameters["free"] == True:
-              opciones.append("free")
-
-            opciones.extend([premium for premium in server_parameters["premium"] if config.get_setting(premium+"premium")==True])
-            logger.info("pelisalacarta.core.servertools opciones disponibles para " + server + ": " + str(len(opciones)) + " "+str(opciones))
-
-            # Sustituye el código por otro "Plex compatible"
-            #exec "from servers import "+server+" as server_connector"
-            servers_module = __import__("servers."+server)
-            server_connector = getattr(servers_module,server)
-
-            logger.info("servidor de "+server+" importado")
-
-            # Si tiene una función para ver si el vídeo existe, lo comprueba ahora
-            if hasattr(server_connector, 'test_video_exists'):
-                logger.info("invocando a "+server+".test_video_exists")
-                puedes,motivo = server_connector.test_video_exists( page_url=url )
-
-                # Si la funcion dice que no existe, fin
-                if not puedes:
-                    logger.info("test_video_exists dice que el video no existe")
-                    if muestra_dialogo: progreso.close()
-                    return video_urls,puedes,motivo
-                else:
-                    logger.info("test_video_exists dice que el video SI existe")
-
-            # Obtiene enlaces free
-            if server_parameters["free"]==True:
-                if muestra_dialogo:
-                    progreso.update((100 / len(opciones)) * opciones.index("free")  , "Conectando con "+server)
-
-                logger.info("invocando a "+server+".get_video_url")
-                video_urls = server_connector.get_video_url( page_url=url , video_password=video_password )
-
-                # Si no se encuentran vídeos en modo free, es porque el vídeo no existe
-                if len(video_urls)==0:
-                    if muestra_dialogo: progreso.close()
-                    return video_urls,False,"No se puede encontrar el vídeo en "+server
-
-            # Obtiene enlaces para las diferentes opciones premium
-            error_message = []
-            for premium in server_parameters["premium"]:
-              if config.get_setting(premium+"premium")==True:
-                if muestra_dialogo:
-                  progreso.update((100 / len(opciones)) * opciones.index(premium)  , "Conectando con "+premium)
-                if premium == server: #Cuenta Premium propia
-                    video_urls.extend(server_connector.get_video_url( page_url=url , premium=True , user=config.get_setting(premium+"user") , password=config.get_setting(premium+"password"), video_password=video_password ))
-                elif premium == "realdebrid":
-                    exec "from servers.debriders import "+premium+" as premium_conector"
-                    debrid_urls = premium_conector.get_video_url( page_url=url , premium=True , video_password=video_password )
-                    if not "REAL-DEBRID:" in debrid_urls[0][0]:
-                        video_urls.extend(debrid_urls)
-                    else:
-                        error_message.append(debrid_urls[0][0])
-                elif premium == "alldebrid":
-                    exec "from servers.debriders import "+premium+" as premium_conector"
-                    alldebrid_urls = premium_conector.get_video_url( page_url=url , premium=True , user=config.get_setting(premium+"user") , password=config.get_setting(premium+"password"), video_password=video_password )
-                    if not "Alldebrid:" in alldebrid_urls[0][0]:
-                        video_urls.extend(alldebrid_urls)
-                    else:
-                        error_message.append(alldebrid_urls[0][0])
-                else:
-                    exec "from servers.debriders import "+premium+" as premium_conector"
-                    video_urls.extend(premium_conector.get_video_url( page_url=url , premium=True , user=config.get_setting(premium+"user") , password=config.get_setting(premium+"password"), video_password=video_password ))
-
-            if not video_urls and error_message:
-                return video_urls, False, " || ".join(error_message)
-
-            if muestra_dialogo:
-                progreso.update( 100 , "Proceso finalizado")
-
-            # Cierra el diálogo de progreso
-            if muestra_dialogo: progreso.close()
-
-            # Llegas hasta aquí y no tienes ningún enlace para ver, así que no vas a poder ver el vídeo
-            if len(video_urls)==0:
-                # ¿Cual es el motivo?
-
-                # 1) No existe -> Ya está controlado
-                # 2) No tienes alguna de las cuentas premium compatibles
-
-                # Lista de las cuentas que soportan este servidor
-                listapremium = []
-                for premium in server_parameters["premium"]:
-                  listapremium.append(get_server_parameters(premium)["name"])
-
-                return video_urls,False,"Para ver un vídeo en "+server+" necesitas<br/>una cuenta en "+" o ".join(listapremium)
-
+            server_module = __import__('servers.%s' % server, None, None, ["servers.%s" % server])
+            logger.info("Servidor importado: %s" % server_module)
         except:
-            if muestra_dialogo: progreso.close()
+            server_module = None
+            logger.error("No se ha podido importar el servidor: %s" % server)
             import traceback
             logger.error(traceback.format_exc())
-            return video_urls,False,"Se ha producido un error en<br/>el conector con "+server
+            
 
-    return video_urls,True,""
+        # Si tiene una función para ver si el vídeo existe, lo comprueba ahora
+        if hasattr(server_module, 'test_video_exists'):
+            logger.info("Invocando a %s.test_video_exists" % server)
+            try:
+                video_exists, message = server_module.test_video_exists(page_url=url)
+                
+                if not video_exists:
+                    error_messages.append(message)
+                    logger.info("test_video_exists dice que el video no existe")
+                else:
+                    logger.info("test_video_exists dice que el video SI existe")
+            except:
+                logger.error("No se ha podido comprobar si el video existe")
+                import traceback
+                logger.error(traceback.format_exc())
+        
+        #Si el video existe y el modo free está disponible, obtenemos la url
+        if video_exists:
+            for opcion in opciones:
+                #Opcion free y premium propio usa el mismo server
+                if opcion == "free" or opcion == server:
+                    serverid = server_module
+                    server_name = server_parameters["name"]
+                    
+                #Resto de opciones premium usa un debrider
+                else:
+                    serverid = __import__('servers.debriders.%s' % opcion, None, None, ["servers.debriders.%s" % opcion])
+                    server_name = get_server_parameters(opcion)["name"]
+                
+                #Muestra el progreso
+                if muestra_dialogo:
+                  progreso.update((100 / len(opciones)) * opciones.index(opcion)  , "Conectando con %s" % server_name)
+                
+                #Modo free
+                if opcion == "free":
+                    try:
+                        logger.info("Invocando a %s.get_video_url" % server)
+                        response = serverid.get_video_url(page_url=url, video_password=video_password)
+                        if response:
+                            save_server_stats({server: "sucess"}, "resolve")                           
+                        video_urls.extend(response)
+                    except:
+                        save_server_stats({server: "error"}, "resolve")  
+                        logger.error("Error al obrener la url en modo free")
+                        error_messages.append("Se ha producido un error en %s" % server_name)
+                        import traceback
+                        logger.error(traceback.format_exc())
+                        
+                #Modo premium        
+                else:        
+                    try:
+                        logger.info("Invocando a %s.get_video_url" % opcion)
+                        response = serverid.get_video_url(page_url=url, premium=True, user=config.get_setting("user", server=opcion), password=config.get_setting("password", server=opcion), video_password=video_password)
+                        if response and response[0][1]:
+                            if opcion == server:
+                                save_server_stats({server: "sucess"}, "resolve")
+                            video_urls.extend(response)
+                        elif response and response[0][0]:
+                            error_messages.append(response[0][0])
+                        else:
+                            error_messages.append("Se ha producido un error en %s" % server_name)
+                    except:
+                        if opcion == server:
+                            save_server_stats({server: "error"}, "resolve")
+                        logger.error("Error en el servidor: %s" % opcion)
+                        error_messages.append("Se ha producido un error en %s" % server_name)
+                        import traceback
+                        logger.error(traceback.format_exc())
+                
+                #Si ya tenemos URLS, dejamos de buscar
+                if video_urls and config.get_setting("resolve_stop") == "true":
+                    break
+                
+            #Cerramos el progreso
+            if muestra_dialogo:
+                progreso.update( 100 , "Proceso finalizado")
+                progreso.close()
+            
+            #Si no hay opciones disponibles mostramos el aviso de las cuentas premium
+            if video_exists and not opciones and server_parameters.get("premium"):
+                listapremium = [get_server_parameters(premium)["name"] for premium in server_parameters["premium"]]
+                error_messages.append("Para ver un vídeo en %s necesitas<br/>una cuenta en: %s" % (server, " o ".join(listapremium)))
+            
+            #Si no tenemos urls ni mensaje de error, ponemos uno generico            
+            elif not video_urls and not error_messages:
+                error_messages.append("Se ha producido un error en %s" % get_server_parameters(server)["name"])
+
+    
+    return video_urls, len(video_urls) > 0, "<br/>".join(error_messages)
+
+
+def get_server_name(serverid):
+    """
+    Función obtener el nombre del servidor real a partir de una cadena.
+    @param serverid: Cadena donde mirar
+    @type serverid: str
+
+    @return: Nombre del servidor
+    @rtype: str
+    """
+    serverid = serverid.lower().split(".")[0]
+    
+    #Obtenemos el listado de servers
+    server_list = get_servers_list().keys()
+    
+    #Si el nombre está en la lista
+    if serverid in server_list: 
+        return serverid
+    
+    #Recorre todos los servers buscando el nombre
+    for server in server_list:
+        params = get_server_parameters(server)
+        #Si la nombre esta en el listado de ids
+        if serverid in params["id"]:
+            return server
+        #Si el nombre es mas de una palabra, comprueba si algun id esta dentro del nombre:
+        elif len(serverid.split()) > 1:
+            for id in params["id"]:
+                if id in serverid:
+                    return server
+    
+    #Si no se encuentra nada se devuelve una cadena vacia
+    return ""
+
 
 def is_server_enabled(server):
-    try:
-        server_parameters = get_server_parameters(server)
-        if server_parameters["active"] == True:
-            if not config.get_setting("hidepremium")==True:
-                return True
-            else:
-                if server_parameters["free"] == True:
-                    return True
-                if [premium for premium in server_parameters["premium"] if config.get_setting(premium+"premium")==True]:
-                    return True
-                else:
-                    return False
-        else:
-            return False
-    except:
-        import traceback
-        logger.error(traceback.format_exc())
+    """
+    Función comprobar si un servidor está segun la configuración establecida
+    @param server: Nombre del servidor
+    @type server: str
+
+    @return: resultado de la comprobación
+    @rtype: bool
+    """
+    
+    server = get_server_name(server)
+
+    #El server no existe
+    if not server:
         return False
+        
+    server_parameters = get_server_parameters(server)
+    if server_parameters["active"] == "true":
+        if not config.get_setting("hidepremium"):
+            return True
+        elif server_parameters["free"] == "true":
+            return True
+        elif [premium for premium in server_parameters["premium"] if config.get_setting("premium",server=premium)]:
+            return True
 
+    return False
+
+        
 def get_server_parameters(server):
-    server=scrapertools.find_single_match(server,'([^\.]+)')
+    """
+    Obtiene los datos del servidor
+    @param server: Nombre del servidor
+    @type server: str
+
+    @return: datos del servidor
+    @rtype: dict
+    """
+    global dict_servers_parameters
+    server = server.split('.')[0]
+    
+    if not server in dict_servers_parameters:
+        try:
+            #Servers
+            if os.path.isfile(os.path.join(config.get_runtime_path(),"servers", server + ".xml")):
+                JSONFile =  xml2dict(os.path.join(config.get_runtime_path(),"servers", server + ".xml"))["server"]
+            #Debriders
+            elif os.path.isfile(os.path.join(config.get_runtime_path(),"servers", "debriders", server + ".xml")):
+                JSONFile =  xml2dict(os.path.join(config.get_runtime_path(),"servers", "debriders", server + ".xml"))["server"]
+            
+            
+            for k in ['premium', 'id']:
+                if not JSONFile.has_key(k) or JSONFile[k] == "":
+                    JSONFile[k] = []
+                elif type(JSONFile[k]) == dict:
+                    JSONFile[k] = JSONFile[k]["value"]
+                if type(JSONFile[k]) == str:
+                    JSONFile[k] = [JSONFile[k]]
+                    
+            if JSONFile.has_key('find_videos'):
+                if type(JSONFile['find_videos']['patterns']) == dict:
+                    JSONFile['find_videos']['patterns'] = [JSONFile['find_videos']['patterns']]
+                
+                if not JSONFile['find_videos'].get("ignore_urls", ""):
+                    JSONFile['find_videos']["ignore_urls"] = []
+                elif type(JSONFile['find_videos']["ignore_urls"] == dict):
+                    JSONFile['find_videos']["ignore_urls"] = JSONFile['find_videos']["ignore_urls"]["value"]
+                if type(JSONFile['find_videos']["ignore_urls"]) == str:
+                    JSONFile['find_videos']["ignore_urls"] = [JSONFile['find_videos']["ignore_urls"]]
+                    
+            if JSONFile.has_key('settings'):
+                if type(JSONFile['settings']) == dict:
+                    JSONFile['settings'] = [JSONFile['settings']]
+            
+                if len(JSONFile['settings']):
+                    JSONFile['has_settings'] = True
+                else:
+                    JSONFile['has_settings'] = False
+            else:
+                JSONFile['has_settings'] = False
+
+            dict_servers_parameters[server] = JSONFile
+
+        except:
+            mensaje = "Error al cargar el servidor: %s\n" % server
+            import traceback
+            logger.error(mensaje + traceback.format_exc())
+            return {}
+    
+    import copy
+    return copy.deepcopy(dict_servers_parameters[server])
+
+
+def get_server_controls_settings(server_name):
+    dict_settings = {}
+
+    list_controls = get_server_parameters(server_name).get('settings',[])
+
+    # Conversion de str a bool, etc...
+    for c in list_controls:
+        if 'id' not in c or 'type' not in c or 'default' not in c:
+            # Si algun control de la lista  no tiene id, type o default lo ignoramos
+            continue
+        
+        c['enabled'] = [True, False][c.get('enabled', '').lower() == "false"]
+        c['visible'] = [True, False][c.get('visible', '').lower() == "false"]
+        
+        if c['type'] == 'bool':
+            c['default'] = [True, False][c.get('default', '').lower() == "false"]
+
+        if unicode(c['default']).isnumeric():
+            c['default'] = int(c['default'])
+
+        dict_settings[c['id']] = c['default']
+
+    return list_controls, dict_settings
+
+
+def get_server_setting(name, server):
+
+    # Creamos la carpeta si no existe
+    if not os.path.exists(os.path.join(config.get_data_path(), "settings_servers")):
+        os.mkdir(os.path.join(config.get_data_path(), "settings_servers"))
+
+    file_settings = os.path.join(config.get_data_path(), "settings_servers", server+"_data.json")
+    dict_settings = {}
+    dict_file = {}
+    if os.path.exists(file_settings):
+        # Obtenemos configuracion guardada de ../settings/channel_data.json
+        try:
+            dict_file = jsontools.load_json(open(file_settings, "rb").read())
+            if isinstance(dict_file, dict) and 'settings' in dict_file:
+                dict_settings = dict_file['settings']
+        except EnvironmentError:
+            logger.info("ERROR al leer el archivo: %s" % file_settings)
+
+    if len(dict_settings) == 0 or name not in dict_settings:
+        # Obtenemos controles del archivo ../channels/channel.xml
+        try:
+            list_controls, default_settings = get_server_controls_settings(server)
+        except:
+            default_settings = {}
+        if name in default_settings:  # Si el parametro existe en el channel.xml creamos el channel_data.json
+            default_settings.update(dict_settings)
+            dict_settings = default_settings
+            dict_file['settings'] = dict_settings
+            # Creamos el archivo ../settings/channel_data.json
+            json_data = jsontools.dump_json(dict_file)
+            try:
+                open(file_settings, "wb").write(json_data)
+            except EnvironmentError:
+                logger.info("ERROR al salvar el archivo: %s" % file_settings)
+
+    # Devolvemos el valor del parametro local 'name' si existe
+    if name in dict_settings:
+        return dict_settings[name]
+    else:
+        return None
+
+
+def set_server_setting(name, value, server):
+    # Creamos la carpeta si no existe
+    if not os.path.exists(os.path.join(config.get_data_path(), "settings_servers")):
+        os.mkdir(os.path.join(config.get_data_path(), "settings_servers"))
+
+    file_settings = os.path.join(config.get_data_path(), "settings_servers", server + "_data.json")
+    dict_settings = {}
+
+    dict_file = None
+
+    if os.path.exists(file_settings):
+        # Obtenemos configuracion guardada de ../settings/channel_data.json
+        try:
+            dict_file = jsontools.load_json(open(file_settings, "r").read())
+            dict_settings = dict_file.get('settings', {})
+        except EnvironmentError:
+            logger.info("ERROR al leer el archivo: %s" % file_settings)
+
+    dict_settings[name] = value
+
+    # comprobamos si existe dict_file y es un diccionario, sino lo creamos
+    if dict_file is None or not dict_file:
+        dict_file = {}
+
+    dict_file['settings'] = dict_settings
+
+    # Creamos el archivo ../settings/channel_data.json
     try:
-      if os.path.isfile(os.path.join(config.get_runtime_path(),"servers", server + ".xml")):  
-        JSONFile =  xml2dict(os.path.join(config.get_runtime_path(),"servers", server + ".xml"))["server"]
-      elif os.path.isfile(os.path.join(config.get_runtime_path(),"servers", "debriders", server + ".xml")):  
-        JSONFile =  xml2dict(os.path.join(config.get_runtime_path(),"servers", "debriders", server + ".xml"))["server"]
-      if type(JSONFile["premium"]) == dict: JSONFile["premium"]=JSONFile["premium"]["value"]
-      if JSONFile["premium"] == "": JSONFile["premium"]=[]
-      if type(JSONFile["premium"]) == str and not JSONFile["premium"] == "": JSONFile["premium"]=[JSONFile["premium"]]
-      return JSONFile
-    except:
-      logger.error("Error al cargar el servidor: " + server)
-      import traceback
-      logger.error(traceback.format_exc())
-      return {}
+        json_data = jsontools.dump_json(dict_file)
+        open(file_settings, "w").write(json_data)
+    except EnvironmentError:
+        logger.info("ERROR al salvar el archivo: %s" % file_settings)
+        return None
 
+    return value
+    
+    
 def get_servers_list():
-  logger.info()
-  ServersPath = os.path.join(config.get_runtime_path(),"servers")
-  ServerList={}
-  for server in os.listdir(ServersPath):
-    if server.endswith(".xml"):
-        if is_server_enabled(server):
+    """
+    Obtiene un diccionario con todos los servidores disponibles
+
+    @return: Diccionario cuyas claves son los nombre de los servidores (nombre del xml)
+    y como valor un diccionario con los parametros del servidor.
+    @rtype: dict
+    """
+    server_list = {}
+    for server in os.listdir(os.path.join(config.get_runtime_path(),"servers")):
+        if server.endswith(".xml") and not server == "version.xml":
             server_parameters = get_server_parameters(server)
-            ServerList[server_parameters["id"]] = server_parameters
+            if server_parameters["active"] == "true":
+                server_list[server.split(".")[0]] = server_parameters
+    
+    return server_list
 
-  return ServerList
+    
+def get_debriders_list():
+    """
+    Obtiene un diccionario con todos los debriders disponibles
+
+    @return: Diccionario cuyas claves son los nombre de los debriders (nombre del xml)
+    y como valor un diccionario con los parametros del servidor.
+    @rtype: dict
+    """
+    server_list = {}
+    for server in os.listdir(os.path.join(config.get_runtime_path(),"servers", "debriders")):
+        if server.endswith(".xml"):
+            server_parameters = get_server_parameters(server)
+            if server_parameters["active"] == "true":
+                logger.info(server_parameters)
+                server_list[server.split(".")[0]] = server_parameters
+    return server_list
+    
+
+def sort_servers(servers_list):
+    """
+    Si existe un listado de servidores favoritos en la configuracion lo utiliza para ordenar la lista servers_list
+    :param servers_list: Listado de servidores para ordenar. Los elementos de la lista servers_list pueden ser strings
+    u objetos Item. En cuyo caso es necesario q tengan un atributo item.server del tipo str.
+    :return: Lista del mismo tipo de objetos que servers_list ordenada en funcion de los servidores favoritos.
+    """
+    if servers_list:
+        if isinstance(servers_list[0],Item):
+            servers_list = sorted(servers_list, key = lambda x: config.get_setting("white_list",server=x.server) or 100)
+        else:
+            servers_list = sorted(servers_list, key = lambda x: config.get_setting("white_list",server=x) or 100)
+    return servers_list
+
+    
+def filter_servers(servers_list):
+    """
+    Si esta activada la opcion "Filtrar servidores (Lista Negra)" en la configuracion, elimina de la lista de entrada los
+    servidores incluidos en la Lista Negra.
+    :param servers_list: Listado de servidores para filtrar. Los elementos de la lista servers_list pueden ser strings
+    u objetos Item. En cuyo caso es necesario q tengan un atributo item.server del tipo str.
+    :return: Lista del mismo tipo de objetos que servers_list filtrada en funcion de la Lista Negra.
+    """
+    servers_list_filter = []
+    if servers_list:
+        if isinstance(servers_list[0],Item):
+            servers_list_filter = filter(lambda x: not config.get_setting("black_list",server=x.server), servers_list)
+        else:
+            servers_list_filter = filter(lambda x: not config.get_setting("black_list",server=x), servers_list)
+            
+        # Si no hay enlaces despues de filtrarlos
+        if not servers_list_filter and platformtools.dialog_yesno("Filtrar servidores (Lista Negra)",
+                                                                  "Todos los enlaces disponibles pertenecen a servidores incluidos en su Lista Negra.",
+                                                                  "¿Desea mostrar estos enlaces?"):
+            return servers_list
+    return servers_list_filter
 
 
-def xml2dict(file=None, xmldata=None):
-    import re, sys, os
-    parse = globals().get(sys._getframe().f_code.co_name)
+def xml2dict(file = None, xmldata = None):
+      import re, sys, os
+      parse = globals().get(sys._getframe().f_code.co_name)
 
-    if xmldata == None and file == None:  raise Exception("No hay nada que convertir!")
-    if xmldata == None:
+      if xmldata == None and file == None:  raise Exception("No hay nada que convertir!")
+      if xmldata == None:
         if not os.path.exists(file): raise Exception("El archivo no existe!")
         xmldata = open(file, "rb").read()
 
-    matches = re.compile("<(?P<tag>[^>]+)>[\n]*[\s]*[\t]*(?P<value>.*?)[\n]*[\s]*[\t]*<\/(?P=tag)\s*>",
-                         re.DOTALL).findall(xmldata)
+      matches = re.compile("<(?P<tag>[^>]+)>[\n]*[\s]*[\t]*(?P<value>.*?)[\n]*[\s]*[\t]*<\/(?P=tag)\s*>",re.DOTALL).findall(xmldata)
 
-    return_dict = {}
-    for tag, value in matches:
-        # Si tiene elementos
+      return_dict = {}
+      for tag, value in matches:
+        #Si tiene elementos
         if "<" and "</" in value:
-            if tag in return_dict:
-                if type(return_dict[tag]) == list:
-                    return_dict[tag].append(parse(xmldata=value))
-                else:
-                    return_dict[tag] = [return_dict[tag]]
-                    return_dict[tag].append(parse(xmldata=value))
+          if tag in return_dict:
+            if type(return_dict[tag])== list:
+              return_dict[tag].append(parse(xmldata=value))
             else:
-                return_dict[tag] = parse(xmldata=value)
+              return_dict[tag] = [return_dict[tag]]
+              return_dict[tag].append(parse(xmldata=value))
+          else:
+              return_dict[tag] = parse(xmldata=value)
+
         else:
-            if tag in return_dict:
-                if type(return_dict[tag]) == list:
-                    return_dict[tag].append(value)
-                else:
-                    return_dict[tag] = [return_dict[tag]]
-                    return_dict[tag].append(value)
+          if tag in return_dict:
+            if type(return_dict[tag])== list:
+              return_dict[tag].append(value)
             else:
-                if value in ["true", "false"]:
-                    if value == "true":
-                        value = True
-                    else:
-                        value = False
-                return_dict[tag] = value
-    return return_dict
+              return_dict[tag] = [return_dict[tag]]
+              return_dict[tag].append(value)
+          else:
+            return_dict[tag] = value
+      return return_dict
+
+    
+def save_server_stats(stats, type="find_videos"):
+    if not config.get_setting("server_stats"):
+        return
+        
+    stats_file = os.path.join(config.get_data_path(), "server_stats.json")
+    today = datetime.datetime.now().strftime ("%Y%m%d")
+    
+    #Leemos el archivo
+    try:
+        server_stats= jsontools.load_json(open(stats_file, "rb").read())
+    except:
+        server_stats = {"created": time.time(), "data": {}}
+    
+    #Actualizamos los datos
+    for server in stats:
+        if not server in server_stats["data"]:
+            server_stats["data"][server]= {}
+        
+        if not today in server_stats["data"][server]:
+            server_stats["data"][server][today] = {"find_videos": {"found": 0}, "resolve": {"sucess": 0, "error": 0}}
+            
+        server_stats["data"][server][today][type][stats[server]] += 1
+     
+    #Guardamos el archivo            
+    open(stats_file, "wb").write(jsontools.dump_json(server_stats))
+    
+    #Enviamos al servidor
+    if time.time() - server_stats["created"] > 86400: #86400: #1 Dia
+        from core import httptools
+        if httptools.downloadpage("url servidor", headers= {'Content-Type': 'application/json'}, post=jsontools.dump_json(server_stats)).sucess:
+            os.remove(stats_file)
+            logger.info("Datos enviados correctamente")
+        else:
+            logger.info("No se han podido enviar los datos")
+

--- a/python/main-classic/platformcode/launcher.py
+++ b/python/main-classic/platformcode/launcher.py
@@ -35,6 +35,7 @@ from core import config
 from core import library
 from core import logger
 from core import scrapertools
+from core import servertools
 from core.item import Item
 from platformcode import platformtools
 
@@ -227,16 +228,13 @@ def run():
                 # First checks if channel has a "findvideos" function
                 if hasattr(channel, 'findvideos'):
                     itemlist = getattr(channel, item.action)(item)
+                    itemlist = servertools.filter_servers(itemlist)
 
                 # If not, uses the generic findvideos function
                 else:
                     logger.info("No channel 'findvideos' method, "
                                 "executing core method")
-                    from core import servertools
                     itemlist = servertools.find_video_items(item)
-
-                if config.get_setting('filter_servers') == True:
-                    itemlist = filtered_servers(itemlist)
 
                 if config.get_setting("max_links", "biblioteca") != 0:
                     itemlist = limit_itemlist(itemlist)
@@ -339,101 +337,6 @@ def run():
                 log_message)
 
 
-def set_server_list():
-    logger.info()
-
-    server_white_list = []
-    server_black_list = []
-
-    if len(config.get_setting('whitelist')) > 0:
-        server_white_list_key = config.get_setting('whitelist').replace(', ', ',').replace(' ,', ',')
-        server_white_list = re.split(',', server_white_list_key)
-
-    if len(config.get_setting('blacklist')) > 0:
-        server_black_list_key = config.get_setting('blacklist').replace(', ', ',').replace(' ,', ',')
-        server_black_list = re.split(',', server_black_list_key)
-
-    logger.info("WhiteList %s" % server_white_list)
-    logger.info("BlackList %s" % server_black_list)
-
-    return server_white_list, server_black_list
-
-
-def filtered_servers(itemlist):
-    logger.info()
-    # logger.debug("Inlet itemlist size: %i" % len(itemlist))
-
-    new_list = []
-    white_counter = 0
-    black_counter = 0
-
-    server_white_list, server_black_list = set_server_list()
-
-    white_list_order = config.get_setting("white_list_order", "biblioteca")
-
-    if len(server_white_list) > 0:
-        logger.info("WhiteList")
-        if white_list_order:
-            for server in server_white_list:
-                logger.info("Servidor: " + server)
-                for item in itemlist:
-                    if server in unicode(item.title, "utf8").lower().encode("utf8"):
-                        logger.info("Coincidencia: " + item.title)
-                        new_list.append(item)
-                        white_counter += 1
-
-        else:
-            for item in itemlist:
-                logger.info("item.title: " + item.title)
-                if any(server in unicode(item.title, "utf8").lower().encode("utf8")
-                       for server in server_white_list):
-                    # logger.info("found")
-                    new_list.append(item)
-                    white_counter += 1
-                # else:
-                #     logger.info("not found")
-
-    if len(server_black_list) > 0:
-        logger.info("BlackList")
-
-        # Si existe 'new_list' se añade lo restante y se filtra
-        if len(new_list) != 0:
-            # Se añade al final de 'new_list' lo que no tuviera de 'itemlist'
-            if len(new_list) != len(itemlist):
-                for item_1 in itemlist:
-                    coincidencia = False
-                    for item_2 in new_list:
-                        if item_2.title == item_1.title:
-                            coincidencia = True
-                            break
-                    if not coincidencia:
-                        new_list.append(item_1)
-
-            itemlist = new_list
-            new_list = []
-
-        for item in itemlist:
-            logger.info("item.title: " + item.title)
-            if any(server in unicode(item.title, "utf8").lower().encode("utf8")
-                   for server in server_black_list):
-                # logger.info("found")
-                black_counter += 1
-
-            # Se pasa a 'new_list' si el servidor no estaba en la lista negra.
-            else:
-                new_list.append(item)
-
-    logger.info("WhiteList server %s has #%d rows" %
-                (server_white_list, white_counter))
-    logger.info("BlackList server %s has #%d rows" %
-                (server_black_list, black_counter))
-    logger.info("Rest has #%d rows" % (len(new_list) - white_counter))
-
-    if len(new_list) == 0:
-        new_list = itemlist
-
-    # logger.debug("Outlet itemlist size: %i" % len(new_list))
-    return new_list
 
 
 def reorder_itemlist(itemlist):
@@ -541,9 +444,9 @@ def play_from_library(item):
 
         p_dialog.update(50, '')
 
-        # Se filtran los enlaces segun la lista blanca y negra
-        if config.get_setting('filter_servers') == True:
-            itemlist = filtered_servers(itemlist)
+        '''# Se filtran los enlaces segun la lista negra
+        if config.get_setting('filter_servers', "servers"):
+            itemlist = servertools.filter_servers(itemlist)'''
 
         # Se limita la cantidad de enlaces a mostrar
         if config.get_setting("max_links", "biblioteca") != 0:

--- a/python/main-classic/platformcode/xbmc_config_menu.py
+++ b/python/main-classic/platformcode/xbmc_config_menu.py
@@ -30,6 +30,7 @@ import os
 
 import xbmcgui
 from core import channeltools
+from core import servertools
 from core import config
 from core import logger
 
@@ -201,7 +202,15 @@ class SettingsWindow(xbmcgui.WindowXMLDialog):
 
                 # La llamada se hace desde un canal
                 self.list_controls, default_values = channeltools.get_channel_controls_settings(self.channel)
+                self.kwargs = {"channel": self.channel}
+                
+            # Si la ruta del canal esta en la carpeta "servers", obtenemos los controles y valores mediante servertools
+            elif os.path.join(config.get_runtime_path(), "servers") in channelpath:
 
+                # La llamada se hace desde un canal
+                self.list_controls, default_values = servertools.get_server_controls_settings(self.channel)
+                self.kwargs = {"server": self.channel}
+                
             # En caso contrario salimos
             else:
                 return None
@@ -566,9 +575,9 @@ class SettingsWindow(xbmcgui.WindowXMLDialog):
 
             # Decidimos si usar el valor por defecto o el valor guardado
             if c["type"] in ["bool", "text", "list"]:
-                if id not in self.values:
+                if c["id"] not in self.values:
                     if not self.callback:
-                        self.values[c["id"]] = config.get_setting(c["id"], self.channel)
+                        self.values[c["id"]] = config.get_setting(c["id"], **self.kwargs)
                     else:
                         self.values[c["id"]] = c["default"]
 
@@ -733,7 +742,7 @@ class SettingsWindow(xbmcgui.WindowXMLDialog):
         if id == 10004:
             '''if not self.callback:
                 for v in self.values:
-                    config.set_setting(v, self.values[v], self.channel)
+                    config.set_setting(v, self.values[v], **self.kwargs)
                 self.close()
             else:
                 self.close()

--- a/python/main-classic/resources/settings.xml
+++ b/python/main-classic/resources/settings.xml
@@ -8,7 +8,11 @@
         <setting id="channel_language" type="labelenum" values="all|es|en|it" label="30019" default="all"/>
         <setting id="forceview" type="bool" label="30043" default="false"/>
         <setting id="debug" type="bool" label="30003" default="false"/>
-
+        <setting label="Uso de servidores" type="lsep"/>
+        <setting id="resolve_priority" type="enum" label="Método prioritario" lvalues="Free primero|Premium primero|Debriders primero" default="0"/>
+        <setting id="resolve_stop" type="bool" label="Dejar de buscar cuando encuentre una opción" default="true"/>
+        <setting id="hidepremium" type="bool" label="Ocultar servidores de pago sin cuenta" default="false"/>
+        <setting id="server_stats" type="bool" label="Enviar estadisticas sobre el uso de servidores" default="true"/>
         <setting type="sep"/>
         <setting label="Canales para adultos" type="lsep"/>
         <setting id="adult_aux_intro_password" type="text" label="Contraseña:" option="hidden"  default=""/>
@@ -27,6 +31,7 @@
 
     <!-- Login -->
     <category label="30500">
+        <!--
         <setting id="hidepremium" type="bool" label="Ocultar servidores de pago sin cuenta" default="false"/>
 
         <setting type="sep"/>
@@ -62,7 +67,7 @@
         <setting id="crunchyrolluser" type="text" label="30014" enable="eq(-1,true)" default=""/>
         <setting id="crunchyrollpassword" type="text" label="30015" option="hidden" enable="!eq(-1,)+eq(-2,true)" default=""/>
         <setting id="crunchyrollsub" type="enum" label="Idioma de subtítulos preferido en Crunchyroll" values="Español España|Español Latino|Inglés|Italiano|Francés|Portugués|Alemán" default="0"/>
-
+        -->
         <setting type="sep"/>
         <setting id="jdownloader_enabled" type="bool" label="JDownloader" default="false"/>
         <setting id="jdownloader" type="text" label="30022" enable="eq(-1,true)" default="http://127.0.0.1:10025"/>
@@ -129,13 +134,14 @@
     </category>
 
     <category label="Otros"><!--30503 -->
+        <!--
         <setting label="Filtros" type="lsep"/>
         <setting id="filter_servers" type="bool" label="30068" default="false"/>
 
         <setting label="30071" type="lsep"/>
         <setting id="whitelist" type="text" label="30069" enable="eq(-2,true)" default=""/>
         <setting id="blacklist" type="text" label="30070" enable="eq(-3,true)" default=""/>
-
+        -->
         <setting label="Info de películas/series en menú contextual" type="lsep"/>
         <setting id="infoplus" type="bool" label="Mostrar opción Infoplus:" default="true"/>
         <setting id="extended_info" type="bool" label="Mostrar opción ExtendedInfo (Necesario addon externo):" default="false"/>

--- a/python/main-classic/servers/adnstream.xml
+++ b/python/main-classic/servers/adnstream.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>adnstream.com/video/([a-zA-Z]+)</pattern>
+			<url>http://www.adnstream.com/video/\1/</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>adnstream</id>
 	<name>adnstream</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_adnstream.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/allmyvideos.xml
+++ b/python/main-classic/servers/allmyvideos.xml
@@ -1,14 +1,73 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Reparado, utiliza proxy en caso que salte el geobloqueo</changes>
-	<date>04/06/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>04/06/2016</date>
+			<description>Reparado, utiliza proxy en caso que salte el geobloqueo</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+			<value>http://allmyvideos.net/embed-theme.html</value>
+			<value>http://allmyvideos.net/embed-jquery.html</value>
+			<value>http://allmyvideos.net/embed-s.html</value>
+			<value>http://allmyvideos.net/embed-images.html</value>
+			<value>http://allmyvideos.net/embed-faq.html</value>
+			<value>http://allmyvideos.net/embed-embed.html</value>
+			<value>http://allmyvideos.net/embed-ri.html</value>
+			<value>http://allmyvideos.net/embed-d.html</value>
+			<value>http://allmyvideos.net/embed-css.html</value>
+			<value>http://allmyvideos.net/embed-js.html</value>
+			<value>http://allmyvideos.net/embed-player.html</value>
+			<value>http://allmyvideos.net/embed-cgi.html</value>
+			<value>http://allmyvideos.net/embed-i.html</value>
+			<value>http://allmyvideos.net/images</value>
+			<value>http://allmyvideos.net/theme</value>
+			<value>http://allmyvideos.net/xupload</value>
+			<value>http://allmyvideos.net/s</value>
+			<value>http://allmyvideos.net/js</value>
+			<value>http://allmyvideos.net/jquery</value>
+			<value>http://allmyvideos.net/login</value>
+			<value>http://allmyvideos.net/make</value>
+			<value>http://allmyvideos.net/i</value>
+			<value>http://allmyvideos.net/faq</value>
+			<value>http://allmyvideos.net/tos</value>
+			<value>http://allmyvideos.net/premium</value>
+			<value>http://allmyvideos.net/checkfiles</value>
+			<value>http://allmyvideos.net/privacy</value>
+			<value>http://allmyvideos.net/refund</value>
+			<value>http://allmyvideos.net/links</value>
+			<value>http://allmyvideos.net/contact</value>
+		</ignore_urls>
+		<patterns>
+			<pattern>allmyvideos.net/(?:embed-)?([a-z0-9]+)</pattern>
+			<url>http://allmyvideos.net/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>allmyvideos</id>
 	<name>allmyvideos</name>
 	<premium>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_allmyvideos.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>2</version>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/allvid.xml
+++ b/python/main-classic/servers/allvid.xml
@@ -1,22 +1,48 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<id>allvid</id>
-	<name>allvid</name>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>02/04/2017</date>
 			<autor>Intel1</autor>
+			<date>02/04/2017</date>
 			<description>Uso de httptools y detectado archivo borrado</description>
 		</change>
 		<change>
+			<autor></autor>
 			<date>25/03/2016</date>
-			<description>Versión incial.</description>
+			<description>Versión incial</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>allvid.ch/(?:embed-)?([a-z0-9]+)</pattern>
+			<url>http://allvid.ch/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
-	<premium></premium>
+	<id>allvid</id>
+	<name>allvid</name>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_allvid.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/auroravid.xml
+++ b/python/main-classic/servers/auroravid.xml
@@ -1,24 +1,52 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>21/03/2017</date>
 			<autor>Cmos</autor>
+			<date>21/03/2017</date>
 			<description>Conector corregido</description>
 		</change>
 		<change>
-			<date>25/03/2016</date>
 			<autor></autor>
+			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>auroravid.to/video/([a-z0-9]{13})</pattern>
+			<url>http://www.auroravid.to/video/\1</url>
+		</patterns>
+		<patterns>
+			<pattern>http://embed.auroravid.to/embed.php.*?v=([a-z0-9]{13})</pattern>
+			<url>http://www.auroravid.to/video/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>auroravid</id>
 	<name>auroravid</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_auroravid.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/backin.xml
+++ b/python/main-classic/servers/backin.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(?:backin).net/([A-Z0-9]+)</pattern>
+			<url>http://backin.net/s/generating.php?code=\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>backin</id>
 	<name>backin</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_backin.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/bigfile.xml
+++ b/python/main-classic/servers/bigfile.xml
@@ -1,15 +1,44 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>bigfile.to/((?:list|file)/[\w]+)</pattern>
+			<url>https://www.bigfile.to/\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>bigfile</id>
 	<name>bigfile</name>
 	<premium>
 		<value>realdebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_bigfile.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/bitshare.xml
+++ b/python/main-classic/servers/bitshare.xml
@@ -1,8 +1,29 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(bitshare.com/files/[^/]+/[\w.+\-_]+)</pattern>
+			<url>http://\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(bitshare.com/files/[a-z0-9]+)[^/a-z0-9]</pattern>
+			<url>http://\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(bitshare.com/\?f=[\w+]+)</pattern>
+			<url>http://\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>bitshare</id>
 	<name>bitshare</name>
@@ -10,7 +31,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_bitshare.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/bitvidsx.xml
+++ b/python/main-classic/servers/bitvidsx.xml
@@ -1,24 +1,52 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>21/03/2017</date>
 			<autor>Cmos</autor>
+			<date>21/03/2017</date>
 			<description>Conector corregido</description>
 		</change>
 		<change>
-			<date>25/03/2016</date>
 			<autor></autor>
+			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
 	</changes>
-
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(http://www.(?:videoweed|bitvid)\.[a-z]+/file/[a-zA-Z0-9]+)</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(http://embed.(?:videoweed|bitvid)\.[a-z]+/embed.php?v=[a-zA-Z0-9]+)</pattern>
+			<url>\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>bitvidsx</id>
 	<name>bitvidsx</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_bitvidsx.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/clicknupload.xml
+++ b/python/main-classic/servers/clicknupload.xml
@@ -1,15 +1,44 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>clicknupload.(?:me|com)/([a-z0-9]+)</pattern>
+			<url>http://clicknupload.me/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>clicknupload</id>
 	<name>clicknupload</name>
 	<premium>
 		<value>realdebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_clicknupload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/cloudy.xml
+++ b/python/main-classic/servers/cloudy.xml
@@ -1,24 +1,48 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>05/03/2017</date>
 			<autor>Cmos</autor>
+			<date>05/03/2017</date>
 			<description>Corregido por cambios en el servidor</description>
 		</change>
 		<change>
-			<date>03/04/2016</date>
 			<autor>supkk</autor>
+			<date>03/04/2016</date>
 			<description>Versión inicial</description>
 		</change>
 	</changes>
-
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>cloudy.ec/(?:embed.php\?id=|v/)([A-z0-9]+)</pattern>
+			<url>https://www.cloudy.ec/embed.php?id=\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>cloudy</id>
 	<name>cloudy</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_cloudy.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/cnubis.xml
+++ b/python/main-classic/servers/cnubis.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>cnubis.com/plugins/mediaplayer/([^/]+/[^.]+.php\?u\=[A-Za-z0-9]+)</pattern>
+			<url>http://cnubis.com/plugins/mediaplayer/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>cnubis</id>
 	<name>cnubis</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_cnubis.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/copiapop.xml
+++ b/python/main-classic/servers/copiapop.xml
@@ -1,18 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>1</version>
 	<changes>
 		<change>
-			<date>16/02/2017</date>
 			<autor>Cmos</autor>
+			<date>16/02/2017</date>
 			<description>Primera versión</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>((?:copiapop.com|diskokosmiko.mx)/[^\s'"]+)</pattern>
+			<url>http://\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>copiapop</id>
 	<name>copiapop</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/EjbfM7p.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/crunchyroll.py
+++ b/python/main-classic/servers/crunchyroll.py
@@ -25,7 +25,7 @@ proxy = "http://anonymouse.org/cgi-bin/anon-www.cgi/"
 def test_video_exists(page_url):
     logger.info("(page_url='%s')" % page_url)
 
-    premium = config.get_setting("crunchyrollpremium")
+    premium = config.get_setting("premium",server="crunchyroll")
     if premium:
         return login(page_url)
     data = httptools.downloadpage(page_url, headers=GLOBAL_HEADER, replace_headers=True).data
@@ -70,7 +70,7 @@ def get_video_url(page_url, premium = False, user="", password="", video_passwor
     
     try:
         idiomas = ['Español \(España\)', 'Español\]', 'English', 'Italiano', 'Français', 'Português', 'Deutsch']
-        index_sub = int(config.get_setting("crunchyrollsub"))
+        index_sub = int(config.get_setting("sub",server="crunchyroll"))
         idioma_sub = idiomas[index_sub]
         link_sub = scrapertools.find_single_match(data, "link='([^']+)' title='\[%s" % idioma_sub)
         if not link_sub and index_sub == 0:
@@ -123,8 +123,8 @@ def find_videos(data):
 
 def login(page_url):
     login_page = "https://www.crunchyroll.com/login"
-    user = config.get_setting("crunchyrolluser")
-    password = config.get_setting("crunchyrollpassword")
+    user = config.get_setting("user",server="crunchyroll")
+    password = config.get_setting("password",server="crunchyroll")
     data = httptools.downloadpage(login_page, headers=GLOBAL_HEADER, replace_headers=True).data
 
     if not "<title>Redirecting" in data:

--- a/python/main-classic/servers/crunchyroll.xml
+++ b/python/main-classic/servers/crunchyroll.xml
@@ -1,25 +1,86 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<id>crunchyroll</id>
-	<name>crunchyroll</name>
-
-	<version>2</version>
 	<changes>
 		<change>
-			<date>12/05/2017</date>
 			<autor>Cmos</autor>
+			<date>12/05/2017</date>
 			<description>Se añade libreria jscrypto para que funcione en cualquier sistema y deteccion enlaces rtmpe</description>
 		</change>
 		<change>
+			<autor></autor>
 			<date>11/01/2017</date>
-			<autor>Cmos</autor>
 			<description>Versión inicial</description>
 		</change>
 	</changes>
-
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(crunchyroll.com/[^/]+/[^-]*-\d+).*$</pattern>
+			<url>http://www.\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
-	<premium></premium>
+	<id>crunchyroll</id>
+	<name>crunchyroll</name>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>premium</id>
+		<label>Activar cuenta premium</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<enabled>eq(-1,true)</enabled>
+		<id>user</id>
+		<label>@30014</label>
+		<type>text</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
+		<hidden>true</hidden>
+		<id>password</id>
+		<label>@30015</label>
+		<type>text</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>0</default>
+		<enabled>eq(-3,true)</enabled>
+		<id>sub</id>
+		<label>Idioma de subtítulos preferido</label>
+		<lvalues>Español España</lvalues>
+		<lvalues>Español Latino</lvalues>
+		<lvalues>Inglés</lvalues>
+		<lvalues>Italiano</lvalues>
+		<lvalues>Francés</lvalues>
+		<lvalues>Portugués</lvalues>
+		<lvalues>Alemán</lvalues>
+		<type>list</type>
+		<visible>true</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/SglkLAb.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/cumlouder.xml
+++ b/python/main-classic/servers/cumlouder.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>http://es.cumlouder.com/embed/([a-z0-9A-Z]+)/</pattern>
+			<url>http://es.cumlouder.com/embed/\1/</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>cumlouder</id>
 	<name>cumlouder</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_cumlouder.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/dailymotion.xml
+++ b/python/main-classic/servers/dailymotion.xml
@@ -1,20 +1,26 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>07/04/2017</date>
 			<autor>Cmos</autor>
+			<date>07/04/2017</date>
 			<description>Corregido para adaptarlo al uso de httptools ya que fallaba</description>
 		</change>
 		<change>
-			<date>25/03/2016</date>
 			<autor></autor>
+			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
 	</changes>
-	<changes>Versión incial</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>dailymotion.com/(?:video/|swf/(?:video/|)|)(?:embed/video/|)([A-z0-9]+)</pattern>
+			<url>http://www.dailymotion.com/embed/video/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>dailymotion</id>
 	<name>dailymotion</name>
@@ -22,6 +28,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_dailymotion.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/datoporn.py
+++ b/python/main-classic/servers/datoporn.py
@@ -77,3 +77,4 @@ def find_videos(data):
             logger.info("  url duplicada=" + url)
 
     return devuelve
+

--- a/python/main-classic/servers/datoporn.xml
+++ b/python/main-classic/servers/datoporn.xml
@@ -1,29 +1,53 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>4</version>
 	<changes>
 		<change>
-			<date>13/05/2017</date>
 			<autor>Cmos</autor>
+			<date>13/05/2017</date>
 			<description>Corregido orden y calidades</description>
 		</change>
 		<change>
-			<date>21/02/2017</date>
 			<autor>Cmos</autor>
+			<date>21/02/2017</date>
 			<description>Corregido y añadida opcion m3u8</description>
 		</change>
 		<change>
-			<date>28/07/2016</date>
 			<autor>Cmos</autor>
+			<date>28/07/2016</date>
 			<description>Versión inicial</description>
 		</change>
 	</changes>
-
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>datoporn.com/(?:embed-|)([A-z0-9]+)</pattern>
+			<url>http://datoporn.com/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>datoporn</id>
 	<name>datoporn</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/tBSWudd.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>5</version>
 </server>

--- a/python/main-classic/servers/debriders/alldebrid.xml
+++ b/python/main-classic/servers/debriders/alldebrid.xml
@@ -1,12 +1,41 @@
 <?xml version="1.0" ?>
 <server>
-	<active>false</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<active>true</active>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
 	<free>false</free>
 	<id>alldebrid</id>
 	<name>All-Debrid</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>premium</id>
+		<label>Activar cuenta premium</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<enabled>eq(-1,true)</enabled>
+		<id>user</id>
+		<label>@30014</label>
+		<type>text</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
+		<hidden>true</hidden>
+		<id>password</id>
+		<label>@30015</label>
+		<type>text</type>
+		<visible>true</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_alldebrid.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
 	<version>1</version>

--- a/python/main-classic/servers/debriders/realdebrid.py
+++ b/python/main-classic/servers/debriders/realdebrid.py
@@ -8,7 +8,6 @@
 import time
 import urllib
 
-from core import channeltools
 from core import config
 from core import jsontools
 from core import logger
@@ -19,11 +18,11 @@ headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:47.0) Gecko/20
 
 
 # Returns an array of possible video url's from the page_url
-def get_video_url(page_url, premium=False, video_password=""):
+def get_video_url( page_url , premium = False , user="" , password="", video_password="" ):
     logger.info("(page_url='%s' , video_password=%s)" % (page_url, video_password))
 
     # Se comprueba si existe un token guardado y sino se ejecuta el proceso de autentificación
-    token_auth = channeltools.get_channel_setting("realdebrid_token", "realdebrid")
+    token_auth = config.get_setting("token", server="realdebrid")
     if token_auth is None or token_auth == "":
         if config.is_xbmc():
             token_auth = authentication()
@@ -40,9 +39,9 @@ def get_video_url(page_url, premium=False, video_password=""):
 
     # Si el token es erróneo o ha caducado, se solicita uno nuevo
     if "error" in data and data["error"] == "bad_token":
-        debrid_id = channeltools.get_channel_setting("realdebrid_id", "realdebrid")
-        secret = channeltools.get_channel_setting("realdebrid_secret", "realdebrid")
-        refresh = channeltools.get_channel_setting("realdebrid_refresh", "realdebrid")
+        debrid_id = config.get_setting("id", server="realdebrid")
+        secret = config.get_setting("secret", server="realdebrid")
+        refresh = config.get_setting("refresh", server="realdebrid")
 
         post_token = urllib.urlencode({"client_id": debrid_id, "client_secret": secret, "code": refresh,
                                        "grant_type": "http://oauth.net/grant_type/device/1.0"})
@@ -51,7 +50,7 @@ def get_video_url(page_url, premium=False, video_password=""):
         renew_token = jsontools.load_json(renew_token)
         if not "error" in renew_token:
             token_auth = renew_token["access_token"]
-            channeltools.set_channel_setting("realdebrid_token", token_auth, "realdebrid")
+            config.set_setting("token", token_auth, server="realdebrid")
             headers["Authorization"] = "Bearer %s" % token_auth
             data = scrapertools.downloadpage(url, post=post_link, headers=headers.items())
             data = jsontools.load_json(data)
@@ -141,10 +140,10 @@ def authentication():
         token = data["access_token"]
         refresh = data["refresh_token"]
 
-        channeltools.set_channel_setting("realdebrid_id", debrid_id, "realdebrid")
-        channeltools.set_channel_setting("realdebrid_secret", secret, "realdebrid")
-        channeltools.set_channel_setting("realdebrid_token", token, "realdebrid")
-        channeltools.set_channel_setting("realdebrid_refresh", refresh, "realdebrid")
+        config.set_setting("id", debrid_id, server="realdebrid")
+        config.set_setting("secret", secret, server="realdebrid")
+        config.set_setting("token", token, server="realdebrid")
+        config.set_setting("refresh", refresh, server="realdebrid")
 
         return token
     except:

--- a/python/main-classic/servers/debriders/realdebrid.xml
+++ b/python/main-classic/servers/debriders/realdebrid.xml
@@ -1,12 +1,26 @@
 <?xml version="1.0" ?>
 <server>
-	<active>false</active>
-	<changes>Corregido al haberse desactivado la api que se usaba</changes>
-	<date>14/06/2016</date>
+	<active>true</active>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>14/06/2016</date>
+			<description>Corregido al haberse desactivado la api que se usaba</description>
+		</change>
+	</changes>
 	<free>false</free>
 	<id>realdebrid</id>
 	<name>Real-Debrid</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>premium</id>
+		<label>Activar cuenta premium</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_realdebrid.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
 	<version>2</version>

--- a/python/main-classic/servers/depositfiles.xml
+++ b/python/main-classic/servers/depositfiles.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>false</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(depositfiles.com/files/[a-z0-9]+)</pattern>
+			<url>http://\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>depositfiles</id>
 	<name>depositfiles</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_depositfiles.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/directo.xml
+++ b/python/main-classic/servers/directo.xml
@@ -1,13 +1,67 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(http://[a-zA-Z0-9]+\.mysites\.com\/get_file\/.*?\.mp4)</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>flashvars="file=(http://[^\.]+.myspacecdn[^\&]+)&</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(http://[^\.]+\.myspacecdn.*?\.flv)</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(http://api.ning.com.*?\.flv)</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>file\=(http\:\/\/es.video.netlogstatic[^\&]+)\&</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>file=http.*?mangaid.com(.*?)backcolor=</pattern>
+			<url>http://mangaid.com\1</url>
+		</patterns>
+		<patterns>
+			<pattern>so\.addVariable\(\’file\’,\’(http\://peliculasid[^\']+)</pattern>
+			<url>\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>directo</id>
 	<name>directo</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_directo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/divxstage.xml
+++ b/python/main-classic/servers/divxstage.xml
@@ -1,24 +1,48 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
-        <change>
-            <date>21/03/2017</date>
-            <autor>Cmos</autor>
-            <description>Conector corregido</description>
-        </change>
-        <change>
-            <date>25/03/2016</date>
-            <autor></autor>
-            <description>Versión incial</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>21/03/2017</date>
+			<description>Conector corregido</description>
+		</change>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(?:divxstage|cloudtime).[^/]+/video/([^"' ]+)</pattern>
+			<url>http://www.cloudtime.to/embed/?v=\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>divxstage</id>
 	<name>divxstage</name>
 	<premium>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_divxstage.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/documentary.xml
+++ b/python/main-classic/servers/documentary.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>http://documentary.es/(\d+[a-z0-9\-]+)</pattern>
+			<url>http://documentary.es/\1?embed"</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>documentary</id>
 	<name>documentary</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_documentary.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/eroshare.xml
+++ b/python/main-classic/servers/eroshare.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>27/02/2017</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>27/02/2017</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(https://eroshare.com/embed/[a-zA-Z0-9]+)</pattern>
+			<url>\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>eroshare</id>
 	<name>eroshare</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>https://s31.postimg.org/cewftt397/eroshare.png</thumbnail>
-	<update_url></update_url>
-	<version>1</version>
+	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/facebook.xml
+++ b/python/main-classic/servers/facebook.xml
@@ -1,14 +1,47 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>http://www.facebook.com/v/([\d]+)</pattern>
+			<url>http://www.facebook.com/video/external_video.php?v=\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(http://video.ak.facebook.com/.*?\.mp4)</pattern>
+			<url>\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>facebook</id>
 	<name>facebook</name>
 	<premium>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_facebook.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/fakingstv.xml
+++ b/python/main-classic/servers/fakingstv.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>http://tv.fakings.com/embed/([a-z0-9A-Z]+)/</pattern>
+			<url>http://tv.fakings.com/embed/\1/</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>fakingstv</id>
 	<name>fakingstv</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_fakingstv.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/fastplay.xml
+++ b/python/main-classic/servers/fastplay.xml
@@ -1,23 +1,48 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>29/05/2017</date>
 			<autor>Intel1</autor>
+			<date>29/05/2017</date>
 			<description>Detección de subtítulos y reparado detección de resolución de videos</description>
 		</change>
 		<change>
-			<date>16/02/2017</date>
 			<autor>Cmos</autor>
+			<date>16/02/2017</date>
 			<description>Primera versión</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>fastplay.(?:cc|sx)/(?:flash-)?([A-z0-9]+)</pattern>
+			<url>http://fastplay.cc/flash-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>fastplay</id>
 	<name>fastplay</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/vHDcd6Y.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/filebox.xml
+++ b/python/main-classic/servers/filebox.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>false</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>filebox.com/(?:embed-)?([0-9a-zA-Z]+)</pattern>
+			<url>http://www.filebox.com/\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>filebox</id>
 	<name>filebox</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_filebox.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/filefactory.xml
+++ b/python/main-classic/servers/filefactory.xml
@@ -1,8 +1,21 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(filefactory.com/file/[a-z0-9]+(?:/n/.*?\.(?:avi|mp4|rar|mkv))?)</pattern>
+			<url>http://www.\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>filefactory</id>
 	<name>filefactory</name>
@@ -10,7 +23,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_filefactory.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/fileflyer.xml
+++ b/python/main-classic/servers/fileflyer.xml
@@ -1,8 +1,21 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(fileflyer.com/view/[a-zA-Z0-9]+)</pattern>
+			<url>http://www.\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>fileflyer</id>
 	<name>fileflyer</name>
@@ -10,7 +23,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_fileflyer.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/filescdn.xml
+++ b/python/main-classic/servers/filescdn.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>15/02/2017</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>15/02/2017</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>((?:(?:http:\/\/|https:\/\/)filescdn\.com\/(?:embed-.*?\.html|[a-zA-Z0-9]+)))</pattern>
+			<url>\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>filescdn</id>
 	<name>filescdn</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>https://s31.postimg.org/ijne6piij/filescdn.png</thumbnail>
-	<update_url></update_url>
-	<version>1</version>
+	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/fileserve.xml
+++ b/python/main-classic/servers/fileserve.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>false</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>http://www.fileserve.com/file/([A-Z0-9a-z]{7})</pattern>
+			<url>http://www.fileserve.com/file/\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>fileserve</id>
 	<name>fileserve</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_fileserve.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/filesmonster.xml
+++ b/python/main-classic/servers/filesmonster.xml
@@ -1,14 +1,67 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Version incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Version incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>filesmonster.com/download(.*?)</pattern>
+			<url>http://filesmonster.com/download\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>filesmonster</id>
 	<name>filesmonster</name>
-	<premium>filesmonster</premium>
+	<premium>
+		<value>filesmonster</value>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>premium</id>
+		<label>Activar cuenta premium</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<enabled>eq(-1,true)</enabled>
+		<id>user</id>
+		<label>@30014</label>
+		<type>text</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
+		<hidden>true</hidden>
+		<id>password</id>
+		<label>@30015</label>
+		<type>text</type>
+		<visible>true</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_filesmonster.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>
-

--- a/python/main-classic/servers/filez.xml
+++ b/python/main-classic/servers/filez.xml
@@ -1,23 +1,48 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>3</version>
 	<changes>
 		<change>
-			<date>12/04/2017</date>
 			<autor>Cmos</autor>
+			<date>12/04/2017</date>
 			<description>Corregido por cambios</description>
 		</change>
 		<change>
-			<date>27/02/2017</date>
 			<autor>Cmos</autor>
+			<date>27/02/2017</date>
 			<description>Primera versión</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>filez.tv/(?:embed/u=)?([A-z0-9]+)</pattern>
+			<url>http://filez.tv/embed/u=\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>filez</id>
 	<name>filez</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/HasfjUH.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>4</version>
 </server>

--- a/python/main-classic/servers/flashx.xml
+++ b/python/main-classic/servers/flashx.xml
@@ -1,24 +1,48 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>3</version>
 	<changes>
 		<change>
-			<date>21/03/2017</date>
 			<autor>Cmos</autor>
+			<date>21/03/2017</date>
 			<description>Mejorado el test de video y uso de httptools</description>
 		</change>
 		<change>
-			<date>04/06/2016</date>
 			<autor></autor>
+			<date>04/06/2016</date>
 			<description>Reparado por cambio en la url embebida</description>
 		</change>
 	</changes>
-
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>flashx.(?:tv|pw)/(?:embed.php\?c=|embed-|playvid-|)([A-z0-9]+)</pattern>
+			<url>https://www.flashx.tv/playvid-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>flashx</id>
 	<name>flashx</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_flashx.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>4</version>
 </server>

--- a/python/main-classic/servers/fourshared.xml
+++ b/python/main-classic/servers/fourshared.xml
@@ -1,8 +1,30 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+			<value>http://www.4shared.com/flash/player.swf</value>
+		</ignore_urls>
+		<patterns>
+			<pattern>(http://www.4shared.com/embed/[A-Z0-9a-z]+/[A-Z0-9a-z]+)</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>file=(http\://[a-z0-9]+.4shared.com/img/.*?\.flv)</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(http://www.4shared.com.*?)</pattern>
+			<url>\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>fourshared</id>
 	<name>fourshared</name>
@@ -10,7 +32,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_fourshared.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/freakshare.xml
+++ b/python/main-classic/servers/freakshare.xml
@@ -1,8 +1,21 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(freakshare.com/files/[^/]+/[^"'\n ]+)</pattern>
+			<url>http://\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>freakshare</id>
 	<name>freakshare</name>
@@ -10,7 +23,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_freakshare.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/gamovideo.xml
+++ b/python/main-classic/servers/gamovideo.xml
@@ -1,34 +1,58 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>5</version>
 	<changes>
 		<change>
-			<date>09/05/17</date>
 			<autor>Cmos</autor>
+			<date>09/05/17</date>
 			<description>Arreglado con el cambio de user agent</description>
 		</change>
 		<change>
-			<date>24/04/17</date>
 			<autor>Intel1</autor>
+			<date>24/04/17</date>
 			<description>Detectado mensaje:video se está procesando</description>
 		</change>
 		<change>
-			<date>23/03/17</date>
 			<autor>Cmos</autor>
+			<date>23/03/17</date>
 			<description>Arreglado con el cambio de user agent</description>
 		</change>
 		<change>
-			<date>07/11/16</date>
 			<autor>Cmos</autor>
+			<date>07/11/16</date>
 			<description>Modificado orden de los videos</description>
 		</change>
 	</changes>
-
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>gamovideo.com/(?:embed-)?([a-z0-9]+)</pattern>
+			<url>http://gamovideo.com/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>gamovideo</id>
 	<name>gamovideo</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_gamovideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>6</version>
 </server>

--- a/python/main-classic/servers/gigasize.xml
+++ b/python/main-classic/servers/gigasize.xml
@@ -1,8 +1,25 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(gigasize.com/get/[a-z0-9]+)</pattern>
+			<url>http://www.\1</url>
+		</patterns>
+		<patterns>
+			<pattern>gigasize.com/get.php\?d\=([a-z0-9]+)</pattern>
+			<url>http://www.gigasize.com/get/\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>gigasize</id>
 	<name>gigasize</name>
@@ -10,7 +27,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_gigasize.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/googlevideo.xml
+++ b/python/main-classic/servers/googlevideo.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>http://video.google.com/googleplayer.swf.*?docid=([0-9]+)</pattern>
+			<url>\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>googlevideo</id>
 	<name>googlevideo</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_googlevideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/hugefiles.xml
+++ b/python/main-classic/servers/hugefiles.xml
@@ -1,15 +1,44 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>hugefiles.net/([a-z0-9]+)</pattern>
+			<url>http://www.hugefiles.net/\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>hugefiles</id>
 	<name>hugefiles</name>
 	<premium>
 		<value>realdebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_hugefiles.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/idowatch.xml
+++ b/python/main-classic/servers/idowatch.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>idowatch.net/(?:embed-)?([a-z0-9]+)</pattern>
+			<url>http://idowatch.net/\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>idowatch</id>
 	<name>idowatch</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_idowatch.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/kingvid.xml
+++ b/python/main-classic/servers/kingvid.xml
@@ -1,18 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>1</version>
 	<changes>
-        <change>
-            <date>28/04/2017</date>
-            <autor>Cmos</autor>
-            <description>Version inicial</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>28/04/2017</date>
+			<description>Version inicial</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>kingvid.tv/(?:embed-|)([A-z0-9]+)</pattern>
+			<url>http://kingvid.tv/embed-\1.html"</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>kingvid</id>
 	<name>kingvid</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/oq0tPhY.png?1</thumbnail>
-	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>	
+	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/letwatch.xml
+++ b/python/main-classic/servers/letwatch.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Reparado porque a veces devuelve enlace directo al video y no ofuscado</changes>
-	<date>04/06/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>04/06/2016</date>
+			<description>Reparado porque a veces devuelve enlace directo al video y no ofuscado</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>letwatch.(?:us|to)/(?:embed-|)([a-z0-9A-Z]+)(?:.html|)</pattern>
+			<url>http://letwatch.to/embed-\1.html"</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>letwatch</id>
 	<name>letwatch</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_letwatch.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>2</version>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/mailru.xml
+++ b/python/main-classic/servers/mailru.xml
@@ -1,24 +1,52 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>05/03/2017</date>
 			<autor>Cmos</autor>
+			<date>05/03/2017</date>
 			<description>Reparado por cambios y corregidas expresiones regulares</description>
 		</change>
 		<change>
-			<date>25/03/2016</date>
 			<autor></autor>
+			<date>25/03/2016</date>
 			<description>Versión inicial</description>
 		</change>
 	</changes>
-
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(?:videoapi|api.video).my.mail.ru/(?:videos|video)/embed/(mail|inbox)/([^/]+)/.*?/(\d+).html</pattern>
+			<url>http://videoapi.my.mail.ru/videos/embed/\1/\2/_myvideo/\3.html</url>
+		</patterns>
+		<patterns>
+			<pattern>my.mail.ru/(?:videos|video)/embed/(?!mail|inbox)([\w]+)</pattern>
+			<url>http://my.mail.ru/+/video/meta/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>mailru</id>
 	<name>mailru</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_mailru.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/mediafire.xml
+++ b/python/main-classic/servers/mediafire.xml
@@ -1,8 +1,37 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>mediafire.com/download.php\?([a-z0-9]+)</pattern>
+			<url>http://www.mediafire.com/?\1</url>
+		</patterns>
+		<patterns>
+			<pattern>mediafire.com/download/([a-z0-9]+)</pattern>
+			<url>http://www.mediafire.com/?\1</url>
+		</patterns>
+		<patterns>
+			<pattern>http://www.mediafire.com/\?([a-z0-9]+)</pattern>
+			<url>http://www.mediafire.com/?\1</url>
+		</patterns>
+		<patterns>
+			<pattern>http://www.mediafire.com/file/([a-z0-9]+)</pattern>
+			<url>http://www.mediafire.com/?\1</url>
+		</patterns>
+		<patterns>
+			<pattern>mediafire.com\%2F\%3F([a-z0-9]+)</pattern>
+			<url>http://www.mediafire.com/?\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>mediafire</id>
 	<name>mediafire</name>
@@ -10,7 +39,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_mediafire.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/mega.xml
+++ b/python/main-classic/servers/mega.xml
@@ -1,15 +1,56 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(mega.co.nz/\#\![A-Za-z0-9\-\_]+\![A-Za-z0-9\-\_]+)</pattern>
+			<url>https://\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(mega.co.nz/\#F\![A-Za-z0-9\-\_]+\![A-Za-z0-9\-\_]+)</pattern>
+			<url>https://\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(mega.nz/\#\![A-Za-z0-9\-\_]+\![A-Za-z0-9\-\_]+)</pattern>
+			<url>https://\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(mega.nz/\#F\![A-Za-z0-9\-\_]+\![A-Za-z0-9\-\_]+)</pattern>
+			<url>https://\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>mega</id>
 	<name>mega</name>
 	<premium>
 		<value>realdebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_mega.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/movshare.xml
+++ b/python/main-classic/servers/movshare.xml
@@ -1,13 +1,47 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>movshare.net/(?:embed|video)/([a-z0-9]+)</pattern>
+			<url>http://www.movshare.net/video/\1</url>
+		</patterns>
+		<patterns>
+			<pattern>movshare.net/embed.php\?v\=([a-z0-9]+)</pattern>
+			<url>http://www.movshare.net/video/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>movshare</id>
 	<name>movshare</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_movshare.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/mp4upload.xml
+++ b/python/main-classic/servers/mp4upload.xml
@@ -1,13 +1,44 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+			<value>http://www.mp4upload.com/embed/embed</value>
+		</ignore_urls>
+		<patterns>
+			<pattern>mp4upload.com/embed-([A-Za-z0-9]+)</pattern>
+			<url>http://www.mp4upload.com/embed-\1.html"</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>mp4upload</id>
 	<name>mp4upload</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_mp4upload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/netutv.xml
+++ b/python/main-classic/servers/netutv.xml
@@ -1,33 +1,79 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>5</version>
 	<changes>
-        <change>
-            <date>28/05/2017</date>
-            <autor>Cmos</autor>
-            <description>Reparado por cambio de dominio</description>
-        </change>
-        <change>
-            <date>06/04/2017</date>
-            <autor>Cmos</autor>
-            <description>Añadido deteccion de subtítulos en español e inglés</description>
-        </change>
-        <change>
-            <date>29/01/2017</date>
-            <autor>Cmos</autor>
-            <description>Reparado por cambios, se elimina la detección de enlaces de yaske que ya no se usa</description>
-        </change>
-        <change>
-            <date>31/08/2015</date>
-            <autor>tvalacarta</autor>
-            <description>Versión inicial</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>28/05/2017</date>
+			<description>Reparado por cambio de dominio</description>
+		</change>
+		<change>
+			<autor>Cmos</autor>
+			<date>06/04/2017</date>
+			<description>Añadido deteccion de subtítulos en español e inglés</description>
+		</change>
+		<change>
+			<autor>Cmos</autor>
+			<date>29/01/2017</date>
+			<description>Reparado por cambios, se elimina la detección de enlaces de yaske que ya no se usa</description>
+		</change>
+		<change>
+			<autor>tvalacarta</autor>
+			<date>31/08/2015</date>
+			<description>Versión inicial</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>/netu/tv/(embed_)(.*?$)</pattern>
+			<url>http://netu.tv/watch_video.php?v=\2</url>
+		</patterns>
+		<patterns>
+			<pattern>hqq.tv/([^=]+)=([a-zA-Z0-9]+)</pattern>
+			<url>http://netu.tv/watch_video.php?v=\2</url>
+		</patterns>
+		<patterns>
+			<pattern>netu.tv/([^=]+)=([a-zA-Z0-9]+)</pattern>
+			<url>http://netu.tv/watch_video.php?v=\2</url>
+		</patterns>
+		<patterns>
+			<pattern>waaw.tv/([^=]+)=([a-zA-Z0-9]+)</pattern>
+			<url>http://netu.tv/watch_video.php?v=\2</url>
+		</patterns>
+		<patterns>
+			<pattern>netu.php\?(nt=)([a-zA-Z0-9]+)</pattern>
+			<url>http://netu.tv/watch_video.php?v=\2</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
-	<id>netutv</id>
+	<id>
+		<value>netutv</value>
+		<value>netu</value>
+		<value>waaw</value>
+		<value>hqq</value>
+	</id>
 	<name>netutv</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_netutv.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>6</version>
 </server>

--- a/python/main-classic/servers/nosvideo.xml
+++ b/python/main-classic/servers/nosvideo.xml
@@ -1,13 +1,47 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>nosvideo.com/(?:\?v=|vj/video.php\?u=|)([a-z0-9]+)</pattern>
+			<url>http://nosvideo.com/vj/videomain.php?u=\1==530</url>
+		</patterns>
+		<patterns>
+			<pattern>nosupload.com(/\?v\=[a-z0-9]+)</pattern>
+			<url>http://nosvideo.com\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>nosvideo</id>
 	<name>nosvideo</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_nosvideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/nowdownload.xml
+++ b/python/main-classic/servers/nowdownload.xml
@@ -1,15 +1,44 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(nowdownload.\w{2}/dl/[a-z0-9]+)</pattern>
+			<url>http://www.\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>nowdownload</id>
 	<name>nowdownload</name>
 	<premium>
 		<value>realdebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_nowdownload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/nowvideo.xml
+++ b/python/main-classic/servers/nowvideo.xml
@@ -1,20 +1,26 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>5</version>
 	<changes>
 		<change>
-			<date>03/03/2017</date>
 			<autor>Cmos</autor>
+			<date>03/03/2017</date>
 			<description>Corregido por cambios en el servidor y limpieza de código</description>
 		</change>
 		<change>
-			<date>25/03/2016</date>
 			<autor>divadres</autor>
+			<date>25/03/2016</date>
 			<description>Versión inicial</description>
 		</change>
 	</changes>
-
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>nowvideo.../(?:video/|embed.php\?.*v=)([A-z0-9]+)</pattern>
+			<url>http://www.nowvideo.sx/video/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>nowvideo</id>
 	<name>nowvideo</name>
@@ -22,6 +28,46 @@
 		<value>nowvideo</value>
 		<value>realdebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>premium</id>
+		<label>Activar cuenta premium</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<enabled>eq(-1,true)</enabled>
+		<id>user</id>
+		<label>@30014</label>
+		<type>text</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
+		<hidden>true</hidden>
+		<id>password</id>
+		<label>@30015</label>
+		<type>text</type>
+		<visible>true</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_nowvideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>6</version>
 </server>

--- a/python/main-classic/servers/oboom.xml
+++ b/python/main-classic/servers/oboom.xml
@@ -1,15 +1,44 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(oboom.com/[a-zA-Z0-9]+)</pattern>
+			<url>https://www.\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>oboom</id>
 	<name>oboom</name>
 	<premium>
 		<value>realdebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_oboom.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/okru.xml
+++ b/python/main-classic/servers/okru.xml
@@ -1,28 +1,53 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>3</version>
 	<changes>
-        <change>
-            <date>09/05/2017</date>
-            <autor>Cmos</autor>
-            <description>Corregido, ha cambiado la web desde la que extraer los enlaces</description>
-        </change>
-        <change>
-            <date>28/01/2017</date>
-            <autor>Cmos</autor>
-            <description>Mejorada detección de enlaces caídos, adaptado a los últimos cambios</description>
-        </change>
-        <change>
-            <date>07/09/2015</date>
-            <autor>kampanita</autor>
-            <description>Version inicial</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>09/05/2017</date>
+			<description>Corregido, ha cambiado la web desde la que extraer los enlaces</description>
+		</change>
+		<change>
+			<autor>Cmos</autor>
+			<date>28/01/2017</date>
+			<description>Mejorada detección de enlaces caídos, adaptado a los últimos cambios</description>
+		</change>
+		<change>
+			<autor>kampanita</autor>
+			<date>07/09/2015</date>
+			<description>Version inicial</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>//(?:www.)?ok.../(?:videoembed|video)/(\d+)</pattern>
+			<url>http://ok.ru/dk?cmd=videoPlayerMetadata=\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>okru</id>
 	<name>okru</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_okru.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>4</version>
 </server>

--- a/python/main-classic/servers/onefichier.py
+++ b/python/main-classic/servers/onefichier.py
@@ -20,9 +20,9 @@ def test_video_exists(page_url):
 def get_video_url(page_url, premium=False, user="", password="", video_password=""):
     logger.info("(page_url='%s')" % page_url)
 
-    if config.get_setting("onefichierpremium") == True:
-        user = config.get_setting("onefichieruser")
-        password = config.get_setting("onefichierpassword")
+    if config.get_setting("premium", server="onefichier") == True:
+        user = config.get_setting("user", server="onefichier")
+        password = config.get_setting("password", server="onefichier")
 
         url = "https://1fichier.com/login.pl"
         logger.info("url=" + url)

--- a/python/main-classic/servers/onefichier.xml
+++ b/python/main-classic/servers/onefichier.xml
@@ -1,8 +1,25 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>([a-z0-9]+\.1fichier.com)</pattern>
+			<url>https://1fichier.com/?\1</url>
+		</patterns>
+		<patterns>
+			<pattern>1fichier.com/\?([a-z0-9]+)</pattern>
+			<url>https://1fichier.com/?\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>onefichier</id>
 	<name>onefichier</name>
@@ -11,7 +28,46 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>premium</id>
+		<label>Activar cuenta premium</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<enabled>eq(-1,true)</enabled>
+		<id>user</id>
+		<label>@30014</label>
+		<type>text</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
+		<hidden>true</hidden>
+		<id>password</id>
+		<label>@30015</label>
+		<type>text</type>
+		<visible>true</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_onefichier.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/openload.xml
+++ b/python/main-classic/servers/openload.xml
@@ -1,30 +1,54 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>11</version>
 	<changes>
 		<change>
-			<date>12/05/2017</date>
 			<autor>Cmos</autor>
+			<date>12/05/2017</date>
 			<description>Corregido por cambios en el servidor</description>
 		</change>
 		<change>
-			<date>07/02/2017</date>
 			<autor>Cmos</autor>
+			<date>07/02/2017</date>
 			<description>Corregido por cambios en el servidor y adaptado al uso de httptools</description>
 		</change>
 		<change>
-			<date>11/01/2017</date>
 			<autor>Cmos</autor>
+			<date>11/01/2017</date>
 			<description>Reparado por cambios en el servidor</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(?:openload|oload).../(?:embed|f)/([0-9a-zA-Z-_]+)</pattern>
+			<url>https://openload.co/embed/\1/</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>openload</id>
 	<name>openload</name>
 	<premium>
 		<value>realdebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_openload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>12</version>
 </server>

--- a/python/main-classic/servers/pcloud.xml
+++ b/python/main-classic/servers/pcloud.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>07/05/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>07/05/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(my.pcloud.com/publink/show\?code=[A-z0-9]+)</pattern>
+			<url>https://\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>pcloud</id>
 	<name>pcloud</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_pcloud.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/playwatch.xml
+++ b/python/main-classic/servers/playwatch.xml
@@ -1,18 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>1</version>
 	<changes>
-        <change>
-            <date>21/03/2017</date>
-            <autor>Cmos</autor>
-            <description>Primera version</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>21/03/2017</date>
+			<description>Primera version</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>playwatch.me/(?:embed/|)([A-z0-9]+)</pattern>
+			<url>http://playwatch.me/embed/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>playwatch</id>
 	<name>playwatch</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/c7LwCTc.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/playwire.xml
+++ b/python/main-classic/servers/playwire.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>07/05/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>07/05/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(?:cdn|config).playwire.com(?:/v2|)/(\d+)/(?:embed|videos/v2|config)/(\d+)</pattern>
+			<url>http://config.playwire.com/\1/videos/v2/\2/zeus.json</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>playwire</id>
 	<name>playwire</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_playwire.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/powvideo.xml
+++ b/python/main-classic/servers/powvideo.xml
@@ -1,33 +1,58 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>5</version>
 	<changes>
-        <change>
-            <date>31/05/2017</date>
-            <autor>robalo</autor>
-            <description>Corregido tras cambios en la ofuscación de los enlaces</description>
-        </change>
-        <change>
-            <date>09/03/2017</date>
-            <autor>Intel1</autor>
-            <description>Muestra mensaje para archivo borrado por terminos de uso</description>
-        </change>
-        <change>
-            <date>25/01/2017</date>
-            <autor>Cmos</autor>
-            <description>Mejorado el conector gracias al método jhexdecode de robalo, reparado y adaptado al uso de httptools</description>
-        </change>
-        <change>
-            <date>07/11/2016</date>
-            <autor>Cmos</autor>
-            <description>Mejorado el código</description>
-        </change>
+		<change>
+			<autor>robalo</autor>
+			<date>31/05/2017</date>
+			<description>Corregido tras cambios en la ofuscación de los enlaces</description>
+		</change>
+		<change>
+			<autor>Intel1</autor>
+			<date>09/03/2017</date>
+			<description>Muestra mensaje para archivo borrado por terminos de uso</description>
+		</change>
+		<change>
+			<autor>Cmos</autor>
+			<date>25/01/2017</date>
+			<description>Mejorado el conector gracias al método jhexdecode de robalo, reparado y adaptado al uso de httptools</description>
+		</change>
+		<change>
+			<autor>Cmos</autor>
+			<date>07/11/2016</date>
+			<description>Mejorado el código</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>powvideo.net/(?:embed-|iframe-|preview-|)([a-z0-9]+)</pattern>
+			<url>http://powvideo.net/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>powvideo</id>
 	<name>powvideo</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_powvideo.png</thumbnail>
-	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>	
+	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>6</version>
 </server>

--- a/python/main-classic/servers/rapidgator.xml
+++ b/python/main-classic/servers/rapidgator.xml
@@ -1,8 +1,21 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(rapidgator.net/file/.*?(?:\.html))</pattern>
+			<url>http://\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>rapidgator</id>
 	<name>rapidgator</name>
@@ -10,7 +23,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_rapidgator.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/rapidvideo.xml
+++ b/python/main-classic/servers/rapidvideo.xml
@@ -1,29 +1,53 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>4</version>
 	<changes>
-        <change>
-            <date>09/05/2017</date>
-            <autor>Cmos</autor>
-            <description>Ampliado regex para detección de enlaces</description>
-        </change>
-        <change>
-            <date>29/04/2017</date>
-            <autor>Cmos</autor>
-            <description>Corregido, usa proxy en caso de error con https</description>
-        </change>
-        <change>
-            <date>25/03/2016</date>
-            <autor>divadr</autor>
-            <description>Versión inicial</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>09/05/2017</date>
+			<description>Ampliado regex para detección de enlaces</description>
+		</change>
+		<change>
+			<autor>Cmos</autor>
+			<date>29/04/2017</date>
+			<description>Corregido, usa proxy en caso de error con https</description>
+		</change>
+		<change>
+			<autor>divadr</autor>
+			<date>25/03/2016</date>
+			<description>Versión inicial</description>
+		</change>
 	</changes>
-
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>rapidvideo.org/([A-Za-z0-9]+)/</pattern>
+			<url>http://www.rapidvideo.org/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>rapidvideo</id>
 	<name>rapidvideo</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_rapidvideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>5</version>
 </server>

--- a/python/main-classic/servers/raptu.xml
+++ b/python/main-classic/servers/raptu.xml
@@ -1,23 +1,48 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>09/05/2017</date>
 			<autor>Intel1</autor>
+			<date>09/05/2017</date>
 			<description>Agregado otro tipo de url de los videos y detección de subtítulos</description>
 		</change>
 		<change>
-			<date>16/02/2017</date>
 			<autor>Cmos</autor>
+			<date>16/02/2017</date>
 			<description>Primera versión</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>raptu.com/(?:\?v=|embed/|e/)([A-z0-9]+)</pattern>
+			<url>http://raptu.com/embed/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>raptu</id>
 	<name>raptu</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/quVK1j0.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/redirects.xml
+++ b/python/main-classic/servers/redirects.xml
@@ -1,13 +1,55 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>26/05/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>26/05/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(https://animeflv.net/embed_izanagi.php\?key=.+?),</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(https://s1.animeflv.com/gdrive.php?id=.+?)\\\\</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(http://www.animeid..{2,3}/embed/.+?/)</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(https://jkanime.net/jk.php\?u=stream/jkmedia.+?)\s</pattern>
+			<url>\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>redirects</id>
 	<name>redirects</name>
-	<premium></premium>
-	<thumbnail></thumbnail>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
+	<thumbnail>http://media.tvalacarta.info/servers/server_servers\redirects.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/rutube.xml
+++ b/python/main-classic/servers/rutube.xml
@@ -1,15 +1,44 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>rutube.ru\/(?:video\/([\da-zA-Z]{32})|play\/embed\/([\d]+))</pattern>
+			<url>http://rutube.ru/api/play/options/\1/?format=json</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>rutube</id>
 	<name>rutube</name>
 	<premium>
 		<value>realdebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_rutube.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/sendvid.xml
+++ b/python/main-classic/servers/sendvid.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>sendvid.com/embed/([a-zA-Z0-9]+)</pattern>
+			<url>http://sendvid.com/embed/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>sendvid</id>
 	<name>sendvid</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_sendvid.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/speedvideo.xml
+++ b/python/main-classic/servers/speedvideo.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>speedvideo.net/(?:embed-|)([A-Z0-9a-z]+)</pattern>
+			<url>http://speedvideo.net/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>speedvideo</id>
 	<name>speedvideo</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_speedvideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/spruto.xml
+++ b/python/main-classic/servers/spruto.xml
@@ -1,28 +1,53 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>4</version>
 	<changes>
 		<change>
-			<date>16/04/2017</date>
 			<autor>Intel1</autor>
+			<date>16/04/2017</date>
 			<description>Detectar servidor caído</description>
 		</change>
 		<change>
-			<date>27/02/2017</date>
 			<autor>Cmos</autor>
+			<date>27/02/2017</date>
 			<description>Reparado conector</description>
 		</change>
 		<change>
-			<date>04/06/2016</date>
 			<autor>Cmos</autor>
+			<date>04/06/2016</date>
 			<description>Reparado por cambios en la expresion regular de los enlaces a los videos</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>spruto.tv/iframe_embed.php\?video_id=(\d+)</pattern>
+			<url>http://spruto.tv/iframe_embed.php?video_id=\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>spruto</id>
 	<name>spruto</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_spruto.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>5</version>
 </server>

--- a/python/main-classic/servers/stagevu.xml
+++ b/python/main-classic/servers/stagevu.xml
@@ -1,13 +1,51 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(http://stagevu.com/video/[A-Z0-9a-z]+)</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>http://stagevu.com.*?uid\=([A-Z0-9a-z]+)</pattern>
+			<url>http://stagevu.com/video/\1</url>
+		</patterns>
+		<patterns>
+			<pattern>http://[^\.]+\.stagevu.com/v/[^/]+/(.*?).avi</pattern>
+			<url>http://stagevu.com/video/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>stagevu</id>
 	<name>stagevu</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_stagevu.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/stormo.xml
+++ b/python/main-classic/servers/stormo.xml
@@ -1,23 +1,48 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
-        <change>
-            <date>28/01/2017</date>
-            <autor>Cmos</autor>
-            <description>Arreglado por cambios en la web</description>
-        </change>
-        <change>
-            <date>09/07/2016</date>
-            <autor>Cmos</autor>
-            <description>Version inicial</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>28/01/2017</date>
+			<description>Arreglado por cambios en la web</description>
+		</change>
+		<change>
+			<autor>Cmos</autor>
+			<date>09/07/2016</date>
+			<description>Version inicial</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>stormo.tv/(?:videos/|embed/)([0-9]+)</pattern>
+			<url>http://stormo.tv/embed/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>stormo</id>
 	<name>stormo</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/mTYCw5E.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/streamango.xml
+++ b/python/main-classic/servers/streamango.xml
@@ -1,18 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>1</version>
 	<changes>
 		<change>
-			<date>22/04/2017</date>
 			<autor>Cmos</autor>
+			<date>22/04/2017</date>
 			<description>Nuevo conector</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>streamango.com/(?:embed|f)/([A-z0-9]+)</pattern>
+			<url>http://streamango.com/embed/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>streamango</id>
 	<name>streamango</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/o8XR8fL.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/streamcloud.xml
+++ b/python/main-classic/servers/streamcloud.xml
@@ -3,8 +3,8 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<date>09/03/2017</date>
 			<autor>Intel1</autor>
+			<date>09/03/2017</date>
 			<description>No detectaba "archivo no encontrado"</description>
 		</change>
 		<change>
@@ -12,13 +12,49 @@
 			<description>Version inicial</description>
 		</change>
 	</changes>
-
+	<find_videos>
+		<ignore_urls>
+			<value>http://streamcloud.eu/stylesheets</value>
+			<value>http://streamcloud.eu/control</value>
+			<value>http://streamcloud.eu/xupload</value>
+			<value>http://streamcloud.eu/js</value>
+			<value>http://streamcloud.eu/favicon</value>
+			<value>http://streamcloud.eu/reward</value>
+			<value>http://streamcloud.eu/login</value>
+			<value>http://streamcloud.eu/deliver</value>
+			<value>http://streamcloud.eu/faq</value>
+			<value>http://streamcloud.eu/tos</value>
+			<value>http://streamcloud.eu/checkfiles</value>
+			<value>http://streamcloud.eu/contact</value>
+			<value>http://streamcloud.eu/serve</value>
+		</ignore_urls>
+		<patterns>
+			<pattern>(streamcloud.eu/[a-z0-9]+)</pattern>
+			<url>http://\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>streamcloud</id>
 	<name>streamcloud</name>
 	<premium>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_streamcloud.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>2</version>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/streame.xml
+++ b/python/main-classic/servers/streame.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>streame.net/(?:embed-|)([a-z0-9]+)</pattern>
+			<url>http://streame.net/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>streame</id>
 	<name>streame</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_streame.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/streaminto.xml
+++ b/python/main-classic/servers/streaminto.xml
@@ -1,13 +1,58 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+			<value>http://streamin.to/embed-theme.html</value>
+			<value>http://streamin.to/embed-jquery.html</value>
+			<value>http://streamin.to/embed-s.html</value>
+			<value>http://streamin.to/embed-images.html</value>
+			<value>http://streamin.to/embed-faq.html</value>
+			<value>http://streamin.to/embed-embed.html</value>
+			<value>http://streamin.to/embed-ri.html</value>
+			<value>http://streamin.to/embed-d.html</value>
+			<value>http://streamin.to/embed-css.html</value>
+			<value>http://streamin.to/embed-js.html</value>
+			<value>http://streamin.to/embed-player.html</value>
+			<value>http://streamin.to/embed-cgi.html</value>
+		</ignore_urls>
+		<patterns>
+			<pattern>streamin.to/(?:embed-)?([a-z0-9A-Z]+)</pattern>
+			<url>http://streamin.to/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
-	<id>streaminto</id>
-	<name>streaminto</name>
-	<premium></premium>
+	<id>
+		<value>streaminto</value>
+		<value>streamin</value>
+	</id>
+	<name>streamin</name>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_streaminto.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/streamixcloud.xml
+++ b/python/main-classic/servers/streamixcloud.xml
@@ -1,18 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>1</version>
 	<changes>
-        <change>
-            <date>16/05/2017</date>
-            <autor>Cmos</autor>
-            <description>Primera versión</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>16/05/2017</date>
+			<description>Primera versión</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>streamix.cloud/(?:embed-|)([A-z0-9]+)</pattern>
+			<url>http://streamix.cloud/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>streamixcloud</id>
 	<name>streamixcloud</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/NuD85Py.png?1</thumbnail>
-	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>	
+	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/streamplay.xml
+++ b/python/main-classic/servers/streamplay.xml
@@ -1,38 +1,63 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>7</version>
 	<changes>
-        <change>
-            <date>31/05/2017</date>
-            <autor>robalo</autor>
-            <description>Corregido tras cambios en la ofuscación de los enlaces</description>
-        </change>
-        <change>
-            <date>28/04/2017</date>
-            <autor>Cmos</autor>
-            <description>Cambio en la url embebida</description>
-        </change>
-        <change>
-            <date>28/03/2017</date>
-            <autor>Cmos</autor>
-            <description>Reparado debido a que se necesita el referer para cargar la pagina y los videos</description>
-        </change>
-        <change>
-            <date>25/01/2017</date>
-            <autor>Cmos</autor>
-            <description>Mejorado el conector gracias al método jhexdecode de robalo, reparado y adaptado al uso de httptools</description>
-        </change>
-        <change>
-            <date>11/01/2016</date>
-            <autor>Cmos</autor>
-            <description>Reparado por cambios</description>
-        </change>
+		<change>
+			<autor>robalo</autor>
+			<date>31/05/2017</date>
+			<description>Corregido tras cambios en la ofuscación de los enlaces</description>
+		</change>
+		<change>
+			<autor>Cmos</autor>
+			<date>28/04/2017</date>
+			<description>Cambio en la url embebida</description>
+		</change>
+		<change>
+			<autor>Cmos</autor>
+			<date>28/03/2017</date>
+			<description>Reparado debido a que se necesita el referer para cargar la pagina y los videos</description>
+		</change>
+		<change>
+			<autor>Cmos</autor>
+			<date>25/01/2017</date>
+			<description>Mejorado el conector gracias al método jhexdecode de robalo, reparado y adaptado al uso de httptools</description>
+		</change>
+		<change>
+			<autor>Cmos</autor>
+			<date>11/01/2016</date>
+			<description>Reparado por cambios</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>streamplay.to/(?:embed-|)([a-z0-9]+)(?:.html|)</pattern>
+			<url>http://streamplay.to/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>streamplay</id>
 	<name>streamplay</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_streamplay.png</thumbnail>
-	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>	
+	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>8</version>
 </server>

--- a/python/main-classic/servers/thevideome.xml
+++ b/python/main-classic/servers/thevideome.xml
@@ -1,23 +1,48 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>27/02/2017</date>
 			<autor>Cmos</autor>
+			<date>27/02/2017</date>
 			<description>Reparado conector</description>
 		</change>
 		<change>
-			<date>25/03/2016</date>
 			<autor></autor>
+			<date>25/03/2016</date>
 			<description>Primera versión</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>thevideo.me/(?:embed-|)([A-z0-9]+)</pattern>
+			<url>http://thevideo.me/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>thevideome</id>
 	<name>thevideome</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_thevideome.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/thevideos.xml
+++ b/python/main-classic/servers/thevideos.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>thevideos.tv/(?:embed-|)([a-z0-9A-Z]+)</pattern>
+			<url>http://thevideos.tv/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>thevideos</id>
 	<name>thevideos</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_thevideos.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/torrent.xml
+++ b/python/main-classic/servers/torrent.xml
@@ -1,13 +1,47 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(http:\/\/(?:.*?)\.torrent)</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(magnet:\?xt=urn:[^"]+)</pattern>
+			<url>\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>torrent</id>
 	<name>torrent</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_torrent.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/tunepk.xml
+++ b/python/main-classic/servers/tunepk.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>tune.pk/player/embed_player.php\?vid\=(\d+)</pattern>
+			<url>http://embed.tune.pk/play/\1?autoplay=no"</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>tunepk</id>
 	<name>tunepk</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_tunepk.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/turbobit.xml
+++ b/python/main-classic/servers/turbobit.xml
@@ -1,8 +1,21 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(turbobit.net/[0-9a-z]+)</pattern>
+			<url>http://\1.html"</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>turbobit</id>
 	<name>turbobit</name>
@@ -10,7 +23,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_turbobit.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/turbovideos.xml
+++ b/python/main-classic/servers/turbovideos.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>turbovideos.net/embed-([a-z0-9A-Z]+)</pattern>
+			<url>http://turbovideos.net/embed-\1.html"</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>turbovideos</id>
 	<name>turbovideos</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_turbovideos.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/tusfiles.py
+++ b/python/main-classic/servers/tusfiles.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------
+# pelisalacarta - XBMC Plugin
+# Conector para adnstream
+# http://blog.tvalacarta.info/plugin-xbmc/pelisalacarta/
+#------------------------------------------------------------
+
+import re
+
+from core import logger
+from core import scrapertools
+from core import httptools
+
+def get_video_url( page_url , premium = False , user="" , password="" , video_password="" ):
+    logger.info("page_url='%s'" % page_url)
+
+    # Saca el código del vídeo
+    data = httptools.downloadpage(page_url).data.replace("\\", "")
+    video_urls = []
+    matches = scrapertools.find_multiple_matches(data, '"label"\s*:\s*(.*?),"type"\s*:\s*"([^"]+)","file"\s*:\s*"([^"]+)"')
+    for calidad, tipo, video_url in matches:
+        tipo = tipo.replace("video/", "")
+        video_urls.append([".%s %sp [tusfiles]" % (tipo, calidad), video_url])
+    
+    video_urls.sort(key=lambda it:int(it[0].split("p ", 1)[0].rsplit(" ")[1]))
+    
+    return video_urls

--- a/python/main-classic/servers/tusfiles.xml
+++ b/python/main-classic/servers/tusfiles.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<server>
+	<active>true</active>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>16/03/2017</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>http://tusfiles.org/\?([A-z0-9]+)</pattern>
+			<url>http://tusfiles.org/?\1/</url>
+		</patterns>
+	</find_videos>
+	<free>true</free>
+	<id>tusfiles</id>
+	<name>tusfiles</name>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
+	<thumbnail>http://media.tvalacarta.info/servers/server_tusfiles.png</thumbnail>
+	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>2</version>
+</server>

--- a/python/main-classic/servers/tutv.xml
+++ b/python/main-classic/servers/tutv.xml
@@ -1,13 +1,47 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>"(http://(?:www.)?tu.tv[^"]+)"</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>tu.tv/(iframe/\d+)</pattern>
+			<url>http://tu.tv/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>tutv</id>
 	<name>tutv</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_tutv.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/uploadedto.xml
+++ b/python/main-classic/servers/uploadedto.xml
@@ -1,17 +1,77 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(?:ul|uploaded).(?:net|to)/(?:file/|f/)?([a-zA-Z0-9]+)</pattern>
+			<url>http://uploaded.net/file/\1</url>
+		</patterns>
+		<patterns>
+			<pattern>(?:ul|uploaded).(?:net|to)/folder/([a-zA-Z0-9]+)</pattern>
+			<url>http://uploaded.net/folder/\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
-	<id>uploadedto</id>
+	<id>
+		<value>uploadedto</value>
+		<value>ul.to</value>
+		<value>uploaded</value>
+	</id>
 	<name>uploadedto</name>
 	<premium>
 		<value>uploadedto</value>
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>premium</id>
+		<label>Activar cuenta premium</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<enabled>eq(-1,true)</enabled>
+		<id>user</id>
+		<label>@30014</label>
+		<type>text</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
+		<hidden>true</hidden>
+		<id>password</id>
+		<label>@30015</label>
+		<type>text</type>
+		<visible>true</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_uploadedto.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/uptobox.xml
+++ b/python/main-classic/servers/uptobox.xml
@@ -1,8 +1,25 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>uptobox.com/([a-z0-9]+)</pattern>
+			<url>http://uptobox.com/\1</url>
+		</patterns>
+		<patterns>
+			<pattern>uptostream.com/iframe/([a-z0-9]+)</pattern>
+			<url>http://uptostream.com/iframe/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>uptobox</id>
 	<name>uptobox</name>
@@ -10,7 +27,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_uptobox.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/userporn.xml
+++ b/python/main-classic/servers/userporn.xml
@@ -1,8 +1,33 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>userporn.com\/f\/([A-Z0-9a-z]{12}).swf</pattern>
+			<url>http://www.userporn.com/video/\1</url>
+		</patterns>
+		<patterns>
+			<pattern>userporn.com\/video\/([A-Z0-9a-z]{12})</pattern>
+			<url>http://www.userporn.com/video/\1</url>
+		</patterns>
+		<patterns>
+			<pattern>userporn.com\/e\/([A-Z0-9a-z]{12})</pattern>
+			<url>http://www.userporn.com/video/\1</url>
+		</patterns>
+		<patterns>
+			<pattern>http\:\/\/(?:www\.)?userporn.com\/(?:(?:e/|flash/)|(?:(?:video/|f/)))?([a-zA-Z0-9]{0,12})</pattern>
+			<url>http://www.userporn.com/video/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>userporn</id>
 	<name>userporn</name>
@@ -10,7 +35,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_userporn.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/userscloud.xml
+++ b/python/main-classic/servers/userscloud.xml
@@ -1,14 +1,21 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>1</version>
 	<changes>
-        <change>
-            <date>21/03/2017</date>
-            <autor>Cmos</autor>
-            <description>Primera version</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>21/03/2017</date>
+			<description>Primera version</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>userscloud.com/(?:embed-|)([A-z0-9]+)</pattern>
+			<url>https://userscloud.com/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>userscloud</id>
 	<name>userscloud</name>
@@ -16,6 +23,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/u4W2DgA.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/veehd.xml
+++ b/python/main-classic/servers/veehd.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>false</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(veehd.com/video/\d+\#)</pattern>
+			<url>http://\1</url>
+		</patterns>
+	</find_videos>
 	<free>false</free>
 	<id>veehd</id>
 	<name>veehd</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_veehd.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/veoh.xml
+++ b/python/main-classic/servers/veoh.xml
@@ -1,13 +1,47 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>href="http://www.veoh.com/.*?permalinkId=([^&"]+)"</pattern>
+			<url>\1</url>
+		</patterns>
+		<patterns>
+			<pattern>pattern="http://www.veoh.com/static/swf/webplayer/WebPlayer.swf.*?permalinkId=([^&]+)=videodetailsembedded=0=anonymous"</pattern>
+			<url>\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>veoh</id>
 	<name>veoh</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_veoh.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/vidabc.xml
+++ b/python/main-classic/servers/vidabc.xml
@@ -1,23 +1,49 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>10/05/17</date>
+			<autor></autor>
 			<autor>Intel1</autor>
+			<date>10/05/17</date>
 			<description>Reparado por robalo, yo solo lo subí al github</description>
 		</change>
 		<change>
-			<date>24/12/2016</date>
 			<autor>Cmos</autor>
+			<date>24/12/2016</date>
 			<description>Versión incial</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>vidabc.com/([a-z0-9]+)</pattern>
+			<url>http://vidabc.com/\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>vidabc</id>
 	<name>vidabc</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidabc.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/videowood.xml
+++ b/python/main-classic/servers/videowood.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(https?://(?:www.)?videowood.tv/)(?:embed|video)(/[0-9a-z]+)</pattern>
+			<url>\1embed\2</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>videowood</id>
 	<name>videowood</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_videowood.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/vidgg.xml
+++ b/python/main-classic/servers/vidgg.xml
@@ -1,23 +1,48 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
-        <change>
-            <date>28/01/2017</date>
-            <autor>Cmos</autor>
-            <description>Arreglado por cambios en la web</description>
-        </change>
-        <change>
-            <date>25/02/2016</date>
-            <autor>Cmos</autor>
-            <description>Version inicial</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>28/01/2017</date>
+			<description>Arreglado por cambios en la web</description>
+		</change>
+		<change>
+			<autor>Cmos</autor>
+			<date>25/02/2016</date>
+			<description>Version inicial</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(?:vidgg.to|vid.gg)/(?:embed/|video/)([a-z0-9]+)</pattern>
+			<url>http://vidgg.to/video/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>vidgg</id>
 	<name>vidgg</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidgg.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/vidgot.xml
+++ b/python/main-classic/servers/vidgot.xml
@@ -1,19 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>1</version>
 	<changes>
-        <change>
-            <date>21/03/2017</date>
-            <autor>Cmos</autor>
-            <description>Primera version</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>21/03/2017</date>
+			<description>Primera version</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>vidgot.com/(?:embed-|)([A-z0-9]+)</pattern>
+			<url>http://www.vidgot.com/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>vidgot</id>
 	<name>vidgot</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/tAI34bF.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/vidoza.xml
+++ b/python/main-classic/servers/vidoza.xml
@@ -1,18 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>1</version>
 	<changes>
 		<change>
-			<date>28/05/2017</date>
 			<autor>Cmos</autor>
+			<date>28/05/2017</date>
 			<description>Nuevo conector</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>vidoza.net/(?:embed-|)([A-z0-9]+)</pattern>
+			<url>http://vidoza.net/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>vidoza</id>
 	<name>vidoza</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/YefcBBY.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>1</version>
 </server>

--- a/python/main-classic/servers/vidspot.xml
+++ b/python/main-classic/servers/vidspot.xml
@@ -1,14 +1,73 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Reparado, utiliza proxy en caso que salte el geobloqueo</changes>
-	<date>04/06/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>04/06/2016</date>
+			<description>Reparado, utiliza proxy en caso que salte el geobloqueo</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+			<value>http://vidspot.net/embed-theme.html</value>
+			<value>http://vidspot.net/embed-jquery.html</value>
+			<value>http://vidspot.net/embed-s.html</value>
+			<value>http://vidspot.net/embed-images.html</value>
+			<value>http://vidspot.net/embed-faq.html</value>
+			<value>http://vidspot.net/embed-embed.html</value>
+			<value>http://vidspot.net/embed-ri.html</value>
+			<value>http://vidspot.net/embed-d.html</value>
+			<value>http://vidspot.net/embed-css.html</value>
+			<value>http://vidspot.net/embed-js.html</value>
+			<value>http://vidspot.net/embed-player.html</value>
+			<value>http://vidspot.net/embed-cgi.html</value>
+			<value>http://vidspot.net/embed-i.html</value>
+			<value>http://vidspot.net/images</value>
+			<value>http://vidspot.net/theme</value>
+			<value>http://vidspot.net/xupload</value>
+			<value>http://vidspot.net/s</value>
+			<value>http://vidspot.net/js</value>
+			<value>http://vidspot.net/jquery</value>
+			<value>http://vidspot.net/login</value>
+			<value>http://vidspot.net/make</value>
+			<value>http://vidspot.net/i</value>
+			<value>http://vidspot.net/faq</value>
+			<value>http://vidspot.net/tos</value>
+			<value>http://vidspot.net/premium</value>
+			<value>http://vidspot.net/checkfiles</value>
+			<value>http://vidspot.net/privacy</value>
+			<value>http://vidspot.net/refund</value>
+			<value>http://vidspot.net/links</value>
+			<value>http://vidspot.net/contact</value>
+		</ignore_urls>
+		<patterns>
+			<pattern>vidspot.(?:net/|php\?id=)(?:embed-)?([a-z0-9]+)</pattern>
+			<url>http://vidspot.net/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>vidspot</id>
 	<name>vidspot</name>
 	<premium>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidspot.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>2</version>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/vidtodo.xml
+++ b/python/main-classic/servers/vidtodo.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>24/12/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>24/12/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>vidtodo.com/([a-z0-9]+)</pattern>
+			<url>http://vidtodo.com/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>vidtodo</id>
 	<name>vidtodo</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidtodo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/vidtome.xml
+++ b/python/main-classic/servers/vidtome.xml
@@ -1,23 +1,52 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
-        <change>
-            <date>21/03/2017</date>
-            <autor>Cmos</autor>
-            <description>Conector corregido</description>
-        </change>
-        <change>
-            <date>25/03/2016</date>
-            <autor></autor>
-            <description>Versión incial</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>21/03/2017</date>
+			<description>Conector corregido</description>
+		</change>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>vidto.me/([a-z0-9A-Z]+)</pattern>
+			<url>http://vidto.me/\1.html</url>
+		</patterns>
+		<patterns>
+			<pattern>vidto.me/embed-([a-z0-9A-Z]+)</pattern>
+			<url>http://vidto.me/\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>vidtome</id>
 	<name>vidtome</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidtome.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/vidup.xml
+++ b/python/main-classic/servers/vidup.xml
@@ -1,18 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>1</version>
 	<changes>
-        <change>
-            <date>21/03/2017</date>
-            <autor>Cmos</autor>
-            <description>Primera version</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>21/03/2017</date>
+			<description>Primera version</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>vidup.me/(?:embed-|)([A-z0-9]+)</pattern>
+			<url>http://vidup.me/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>vidup</id>
 	<name>vidup</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/sZvy8IC.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/vidzi.xml
+++ b/python/main-classic/servers/vidzi.xml
@@ -1,23 +1,52 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>22/04/2017</date>
 			<autor>Cmos</autor>
+			<date>22/04/2017</date>
 			<description>Corregido por cambios</description>
 		</change>
 		<change>
-			<date>25/03/2016</date>
 			<autor>divadr</autor>
+			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>vidzi.tv/embed-([a-z0-9A-Z]+)</pattern>
+			<url>http://vidzi.tv/embed-\1.html</url>
+		</patterns>
+		<patterns>
+			<pattern>vidzi.tv/([a-z0-9A-Z]+)</pattern>
+			<url>http://vidzi.tv/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>vidzi</id>
 	<name>vidzi</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidzi.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/vimeo.xml
+++ b/python/main-classic/servers/vimeo.xml
@@ -1,8 +1,21 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>(?:vimeo.com/|player.vimeo.com/video/)([0-9]+)</pattern>
+			<url>https://player.vimeo.com/video/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>vimeo</id>
 	<name>vimeo</name>
@@ -10,7 +23,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vimeo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/vimpleru.xml
+++ b/python/main-classic/servers/vimpleru.xml
@@ -1,24 +1,48 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>05/03/2017</date>
 			<autor>Cmos</autor>
+			<date>05/03/2017</date>
 			<description>Reparado por cambios</description>
 		</change>
 		<change>
-			<date>25/03/2016</date>
 			<autor></autor>
+			<date>25/03/2016</date>
 			<description>Versión inicial</description>
 		</change>
 	</changes>
-
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>vimple.ru/iframe/([a-f0-9]+)</pattern>
+			<url>http://player.vimple.ru/iframe/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>vimpleru</id>
 	<name>vimpleru</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vimpleru.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/vk.xml
+++ b/python/main-classic/servers/vk.xml
@@ -1,14 +1,47 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Reparado por cambios</changes>
-	<date>11/01/2017</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>11/01/2017</date>
+			<description>Reparado por cambios</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>/video_ext.php\?oid=([^&]+)(?:&||)id=([^&]+)(?:&||)hash=([a-z0-9]+)</pattern>
+			<url>http://vk.com/video_ext.php?oid=\1=\2=\3</url>
+		</patterns>
+		<patterns>
+			<pattern>(vk\.[a-z]+\/video[0-9]+_[0-9]+)</pattern>
+			<url>http://\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>vk</id>
 	<name>vk</name>
 	<premium>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vk.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>2</version>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/watchers.xml
+++ b/python/main-classic/servers/watchers.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión inicial</changes>
-	<date>09/01/2017</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>09/01/2017</date>
+			<description>Versión inicial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>watchers.to/(?:embed-|)([A-z0-9]+)</pattern>
+			<url>http://watchers.to/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>watchers</id>
 	<name>watchers</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/WApzSMn.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/watchvideo.xml
+++ b/python/main-classic/servers/watchvideo.xml
@@ -1,18 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>1</version>
 	<changes>
-        <change>
-            <date>21/03/2017</date>
-            <autor>Cmos</autor>
-            <description>Primera version</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>21/03/2017</date>
+			<description>Primera version</description>
+		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>watchvideo.us/(?:embed-|)([A-z0-9]+)</pattern>
+			<url>http://watchvideo.us/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>watchvideo</id>
 	<name>watchvideo</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/vDev2I6.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/wholecloud.xml
+++ b/python/main-classic/servers/wholecloud.xml
@@ -1,18 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>27/02/2017</date>
 			<autor>Cmos</autor>
+			<date>27/02/2017</date>
 			<description>Primera versión</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>wholecloud.net/(?:video/|embed/?v=)([A-z0-9]+)</pattern>
+			<url>http://wholecloud.net/embed/?v=\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>wholecloud</id>
 	<name>wholecloud</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/yIAQurm.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/xvideos.xml
+++ b/python/main-classic/servers/xvideos.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión incial</changes>
-	<date>25/03/2016</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>http://flashservice.xvideos.com/embedframe/([0-9]+)</pattern>
+			<url>http://www.xvideos.com/video\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>xvideos</id>
 	<name>xvideos</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_xvideos.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/main-classic/servers/yourupload.xml
+++ b/python/main-classic/servers/yourupload.xml
@@ -1,28 +1,58 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>3</version>
 	<changes>
 		<change>
-			<date>05/03/2017</date>
 			<autor>Cmos</autor>
+			<date>05/03/2017</date>
 			<description>Reparado por cambios</description>
 		</change>
 		<change>
-			<date>09/02/2017</date>
 			<autor>Cmos</autor>
+			<date>09/02/2017</date>
 			<description>Reparado y adaptado al uso de httptools</description>
 		</change>
 		<change>
-			<date>25/03/2016</date>
 			<autor></autor>
+			<date>25/03/2016</date>
 			<description>Versión inicial</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+			<value>http://www.yourupload.com/embed/embed</value>
+		</ignore_urls>
+		<patterns>
+			<pattern>yourupload.com/embed/([A-z0-9]+)</pattern>
+			<url>http://www.yourupload.com/embed/\1</url>
+		</patterns>
+		<patterns>
+			<pattern>embed[./]yourupload.com(?:/|.php\?url=)([A-z0-9]+)</pattern>
+			<url>http://www.yourupload.com/embed/\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>yourupload</id>
 	<name>yourupload</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_yourupload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>4</version>
 </server>

--- a/python/main-classic/servers/youtube.xml
+++ b/python/main-classic/servers/youtube.xml
@@ -1,19 +1,34 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>03/02/2017</date>
 			<autor>Cmos</autor>
+			<date>03/02/2017</date>
 			<description>Adaptado para el uso de mpd (calidades 1080p y superiores) en Kodi 17. Reestructurado parte del código</description>
 		</change>
 		<change>
-			<date>25/03/2016</date>
 			<autor></autor>
+			<date>25/03/2016</date>
 			<description>Versión inicial</description>
 		</change>
 	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>youtube(?:-nocookie)?\.com/(?:(?:(?:v/|embed/))|(?:(?:watch(?:_popup)?(?:\.php)?)?(?:\?|#!?)(?:.+&)?v=))?([0-9A-Za-z_-]{11})</pattern>
+			<url>http://www.youtube.com/watch?v=\1</url>
+		</patterns>
+		<patterns>
+			<pattern>www.youtube.*?v(?:=|%3D)([0-9A-Za-z_-]{11})</pattern>
+			<url>http://www.youtube.com/watch?v=\1</url>
+		</patterns>
+		<patterns>
+			<pattern>youtube.com/v/([0-9A-Za-z_-]{11})</pattern>
+			<url>http://www.youtube.com/watch?v=\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>youtube</id>
 	<name>youtube</name>
@@ -21,6 +36,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_youtube.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/youwatch.xml
+++ b/python/main-classic/servers/youwatch.xml
@@ -1,26 +1,49 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
-        <change>
-            <date>28/03/2017</date>
-            <autor>Cmos</autor>
-            <description>Corregido conector</description>
-        </change>
-        <change>
-            <date>25/03/2016</date>
-            <autor></autor>
-            <description>Mejorado el código</description>
-        </change>
+		<change>
+			<autor>Cmos</autor>
+			<date>28/03/2017</date>
+			<description>Corregido conector</description>
+		</change>
+		<change>
+			<autor></autor>
+			<date>25/03/2016</date>
+			<description>Versión incial</description>
+		</change>
 	</changes>
-
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>http://(?:youwatch.org|chouhaa.info)/(?:embed-|)([a-z0-9]+)</pattern>
+			<url>http://youwatch.org/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>youwatch</id>
 	<name>youwatch</name>
 	<premium>
 		<value>realdebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_youwatch.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/zippyshare.xml
+++ b/python/main-classic/servers/zippyshare.xml
@@ -1,20 +1,26 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>2</version>
 	<changes>
 		<change>
-			<date>03/03/2017</date>
 			<autor>Cmos</autor>
+			<date>03/03/2017</date>
 			<description>Corregido por cambios en el servidor y añadido como free</description>
 		</change>
 		<change>
-			<date>25/03/2016</date>
 			<autor>divadres</autor>
+			<date>25/03/2016</date>
 			<description>Versión inicial</description>
 		</change>
 	</changes>
-
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>([a-z0-9]+\.zippyshare.com/v/[A-z0-9]+/file.html)</pattern>
+			<url>http://\1</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>zippyshare</id>
 	<name>zippyshare</name>
@@ -22,6 +28,23 @@
 		<value>realdebrid</value>
 		<value>alldebrid</value>
 	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_zippyshare.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/zstream.xml
+++ b/python/main-classic/servers/zstream.xml
@@ -1,13 +1,43 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<changes>Versión inicial</changes>
-	<date>09/01/2017</date>
+	<changes>
+		<change>
+			<autor></autor>
+			<date>09/01/2017</date>
+			<description>Versión inicial</description>
+		</change>
+	</changes>
+	<find_videos>
+		<ignore_urls>
+		</ignore_urls>
+		<patterns>
+			<pattern>zstream.to/(?:embed-|)([A-z0-9]+)</pattern>
+			<url>http://zstream.to/embed-\1.html</url>
+		</patterns>
+	</find_videos>
 	<free>true</free>
 	<id>zstream</id>
 	<name>zstream</name>
-	<premium></premium>
+	<premium>
+	</premium>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>black_list</id>
+		<label>Incluir en lista negra</label>
+		<type>bool</type>
+		<visible>true</visible>
+	</settings>
+	<settings>
+		<default>false</default>
+		<enabled>true</enabled>
+		<id>white_list</id>
+		<label>Incluir en lista de favoritos</label>
+		<type>bool</type>
+		<visible>false</visible>
+	</settings>
 	<thumbnail>http://i.imgur.com/UJMfMZJ.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>1</version>
+	<version>2</version>
 </server>

--- a/python/version-boxee/core/config.py
+++ b/python/version-boxee/core/config.py
@@ -54,7 +54,7 @@ def open_settings():
     import sys
     xbmcplugin.openSettings( sys.argv[ 0 ] )
 
-def get_setting(name, channel=""):
+def get_setting(name, channel="", server=""):
     """
     Retorna el valor de configuracion del parametro solicitado.
 
@@ -81,6 +81,14 @@ def get_setting(name, channel=""):
         # xbmc.log("config.get_setting reading channel setting '"+name+"' from channel xml")
         from core import channeltools
         value = channeltools.get_channel_setting(name, channel)
+        # xbmc.log.info("config.get_setting -> '"+repr(value)+"'")
+
+        return value
+            
+    elif server:
+        # xbmc.log("config.get_setting reading server setting '"+name+"' from server xml")
+        from core import servertools
+        value = servertools.get_server_setting(name, server)
         # xbmc.log("config.get_setting -> '"+repr(value)+"'")
 
         return value
@@ -106,7 +114,8 @@ def get_setting(name, channel=""):
             return value
 
 
-def set_setting(name,value, channel=""):
+
+def set_setting(name, value, channel="", server=""):
     """
     Fija el valor de configuracion del parametro indicado.
 
@@ -133,6 +142,9 @@ def set_setting(name,value, channel=""):
     if channel:
         from core import channeltools
         return channeltools.set_channel_setting(name, value, channel)
+    elif server:
+        from core import servertools
+        return servertools.set_server_setting(name, value, server)
     else:
         try:
             if isinstance(value, bool):

--- a/python/version-command-line/core/config.py
+++ b/python/version-command-line/core/config.py
@@ -77,44 +77,102 @@ def get_system_platform():
 def open_settings():
     return None
 
-def get_setting(name):
-    try:
-        if name in overrides:
-            dev = overrides[name]
-            #print "Overrides: ",name,"=",dev
-        #elif name=="debug":
-        #    return "true"
-        else:
-            dev=configfile.get("General",name)
-            #print "Config file: ",name,"=",dev
+def get_setting(name, channel="", server=""):
+    """
+    Retorna el valor de configuracion del parametro solicitado.
 
-            if dev == "true":
-                return True
-            elif dev == "false":
-                return False
-            else:
-                try:
-                    dev = int(dev)
-                except ValueError:
-                    pass
+    Devuelve el valor del parametro 'name' en la configuracion global o en la configuracion propia del canal 'channel'.
 
-        #print "get_setting",name,dev
-        return dev
-    except:
-        #print "get_setting",name,"(vacío)"
-        return ""
+    Si se especifica el nombre del canal busca en la ruta \addon_data\plugin.video.pelisalacarta\settings_channels el
+    archivo channel_data.json y lee el valor del parametro 'name'. Si el archivo channel_data.json no existe busca en la
+     carpeta channels el archivo channel.xml y crea un archivo channel_data.json antes de retornar el valor solicitado.
+    Si el parametro 'name' no existe en channel_data.json lo busca en la configuracion global y si ahi tampoco existe
+    devuelve un str vacio.
+
+    Parametros:
+    name -- nombre del parametro
+    channel [opcional] -- nombre del canal
+
+    Retorna:
+    value -- El valor del parametro 'name'
+
+    """
+
+    # Specific channel setting
+    if channel:
+
+        # logger.info("config.get_setting reading channel setting '"+name+"' from channel xml")
+        from core import channeltools
+        value = channeltools.get_channel_setting(name, channel)
+        # logger.info("config.get_setting -> '"+repr(value)+"'")
+
+        return value
+            
+    elif server:
+        # logger.info("config.get_setting reading server setting '"+name+"' from server xml")
+        from core import servertools
+        value = servertools.get_server_setting(name, server)
+        # logger.info("config.get_setting -> '"+repr(value)+"'")
+
+        return value
+
+    # Global setting
+    else:
+	    try:
+	        if name in overrides:
+	            dev = overrides[name]
+	            #print "Overrides: ",name,"=",dev
+	        #elif name=="debug":
+	        #    return "true"
+	        else:
+	            dev=configfile.get("General",name)
+	            #print "Config file: ",name,"=",dev
+	        #print "get_setting",name,dev
+	        return dev
+	    except:
+	        #print "get_setting",name,"(vacío)"
+	        return ""
     
-def set_setting(name,value):
-    #print "set_setting",name,value
-    if isinstance(value, bool):
-        if value:
-            value = "true"
-        else:
-            value = "false"
-    elif isinstance(value, (int, long)):
-        value = str(value)
+def set_setting(name, value, channel="", server=""):
+    """
+    Fija el valor de configuracion del parametro indicado.
 
-    overrides[name]=value
+    Establece 'value' como el valor del parametro 'name' en la configuracion global o en la configuracion propia del
+    canal 'channel'.
+    Devuelve el valor cambiado o None si la asignacion no se ha podido completar.
+
+    Si se especifica el nombre del canal busca en la ruta \addon_data\plugin.video.pelisalacarta\settings_channels el
+    archivo channel_data.json y establece el parametro 'name' al valor indicado por 'value'. Si el archivo
+    channel_data.json no existe busca en la carpeta channels el archivo channel.xml y crea un archivo channel_data.json
+    antes de modificar el parametro 'name'.
+    Si el parametro 'name' no existe lo añade, con su valor, al archivo correspondiente.
+
+
+    Parametros:
+    name -- nombre del parametro
+    value -- valor del parametro
+    channel [opcional] -- nombre del canal
+
+    Retorna:
+    'value' en caso de que se haya podido fijar el valor y None en caso contrario
+
+    """
+    if channel:
+        from core import channeltools
+        return channeltools.set_channel_setting(name, value, channel)
+    elif server:
+        from core import servertools
+        return servertools.set_server_setting(name, value, server)
+    else:
+    	#print "set_setting",name,value
+	    if isinstance(value, bool):
+	        if value:
+	            value = "true"
+	        else:
+	            value = "false"
+	    elif isinstance(value, (int, long)):
+	        value = str(value)
+    	overrides[name]=value
 
 def get_localized_string(code):
     cadenas = re.findall('<string id="%d">([^<]+)<' % code,translations)

--- a/python/version-mediaserver/core/config.py
+++ b/python/version-mediaserver/core/config.py
@@ -132,7 +132,7 @@ def open_settings():
         set_setting('adult_aux_new_password2', '')
 
 
-def get_setting(name, channel=""):
+def get_setting(name, channel="", server=""):
     """
     Retorna el valor de configuracion del parametro solicitado.
 
@@ -159,6 +159,14 @@ def get_setting(name, channel=""):
         # logger.info("config.get_setting reading channel setting '"+name+"' from channel xml")
         from core import channeltools
         value = channeltools.get_channel_setting(name, channel)
+        # logger.info("config.get_setting -> '"+repr(value)+"'")
+
+        return value
+            
+    elif server:
+        # logger.info("config.get_setting reading server setting '"+name+"' from server xml")
+        from core import servertools
+        value = servertools.get_server_setting(name, server)
         # logger.info("config.get_setting -> '"+repr(value)+"'")
 
         return value
@@ -190,7 +198,7 @@ def get_setting(name, channel=""):
             return value
 
 
-def set_setting(name, value, channel=""):
+def set_setting(name, value, channel="", server=""):
     """
     Fija el valor de configuracion del parametro indicado.
 
@@ -217,6 +225,9 @@ def set_setting(name, value, channel=""):
     if channel:
         from core import channeltools
         return channeltools.set_channel_setting(name, value, channel)
+    elif server:
+        from core import servertools
+        return servertools.set_server_setting(name, value, server)
     else:
         global settings_dic
 

--- a/python/version-mediaserver/platformcode/controllers/html.py
+++ b/python/version-mediaserver/platformcode/controllers/html.py
@@ -410,7 +410,6 @@ class platform(Platformtools):
 
             def update(self, percent=0, heading="", message=""):
                 JsonData = {}
-                message = self.platformtools.kodi_labels_to_html(message)
                 JsonData["action"]="ProgressBGUpdate" 
                 JsonData["data"]={}
                 JsonData["data"]["title"]=self.platformtools.kodi_labels_to_html(heading)
@@ -602,6 +601,7 @@ class platform(Platformtools):
     def show_channel_settings(self, list_controls=None, dict_values=None, caption="", callback=None, item=None, custom_button=None, channelpath=None):
       from core import config
       from core import channeltools
+      from core import servertools
       import inspect
       if not os.path.isdir(os.path.join(config.get_data_path(), "settings_channels")):
          os.mkdir(os.path.join(config.get_data_path(), "settings_channels"))
@@ -631,6 +631,13 @@ class platform(Platformtools):
         
           # La llamada se hace desde un canal
           list_controls, default_values = channeltools.get_channel_controls_settings(channelname)
+          kwargs = {"channel": channelname}
+          
+        #Si la ruta del canal esta en la carpeta "servers", obtenemos los controles y valores mediante servertools
+        elif os.path.join(config.get_runtime_path(), "servers") in channelpath:
+          # La llamada se hace desde un server
+          list_controls, default_values = servertools.get_server_controls_settings(channelname)
+          kwargs = {"server": channelname}
 
         #En caso contrario salimos
         else:
@@ -666,7 +673,7 @@ class platform(Platformtools):
           #Obtenemos el valor
           if not c["id"] in dict_values:
             if not callback:
-              c["value"]= config.get_setting(c["id"],channelname)
+              c["value"]= config.get_setting(c["id"], **kwargs)
             else:
               c["value"] = c["default"]
 
@@ -725,7 +732,7 @@ class platform(Platformtools):
               except AttributeError:
                   # ... si tampoco existe 'cb_validate_config'...
                   for v in data:
-                      config.set_setting(v,data[v],channelname)
+                      config.set_setting(v,data[v], **kwargs)
           
         elif data == "custom_button":
           try:

--- a/python/version-mediaserver/platformcode/launcher.py
+++ b/python/version-mediaserver/platformcode/launcher.py
@@ -164,9 +164,8 @@ def run(item):
     
      
     #Filtrado de Servers      
-    if item.action== "findvideos" and config.get_setting('filter_servers') == True:
-      server_white_list, server_black_list = set_server_list() 
-      itemlist = filtered_servers(itemlist, server_white_list, server_black_list) 
+    if item.action== "findvideos":
+        itemlist = servertools.filter_servers(itemlist)
       
     
     #Si la accion no ha devuelto ningún resultado, añade un item con el texto "No hay elementos para mostrar"              
@@ -376,69 +375,6 @@ def download_all_episodes(item,first_episode="",preferred_server="vidspot",filte
         if not descargado:
             logger.info("EPISODIO NO DESCARGADO "+episode_title)
 
-
-
-
-def set_server_list():
-    logger.info("start")
-    server_white_list = []
-    server_black_list = []
-
-    if len(config.get_setting('whitelist')) > 0:
-        server_white_list_key = config.get_setting('whitelist').replace(', ', ',').replace(' ,', ',')
-        server_white_list = re.split(',', server_white_list_key)
-
-    if len(config.get_setting('blacklist')) > 0:
-        server_black_list_key = config.get_setting('blacklist').replace(', ', ',').replace(' ,', ',')
-        server_black_list = re.split(',', server_black_list_key)
-
-    logger.info("set_server_list whiteList %s" % server_white_list)
-    logger.info("set_server_list blackList %s" % server_black_list)
-    logger.info("end")
-
-    return server_white_list, server_black_list
-
-def filtered_servers(itemlist, server_white_list, server_black_list):
-    logger.info("start")
-    new_list = []
-    white_counter = 0
-    black_counter = 0
-
-    logger.info("filtered_servers whiteList %s" % server_white_list)
-    logger.info("filtered_servers blackList %s" % server_black_list)
-
-    if len(server_white_list) > 0:
-        logger.info("filtered_servers whiteList")
-        for item in itemlist:
-            logger.info("item.title " + item.title)
-            if any(server in item.title for server in server_white_list):
-                # if item.title in server_white_list:
-                logger.info("found")
-                new_list.append(item)
-                white_counter += 1
-            else:
-                logger.info("not found")
-
-    if len(server_black_list) > 0:
-        logger.info("filtered_servers blackList")
-        for item in itemlist:
-            logger.info("item.title " + item.title)
-            if any(server in item.title for server in server_black_list):
-                # if item.title in server_white_list:
-                logger.info("found")
-                black_counter += 1
-            else:
-                new_list.append(item)
-                logger.info("not found")
-
-    logger.info("whiteList server %s has #%d rows" % (server_white_list, white_counter))
-    logger.info("blackList server %s has #%d rows" % (server_black_list, black_counter))
-
-    if len(new_list) == 0:
-        new_list = itemlist
-    logger.info("end")
-
-    return new_list
 
 
 def add_to_favorites(item):

--- a/python/version-mediaserver/resources/settings.xml
+++ b/python/version-mediaserver/resources/settings.xml
@@ -9,6 +9,11 @@
         <setting id="thumbnail_type" type="enum" lvalues="30011|30012|30200" label="30010" default="2"/>
         <setting id="channel_language" type="labelenum" values="all|es|en|it" label="30019" default="all"/>
         <setting id="debug" type="bool" label="30003" default="false"/>
+		<setting label="Uso de servidores" type="lsep"/>
+		<setting id="resolve_priority" type="enum" label="Método prioritario" lvalues="Free primero|Premium primero|Debriders primero" default="0"/>
+        <setting id="resolve_stop" type="bool" label="Dejar de buscar cuando encuentre una opción" default="true"/>
+		<setting id="hidepremium" type="bool" label="Ocultar servidores de pago sin cuenta" default="false"/>
+        <setting id="server_stats" type="bool" label="Enviar estadisticas sobre el uso de servidores" default="true"/>
         <setting type="sep"/>
         <setting label="Canales para adultos" type="lsep"/>
         <setting id="adult_aux_intro_password" type="text" label="Contraseña:" option="hidden"  default=""/>
@@ -27,6 +32,7 @@
 
     <!-- Login -->
     <category label="30500">
+		<!--
         <setting id="hidepremium" type="bool" label="Ocultar servidores de pago sin cuenta" default="false"/>
 
         <setting type="sep"/>
@@ -62,7 +68,7 @@
         <setting id="crunchyrolluser" type="text" label="30014" enable="eq(-1,true)" default=""/>
         <setting id="crunchyrollpassword" type="text" label="30015" option="hidden" enable="!eq(-1,)+eq(-2,true)" default=""/>
         <setting id="crunchyrollsub" type="enum" label="Idioma de subtítulos preferido en Crunchyroll" values="Español España|Español Latino|Inglés|Italiano|Francés|Portugués|Alemán" default="0"/>
-
+        -->
         <setting type="sep"/>
         <setting id="jdownloader_enabled" type="bool" label="JDownloader" default="false"/>
         <setting id="jdownloader" type="text" label="30022" enable="eq(-1,true)" default="http://127.0.0.1:10025"/>
@@ -114,20 +120,11 @@
         <setting type="sep"/-->
         <setting id="downloadpath" type="text" label="30017" default=""/>
         <setting id="downloadlistpath" type="text" label="30018" default=""/>
-        <setting id="bookmarkpath" type="text" source="video" option="writeable" label="30030" default=""/>
         <setting id="librarypath" type="text" label="30067" default=""/>
 
+        <setting type="sep"/>
         <setting label="Nombre de carpetas" type="lsep"/>
         <setting id="folder_tvshows" type="text" label="Series" default="SERIES"/>
         <setting id="folder_movies" type="text" label="Peliculas" default="CINE"/>
-    </category>
-
-    <category label="Otros"><!--30503 -->
-        <setting label="Filtros" type="lsep"/>
-        <setting id="filter_servers" type="bool" label="30068" default="false"/>
-
-        <setting label="30071" type="lsep"/>
-        <setting id="whitelist" type="text" label="30069" enable="eq(-2,true)" default=""/>
-        <setting id="blacklist" type="text" label="30070" enable="eq(-3,true)" default=""/>
     </category>
 </settings>

--- a/python/version-plex/Code/__init__.py
+++ b/python/version-plex/Code/__init__.py
@@ -183,7 +183,7 @@ def canal(channel_name="",action="",caller_item_serialized=None, itemlist=""):
         Log.Info("caller_item="+str(caller_item))
 
         Log.Info("Importando...")
-        channelmodule = servertools.get_channel_module(channel_name)
+        channelmodule = channeltools.get_channel_module(channel_name)
         Log.Info("Importado")
 
         Log.Info("Antes de hasattr")
@@ -191,6 +191,8 @@ def canal(channel_name="",action="",caller_item_serialized=None, itemlist=""):
             Log.Info("El módulo "+caller_item.channel+" tiene una funcion "+action)
             
             itemlist = getattr(channelmodule, action)(caller_item)
+            if action=="findvideos":
+                itemlist = servertools.filter_servers(itemlist)
 
             if action=="play" and len(itemlist)>0 and isinstance(itemlist[0], Item):
                 itemlist=play_video(itemlist[0])

--- a/python/version-plex/DefaultPrefs.json
+++ b/python/version-plex/DefaultPrefs.json
@@ -31,170 +31,29 @@
     "secure": "true"
   },
   {
-    "id": "realdebridpremium",
-    "label": "Cuenta premium Real Debrid (Activar en menú ayuda)",
+	"id": "resolve_priority",
+	"type": "enum",
+	"label": "Método prioritario",
+	"values": ["Free primero", "Premium primero", "Debriders primero"],
+	"default": 0
+  },
+  {
+    "id": "hidepremium",
+    "label": "Ocultar servidores de pago sin cuenta",
     "type": "bool",
     "default": "false"
   },
   {
-    "id": "alldebridpremium",
-    "label": "Cuenta premium All Debrid",
+    "id": "resolve_stop",
+    "label": "Dejar de buscar cuando encuentre una opción",
     "type": "bool",
-    "default": "false"
+    "default": "true"
   },
   {
-    "id": "alldebriduser",
-    "label": "Usuario",
-    "type": "text",
-    "default": ""
-  },
-  {
-    "id": "alldebridpassword",
-    "label": "Password",
-    "type": "text",
-    "option": "hidden",
-    "default": "",
-    "secure": "true"
-  },
-  {
-    "id": "uploadedtopremium",
-    "label": "Cuenta premium uploaded.to",
+    "id": "server_stats",
+    "label": "Enviar estadisticas sobre el uso de servidores",
     "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "uploadedtouser",
-    "label": "Usuario",
-    "type": "text",
-    "default": ""
-  },
-  {
-    "id": "uploadedtopassword",
-    "label": "Password",
-    "type": "text",
-    "option": "hidden",
-    "default": "",
-    "secure": "true"
-  },
-  {
-    "id": "onefichierpremium",
-    "label": "Cuenta premium 1fichier",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "onefichieruser",
-    "label": "Usuario",
-    "type": "text",
-    "default": ""
-  },
-  {
-    "id": "onefichierpassword",
-    "label": "Password",
-    "type": "text",
-    "option": "hidden",
-    "default": "",
-    "secure": "true"
-  },
-  {
-    "id": "filesmonsterpremium",
-    "label": "Cuenta premium filesmonster",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "filesmonsteruser",
-    "label": "Usuario",
-    "type": "text",
-    "default": ""
-  },
-  {
-    "id": "filesmonsterpassword",
-    "label": "Password",
-    "type": "text",
-    "option": "hidden",
-    "default": "",
-    "secure": "true"
-  },
-  {
-    "id": "mocosoftxaccount",
-    "label": "Cuenta MocosoftX",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "mocosoftxuser",
-    "label": "Usuario",
-    "type": "text",
-    "default": ""
-  },
-  {
-    "id": "mocosoftxpassword",
-    "label": "Password",
-    "type": "text",
-    "option": "hidden",
-    "default": "",
-    "secure": "true"
-  },
-  {
-    "id": "pordedeaccount",
-    "label": "Cuenta pordede",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "pordedeuser",
-    "label": "Usuario",
-    "type": "text",
-    "default": ""
-  },
-  {
-    "id": "pordedepassword",
-    "label": "Password",
-    "type": "text",
-    "option": "hidden",
-    "default": "",
-    "secure": "true"
-  },
-  {
-    "id": "torrentestrenosaccount",
-    "label": "Cuenta torrentestrenos",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "torrentestrenosuser",
-    "label": "Usuario",
-    "type": "text",
-    "default": ""
-  },
-  {
-    "id": "torrentestrenospassword",
-    "label": "Password",
-    "type": "text",
-    "option": "hidden",
-    "default": "",
-    "secure": "true"
-  },
-  {
-    "id": "hdfullaccount",
-    "label": "Cuenta hdfull",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "hdfulluser",
-    "label": "Usuario",
-    "type": "text",
-    "default": ""
-  },
-  {
-    "id": "hdfullpassword",
-    "label": "Password",
-    "type": "text",
-    "option": "hidden",
-    "default": "",
-    "secure": "true"
+    "default": "true"
   },
   {
     "id": "personalchannel",

--- a/python/version-plex/core/config.py
+++ b/python/version-plex/core/config.py
@@ -37,30 +37,59 @@ def open_settings():
     return
 
   
-def get_setting(name, channel=""):
+def get_setting(name, channel="", server=""):
+    """
+    Retorna el valor de configuracion del parametro solicitado.
+
+    Devuelve el valor del parametro 'name' en la configuracion global o en la configuracion propia del canal 'channel'.
+
+    Si se especifica el nombre del canal busca en la ruta \addon_data\plugin.video.pelisalacarta\settings_channels el
+    archivo channel_data.json y lee el valor del parametro 'name'. Si el archivo channel_data.json no existe busca en la
+     carpeta channels el archivo channel.xml y crea un archivo channel_data.json antes de retornar el valor solicitado.
+    Si el parametro 'name' no existe en channel_data.json lo busca en la configuracion global y si ahi tampoco existe
+    devuelve un str vacio.
+
+    Parametros:
+    name -- nombre del parametro
+    channel [opcional] -- nombre del canal
+
+    Retorna:
+    value -- El valor del parametro 'name'
+
+    """
+
+    # Specific channel setting
     if channel:
         from core import channeltools
         value = channeltools.get_channel_setting(name, channel)
         if not value is None:
             return value
+            
+    elif server:
+        from core import servertools
+        value = servertools.get_server_setting(name, server)
+        if not value is None:
+            return value
 
-    # Devolvemos el valor del parametro global 'name'
-    if name=="cache.dir":
-        return ""
-
-    if name=="debug" or name=="download.enabled":
-        return False
-    
-    if name=="cookies.dir":
-        return os.getcwd()
-
-    if name=="cache.mode" or name=="thumbnail_type":
-        return 2
+    # Global setting
     else:
-        try:
-            devuelve = bridge.get_setting(name)
-        except:
-            devuelve = ""
+        # Devolvemos el valor del parametro global 'name'
+	    if name=="cache.dir":
+	        return ""
+	
+	    if name=="debug" or name=="download.enabled":
+	        return False
+	    
+	    if name=="cookies.dir":
+	        return os.getcwd()
+	
+	    if name=="cache.mode" or name=="thumbnail_type":
+	        return 2
+	    else:
+	        try:
+	            devuelve = bridge.get_setting(name)
+	        except:
+	            devuelve = ""
         
         # hack para devolver el tipo correspondiente
         if devuelve == "true":
@@ -78,11 +107,36 @@ def get_setting(name, channel=""):
 
         return devuelve
 
+def set_setting(name, value, channel="", server=""):
+    """
+    Fija el valor de configuracion del parametro indicado.
 
-def set_setting(name,value, channel=""):
+    Establece 'value' como el valor del parametro 'name' en la configuracion global o en la configuracion propia del
+    canal 'channel'.
+    Devuelve el valor cambiado o None si la asignacion no se ha podido completar.
+
+    Si se especifica el nombre del canal busca en la ruta \addon_data\plugin.video.pelisalacarta\settings_channels el
+    archivo channel_data.json y establece el parametro 'name' al valor indicado por 'value'. Si el archivo
+    channel_data.json no existe busca en la carpeta channels el archivo channel.xml y crea un archivo channel_data.json
+    antes de modificar el parametro 'name'.
+    Si el parametro 'name' no existe lo añade, con su valor, al archivo correspondiente.
+
+
+    Parametros:
+    name -- nombre del parametro
+    value -- valor del parametro
+    channel [opcional] -- nombre del canal
+
+    Retorna:
+    'value' en caso de que se haya podido fijar el valor y None en caso contrario
+
+    """
     if channel:
-      from core import channeltools
-      return channeltools.set_channel_setting(name,value, channel)
+        from core import channeltools
+        return channeltools.set_channel_setting(name, value, channel)
+    elif server:
+        from core import servertools
+        return servertools.set_server_setting(name, value, server)
     else:
         encontrado = False
         try:

--- a/python/version-plex/platformcode/plex_config_menu.py
+++ b/python/version-plex/platformcode/plex_config_menu.py
@@ -156,6 +156,13 @@ def show_channel_settings(list_controls=None, dict_values=None, caption="", call
 
             # La llamada se hace desde un canal
             list_controls, default_values = channeltools.get_channel_controls_settings(channelname)
+            kwargs = {"channel": channelname}
+          
+        #Si la ruta del canal esta en la carpeta "servers", obtenemos los controles y valores mediante servertools
+        elif os.path.join(config.get_runtime_path(), "servers") in channelpath:
+            # La llamada se hace desde un server
+            list_controls, default_values = servertools.get_server_controls_settings(channelname)
+            kwargs = {"server": channelname}
 
         #En caso contrario salimos
         else:
@@ -187,7 +194,7 @@ def show_channel_settings(list_controls=None, dict_values=None, caption="", call
         #Obtenemos el valor
         if not c["id"] in dict_values:
             if not callback:
-                dict_values[c["id"]]= config.get_setting(c["id"],channelname)
+                dict_values[c["id"]]= config.get_setting(c["id"], **kwargs)
             else:
                 if not 'default' in c: c["default"] = ''
                 dict_values[c["id"]] = c["default"]
@@ -230,7 +237,7 @@ def show_channel_settings(list_controls=None, dict_values=None, caption="", call
 
 
 
-    params = {"list_controls":list_controls, "dict_values":dict_values, "caption":caption, "channelpath":channelpath, "callback":callback, "item":item, "custom_button": custom_button}
+    params = {"list_controls":list_controls, "dict_values":dict_values, "caption":caption, "channelpath":channelpath, "callback":callback, "item":item, "custom_button": custom_button, "kwargs": kwargs}
     if itemlist:
 
         #Creamos un itemlist nuevo añadiendo solo los items que han pasado la evaluacion
@@ -454,7 +461,7 @@ def ok_Button_click(item):
         except AttributeError:
             # ... si tampoco existe 'cb_validate_config'...
             for v in dict_values:
-                config.set_setting(v, dict_values[v], channel)
+                config.set_setting(v, dict_values[v], **kwargs)
 
     if not itemlist:
         itemlist = getattr(cb_channel, 'mainlist')(item)

--- a/python/version-xbmc-09-plugin/core/config.py
+++ b/python/version-xbmc-09-plugin/core/config.py
@@ -74,7 +74,7 @@ def open_settings():
     xbmcplugin.openSettings(sys.argv[0])
 
 
-def get_setting(name, channel=""):
+def get_setting(name, channel="", server=""):
     """
     Retorna el valor de configuracion del parametro solicitado.
 
@@ -104,6 +104,14 @@ def get_setting(name, channel=""):
         # logger.info("config.get_setting -> '"+repr(value)+"'")
 
         return value
+            
+    elif server:
+        # logger.info("config.get_setting reading server setting '"+name+"' from server xml")
+        from core import servertools
+        value = servertools.get_server_setting(name, server)
+        # logger.info("config.get_setting -> '"+repr(value)+"'")
+
+        return value
 
     # Global setting
     else:
@@ -129,7 +137,7 @@ def get_setting(name, channel=""):
             return value
 
 
-def set_setting(name, value, channel=""):
+def set_setting(name, value, channel="", server=""):
     """
     Fija el valor de configuracion del parametro indicado.
 
@@ -156,6 +164,9 @@ def set_setting(name, value, channel=""):
     if channel:
         from core import channeltools
         return channeltools.set_channel_setting(name, value, channel)
+    elif server:
+        from core import servertools
+        return servertools.set_server_setting(name, value, server)
     else:
         try:
             if isinstance(value, bool):


### PR DESCRIPTION
servertools modificado juntamente con @superberny70, entre las modificaciones echas están:
 - Pasados los patrones a los XML's de este modo es posible realizar las búsquedas sin necesidad de importar todos los canales, lo que gana en velocidad.
 - Soporte para configuración de servidores independiente (como los canales) con los controles guardados en el XML
 - Posibilidad de bloquear los servidores que no queramos usar desde la configuración
 - Posibilidad de seleccionar 5 servidores favoritos que se mostraran los enlaces al principio de todo (según compatibilidad con los canales)
 - Añadida función servertools.get_servers_itemlist(itemlist, fnc):
    - Devuelve el itemlist con todos sus ítems añadido el server, y añadido el thumbnail del server, lo mismo que get_server_from_url y guess_server_thumbnail pero con un rendimiento mejor ya que realiza una búsqueda global 
    - Si se le pasa una función por el parámetro fnc se le pasa esta es llamada pasando cada ítem como argumento y el valor devuelto es puesto al title de cada ítem, esto es para cuando queremos poner en el title en nombre del servidor, y hasta que no se ha asignado no lo conocemos, en los canales que he modificado podéis ver ejemplos de su uso 

 - Movidas las funciones de lista blanca/negra del launcher al servertools, para que sea genérica para todas las plataformas
 - Modificadas la función resolve_video_urls_for_playing:
    - Reorganizado el código
    - Añadida la posibilidad de hacer que siga buscando en las demás opciones (cuentas Premium) aun cuando ya se ha encontrado una url
    - Posibilidad de elegir el orden en el que se buscan los videos (free, Premium, debriders)
 - Añadido un sistema de estadísticas para detectar cuando un servidor falla (todavía no funcional ya que hay que crear un servidor que recoja esos valores de los usuarios)  


Aprovecho a crear el PR ahora que no hay PR's pendientes de servidores, ya que esto modifica TODOS los xmls y así evito conflictos.

Los nuevos XML contienen una clave 'find_videos' con un listado con los patrones y un listado con las urls a ignorar (algunos servidores las usan).
Su funcionamiento es sencillo así que si miráis un XML ya veréis como funciona

También contienen los controles de los settings igual que los canales, todos los servers contienen dos controles por defecto, el de lista negra (bloqueado) y el de lista blanca (favoritos)

