### PR TITLE
Reparados varios conectores y expresiones regulares en los xml

### DIFF
--- a/python/main-classic/servers/clicknupload.py
+++ b/python/main-classic/servers/clicknupload.py
@@ -8,8 +8,12 @@
 import re
 import urllib
 
+from core import httptools
 from core import logger
 from core import scrapertools
+
+token = ""
+exception = False
 
 
 def test_video_exists(page_url):
@@ -24,25 +28,16 @@ def test_video_exists(page_url):
 def get_video_url(page_url, premium=False, user="", password="", video_password=""):
     logger.info("url=" + page_url)
 
-    data = scrapertools.cache_page(page_url)
-    data = data.replace("\n", "").replace("\t", "")
+    data = get_data(page_url)
+
     post = ""
-    block = scrapertools.find_single_match(data, '<Form method="POST"(.*?)</Form>')
+    block = scrapertools.find_single_match(data, '(?i)<Form method="POST"(.*?)</Form>')
     matches = scrapertools.find_multiple_matches(block, 'input.*?name="([^"]+)".*?value="([^"]*)"')
     for inputname, inputvalue in matches:
         post += inputname + "=" + inputvalue + "&"
-    # Primera solicitud post
-    data = scrapertools.cache_page(page_url, post=post)
-    data = data.replace("\n", "").replace("\t", "")
-    import time
-    time.sleep(5)
-    post = ""
-    block = scrapertools.find_single_match(data, '<Form name="F1" method="POST"(.*?)</Form>')
-    matches = scrapertools.find_multiple_matches(block, '<input.*?name="([^"]+)".*?value="([^"]*)">')
-    for inputname, inputvalue in matches:
-        post += inputname + "=" + inputvalue + "&"
-    # Segunda solicitud post tras 5 segundos de espera
-    data = scrapertools.cache_page(page_url, post=post)
+    post = post.replace("download1", "download2")
+
+    data = get_data(page_url, post)
 
     video_urls = []
     media = scrapertools.find_single_match(data, "onClick=\"window.open\('([^']+)'")
@@ -62,13 +57,13 @@ def find_videos(data):
     devuelve = []
 
     # http://clicknupload.me/jdfscsa5uoy4
-    patronvideos = "clicknupload.(?:me|com)/([a-z0-9]+)"
+    patronvideos = "clicknupload.(?:me|com|org)/([a-z0-9]+)"
     logger.info("#" + patronvideos + "#")
     matches = re.compile(patronvideos, re.DOTALL).findall(data)
 
     for match in matches:
         titulo = "[clicknupload]"
-        url = "http://clicknupload.me/%s" % match
+        url = "https://clicknupload.org/%s" % match
         if url not in encontrados:
             logger.info("  url=" + url)
             devuelve.append([titulo, url, 'clicknupload'])
@@ -77,3 +72,35 @@ def find_videos(data):
             logger.info("  url duplicada=" + url)
 
     return devuelve
+
+
+def get_data(url_orig, req_post=""):
+    try:
+        if not exception:
+            response = httptools.downloadpage(url_orig, req_post)
+            if not response.data or "urlopen error [Errno 1]" in str(response.code):
+                global exception
+                exception = True
+                raise Exception
+            return response.data
+        else:
+            raise Exception
+    except:
+        import urllib
+        post = {"address":url_orig}
+        if req_post:
+            post["options"] = [{"man":"--data","attribute": req_post}]
+        else:
+            post["options"] = []
+        from core import jsontools
+        global token
+        if not token:
+            data = httptools.downloadpage("http://onlinecurl.com/").data
+            token = scrapertools.find_single_match(data, '<meta name="csrf-token" content="([^"]+)"')
+        
+        headers = {'X-Requested-With': 'XMLHttpRequest', 'X-CSRF-Token': token, 'Referer': 'http://onlinecurl.com/'}
+        post = "curl_request=" + urllib.quote(jsontools.dump_json(post)) + "&email="
+        response = httptools.downloadpage("http://onlinecurl.com/onlinecurl", post=post, headers=headers).data
+        data = jsontools.load_json(response).get("body", "")
+
+        return data

--- a/python/main-classic/servers/clicknupload.py
+++ b/python/main-classic/servers/clicknupload.py
@@ -13,13 +13,13 @@ from core import logger
 from core import scrapertools
 
 token = ""
-exception = False
+excption = False
 
 
 def test_video_exists(page_url):
     logger.info("(page_url='%s')" % page_url)
 
-    data = scrapertools.cache_page(page_url)
+    data = get_data(page_url.replace(".org", ".me"))
     if "File Not Found" in data: return False, "[Clicknupload] El archivo no existe o ha sido borrado"
 
     return True, ""
@@ -28,7 +28,7 @@ def test_video_exists(page_url):
 def get_video_url(page_url, premium=False, user="", password="", video_password=""):
     logger.info("url=" + page_url)
 
-    data = get_data(page_url)
+    data = get_data(page_url.replace(".org", ".me"))
 
     post = ""
     block = scrapertools.find_single_match(data, '(?i)<Form method="POST"(.*?)</Form>')
@@ -76,20 +76,20 @@ def find_videos(data):
 
 def get_data(url_orig, req_post=""):
     try:
-        if not exception:
+        if not excption:
             response = httptools.downloadpage(url_orig, req_post)
             if not response.data or "urlopen error [Errno 1]" in str(response.code):
-                global exception
-                exception = True
+                global excption
+                excption = True
                 raise Exception
             return response.data
         else:
             raise Exception
     except:
         import urllib
-        post = {"address":url_orig}
+        post = {"address": url_orig.replace(".me", ".org")}
         if req_post:
-            post["options"] = [{"man":"--data","attribute": req_post}]
+            post["options"] = [{"man": "--data", "attribute": req_post}]
         else:
             post["options"] = []
         from core import jsontools

--- a/python/main-classic/servers/clicknupload.xml
+++ b/python/main-classic/servers/clicknupload.xml
@@ -12,8 +12,8 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>clicknupload.(?:me|com)/([a-z0-9]+)</pattern>
-			<url>http://clicknupload.me/\1</url>
+			<pattern>clicknupload.(?:me|com|org)/([a-z0-9]+)</pattern>
+			<url>https://clicknupload.org/\1</url>
 		</patterns>
 	</find_videos>
 	<free>true</free>

--- a/python/main-classic/servers/documentary.xml
+++ b/python/main-classic/servers/documentary.xml
@@ -13,7 +13,7 @@
 		</ignore_urls>
 		<patterns>
 			<pattern>http://documentary.es/(\d+[a-z0-9\-]+)</pattern>
-			<url>http://documentary.es/\1?embed"</url>
+			<url>http://documentary.es/\1?embed</url>
 		</patterns>
 	</find_videos>
 	<free>true</free>

--- a/python/main-classic/servers/kingvid.xml
+++ b/python/main-classic/servers/kingvid.xml
@@ -13,7 +13,7 @@
 		</ignore_urls>
 		<patterns>
 			<pattern>kingvid.tv/(?:embed-|)([A-z0-9]+)</pattern>
-			<url>http://kingvid.tv/embed-\1.html"</url>
+			<url>http://kingvid.tv/embed-\1.html</url>
 		</patterns>
 	</find_videos>
 	<free>true</free>

--- a/python/main-classic/servers/letwatch.xml
+++ b/python/main-classic/servers/letwatch.xml
@@ -13,7 +13,7 @@
 		</ignore_urls>
 		<patterns>
 			<pattern>letwatch.(?:us|to)/(?:embed-|)([a-z0-9A-Z]+)(?:.html|)</pattern>
-			<url>http://letwatch.to/embed-\1.html"</url>
+			<url>http://letwatch.to/embed-\1.html</url>
 		</patterns>
 	</find_videos>
 	<free>true</free>

--- a/python/main-classic/servers/mediafire.xml
+++ b/python/main-classic/servers/mediafire.xml
@@ -12,23 +12,7 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>mediafire.com/download.php\?([a-z0-9]+)</pattern>
-			<url>http://www.mediafire.com/?\1</url>
-		</patterns>
-		<patterns>
-			<pattern>mediafire.com/download/([a-z0-9]+)</pattern>
-			<url>http://www.mediafire.com/?\1</url>
-		</patterns>
-		<patterns>
-			<pattern>http://www.mediafire.com/\?([a-z0-9]+)</pattern>
-			<url>http://www.mediafire.com/?\1</url>
-		</patterns>
-		<patterns>
-			<pattern>http://www.mediafire.com/file/([a-z0-9]+)</pattern>
-			<url>http://www.mediafire.com/?\1</url>
-		</patterns>
-		<patterns>
-			<pattern>mediafire.com\%2F\%3F([a-z0-9]+)</pattern>
+			<pattern>mediafire.com(?:/download.php\?|/download/|/file/|/\?|\%2F\%3F)([a-z0-9]+)</pattern>
 			<url>http://www.mediafire.com/?\1</url>
 		</patterns>
 	</find_videos>

--- a/python/main-classic/servers/mp4upload.xml
+++ b/python/main-classic/servers/mp4upload.xml
@@ -14,7 +14,7 @@
 		</ignore_urls>
 		<patterns>
 			<pattern>mp4upload.com/embed-([A-Za-z0-9]+)</pattern>
-			<url>http://www.mp4upload.com/embed-\1.html"</url>
+			<url>http://www.mp4upload.com/embed-\1.html</url>
 		</patterns>
 	</find_videos>
 	<free>true</free>

--- a/python/main-classic/servers/raptu.py
+++ b/python/main-classic/servers/raptu.py
@@ -62,7 +62,7 @@ def find_videos(data):
 
     for match in matches:
         titulo = "[raptu]"
-        url = "http://raptu.com/embed/%s" % match
+        url = "https://raptu.com/embed/%s" % match
         if url not in encontrados:
             logger.info("  url=" + url)
             devuelve.append([titulo, url, 'raptu'])

--- a/python/main-classic/servers/raptu.xml
+++ b/python/main-classic/servers/raptu.xml
@@ -18,7 +18,7 @@
 		</ignore_urls>
 		<patterns>
 			<pattern>raptu.com/(?:\?v=|embed/|e/)([A-z0-9]+)</pattern>
-			<url>http://raptu.com/embed/\1</url>
+			<url>https://raptu.com/embed/\1</url>
 		</patterns>
 	</find_videos>
 	<free>true</free>

--- a/python/main-classic/servers/thevideome.py
+++ b/python/main-classic/servers/thevideome.py
@@ -29,8 +29,8 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
 
     data = httptools.downloadpage(page_url).data
 
-    mpri_Key = scrapertools.find_single_match(data, "mpri_Key='([^']+)'")
-    data_vt = httptools.downloadpage("http://thevideo.me/jwv/%s" % mpri_Key).data
+    mpri_Key = scrapertools.find_single_match(data, "lets_play_a_game='([^']+)'")
+    data_vt = httptools.downloadpage("https://thevideo.me/vsign/player/%s" % mpri_Key).data
     vt = scrapertools.find_single_match(data_vt, 'function\|([^\|]+)\|')
     if "fallback" in vt:
         vt = scrapertools.find_single_match(data_vt, 'jwConfig\|([^\|]+)\|')

--- a/python/main-classic/servers/tunepk.xml
+++ b/python/main-classic/servers/tunepk.xml
@@ -13,7 +13,7 @@
 		</ignore_urls>
 		<patterns>
 			<pattern>tune.pk/player/embed_player.php\?vid\=(\d+)</pattern>
-			<url>http://embed.tune.pk/play/\1?autoplay=no"</url>
+			<url>http://embed.tune.pk/play/\1?autoplay=no</url>
 		</patterns>
 	</find_videos>
 	<free>true</free>

--- a/python/main-classic/servers/turbobit.xml
+++ b/python/main-classic/servers/turbobit.xml
@@ -13,7 +13,7 @@
 		</ignore_urls>
 		<patterns>
 			<pattern>(turbobit.net/[0-9a-z]+)</pattern>
-			<url>http://\1.html"</url>
+			<url>http://\1.html</url>
 		</patterns>
 	</find_videos>
 	<free>false</free>

--- a/python/main-classic/servers/turbovideos.xml
+++ b/python/main-classic/servers/turbovideos.xml
@@ -13,7 +13,7 @@
 		</ignore_urls>
 		<patterns>
 			<pattern>turbovideos.net/embed-([a-z0-9A-Z]+)</pattern>
-			<url>http://turbovideos.net/embed-\1.html"</url>
+			<url>http://turbovideos.net/embed-\1.html</url>
 		</patterns>
 	</find_videos>
 	<free>true</free>

--- a/python/main-classic/servers/tutv.xml
+++ b/python/main-classic/servers/tutv.xml
@@ -12,7 +12,7 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>"(http://(?:www.)?tu.tv[^"]+)"</pattern>
+			<pattern>(http://(?:www.)?tu.tv[^"]+)</pattern>
 			<url>\1</url>
 		</patterns>
 		<patterns>

--- a/python/main-classic/servers/userscloud.py
+++ b/python/main-classic/servers/userscloud.py
@@ -35,7 +35,7 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
         post = "op=download2&id=%s&rand=%s&referer=%s&method_free=&method_premium=" % (id_, rand, page_url)
         data = httptools.downloadpage(page_url, post).data
 
-        media_url = scrapertools.find_single_match(data, '<a href="([^"]+)" class="btn btn-success"')
+        media_url = scrapertools.find_single_match(data, '<div id="dl_link".*?<a href="([^"]+)"')
 
     ext = scrapertools.get_filename_from_url(media_url)[-4:]
     video_urls.append(["%s [userscloud]" % ext, media_url])
@@ -60,7 +60,7 @@ def find_videos(data):
 
     for match in matches:
         titulo = "[userscloud]"
-        url = "https://userscloud.com/%s" % match
+        url = "http://userscloud.com/%s" % match
         if url not in encontrados:
             logger.info("  url=" + url)
             devuelve.append([titulo, url, 'userscloud'])

--- a/python/main-classic/servers/userscloud.xml
+++ b/python/main-classic/servers/userscloud.xml
@@ -13,7 +13,7 @@
 		</ignore_urls>
 		<patterns>
 			<pattern>userscloud.com/(?:embed-|)([A-z0-9]+)</pattern>
-			<url>https://userscloud.com/\1</url>
+			<url>http://userscloud.com/\1</url>
 		</patterns>
 	</find_videos>
 	<free>true</free>

--- a/python/main-classic/servers/vidabc.xml
+++ b/python/main-classic/servers/vidabc.xml
@@ -19,7 +19,7 @@
 		</ignore_urls>
 		<patterns>
 			<pattern>vidabc.com/([a-z0-9]+)</pattern>
-			<url>http://vidabc.com/\1.html</url>
+			<url>http://vidabc.com/embed-\1.html</url>
 		</patterns>
 	</find_videos>
 	<free>true</free>

--- a/python/main-classic/servers/vidzi.py
+++ b/python/main-classic/servers/vidzi.py
@@ -37,10 +37,9 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
 
     video_urls = []
     for media_url in media_urls:
-        if ".m3u8" in media_url:
-            media_url += "|Referer=http://static.vidzi.tv/nplayer/jwplayer.flash.swf"
+        ext = scrapertools.get_filename_from_url(media_url)[-4:]
         if not media_url.endswith("vtt"):
-            video_urls.append([scrapertools.get_filename_from_url(media_url)[-4:] + " [vidzi]", media_url])
+            video_urls.append(["%s [vidzi]" % ext, media_url])
 
     return video_urls
 

--- a/python/main-classic/servers/zippyshare.py
+++ b/python/main-classic/servers/zippyshare.py
@@ -40,15 +40,14 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
     data = httptools.downloadpage(page_url).data
     match = re.search('(.+)/v/(\w+)/file.html', page_url)
     domain = match.group(1)
-    file_id = match.group(2)
-    filename = re.search('\](.+)\[\/url\]', data).group(1)
 
-    # Extract magic number
-    a = int(scrapertools.find_single_match(data, 'var a\s*=\s*(\d+);'))
-    b = int(scrapertools.find_single_match(data, 'var b\s*=\s*(\d+);'))
-    magic_number = int(a / 3) + a % b
+    patron = 'getElementById\(\'dlbutton\'\).href\s*=\s*(.*?);'
+    media_url = scrapertools.find_single_match(data, patron)
+    numbers = scrapertools.find_single_match(media_url, '\((.*?)\)')
+    url = media_url.replace(numbers, "'%s'" % eval(numbers))
+    url = eval(url)
 
-    mediaurl = '%s/d/%s/%s/%s' % (domain, file_id, magic_number, filename)
+    mediaurl = '%s%s' % (domain, url)
     extension = "." + mediaurl.split('.')[-1]
     video_urls.append([extension + " [zippyshare]", mediaurl])
 


### PR DESCRIPTION
- Reparados: Mediafire, zippyshare, clicknupload (usa proxy en caso de fallo por https), thevideome y userscloud.
- Raptu solo funciona en Kodi 17 ya que la url del vídeo está ligada a la ip y no es posible usar proxy.