### PR TITLE
Corregidos algunos conectores pendientes

### DIFF
--- a/python/main-classic/platformcode/platformtools.py
+++ b/python/main-classic/platformcode/platformtools.py
@@ -330,12 +330,6 @@ def set_context_commands(item, parent_item):
         if type(command) == str:
             if command == "no_context":
                 return []
-            if command == "buscar_trailer" or item.action == "findvideos":
-                context_commands.append(("Buscar Trailer", "XBMC.RunPlugin(%s?%s)" % (sys.argv[0], item.clone(
-                    channel="trailertools",
-                    action="buscartrailer",
-                    contextual=True
-                ).tourl())))
 
         # Formato dict
         if type(command) == dict:
@@ -460,6 +454,11 @@ def set_context_commands(item, parent_item):
         if parent_item.channel not in ["configuracion", "novedades", "buscador"]:
             context_commands.append(("Abrir Configuración", "XBMC.Container.Update(%s?%s)" %
                                      (sys.argv[0], Item(channel="configuracion", action="mainlist").tourl())))
+
+        # Buscar Trailer
+        if item.action == "findvideos" or "buscar_trailer" in context:
+            context_commands.append(("Buscar Trailer", "XBMC.RunPlugin(%s?%s)" % (sys.argv[0], item.clone(
+                                     channel="trailertools", action="buscartrailer", contextual=True).tourl())))
 
     # Añadir SuperFavourites al menu contextual (1.0.53 o superior necesario)
     sf_file_path = xbmc.translatePath("special://home/addons/plugin.program.super.favourites/LaunchSFMenu.py")

--- a/python/main-classic/servers/auroravid.xml
+++ b/python/main-classic/servers/auroravid.xml
@@ -17,12 +17,8 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>auroravid.to/video/([a-z0-9]{13})</pattern>
-			<url>http://www.auroravid.to/video/\1</url>
-		</patterns>
-		<patterns>
-			<pattern>http://embed.auroravid.to/embed.php.*?v=([a-z0-9]{13})</pattern>
-			<url>http://www.auroravid.to/video/\1</url>
+			<pattern>(?:embed.|)auroravid.to/(?:video/|embed/\?v=)([A-z0-9]{13})</pattern>
+			<url>http://www.auroravid.to/embed/?v=\1</url>
 		</patterns>
 	</find_videos>
 	<free>true</free>

--- a/python/main-classic/servers/datoporn.xml
+++ b/python/main-classic/servers/datoporn.xml
@@ -22,8 +22,8 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>datoporn.com/(?:embed-|)([A-z0-9]+)</pattern>
-			<url>http://datoporn.com/embed-\1.html</url>
+			<pattern>(?:datoporn.com|dato.porn)/(?:embed-|)([A-z0-9]+)</pattern>
+			<url>http://dato.porn/embed-\1.html</url>
 		</patterns>
 	</find_videos>
 	<free>true</free>

--- a/python/main-classic/servers/netutv.xml
+++ b/python/main-classic/servers/netutv.xml
@@ -31,20 +31,12 @@
 			<url>http://netu.tv/watch_video.php?v=\2</url>
 		</patterns>
 		<patterns>
-			<pattern>hqq.tv/([^=]+)=([a-zA-Z0-9]+)</pattern>
-			<url>http://netu.tv/watch_video.php?v=\2</url>
+			<pattern>(?:hqq|waaw|netu)(?:\.tv\/|\.watch\/|\.php\?).*(?:v=|vid=)([A-z0-9]+)</pattern>
+			<url>http://netu.tv/watch_video.php?v=\1</url>
 		</patterns>
 		<patterns>
-			<pattern>netu.tv/([^=]+)=([a-zA-Z0-9]+)</pattern>
-			<url>http://netu.tv/watch_video.php?v=\2</url>
-		</patterns>
-		<patterns>
-			<pattern>waaw.tv/([^=]+)=([a-zA-Z0-9]+)</pattern>
-			<url>http://netu.tv/watch_video.php?v=\2</url>
-		</patterns>
-		<patterns>
-			<pattern>netu.php\?(nt=)([a-zA-Z0-9]+)</pattern>
-			<url>http://netu.tv/watch_video.php?v=\2</url>
+			<pattern>(?:hqq|waaw|netu)(?:\.tv\/|\.watch\/|\.php\?).*hash=([A-z0-9]+)</pattern>
+			<url>http://hqq.tv/player/hash.php?hash=\1</url>
 		</patterns>
 	</find_videos>
 	<free>true</free>

--- a/python/main-classic/servers/rapidvideo.py
+++ b/python/main-classic/servers/rapidvideo.py
@@ -21,7 +21,13 @@ def test_video_exists(page_url):
         pass
 
     if not response.data or "urlopen error [Errno 1]" in str(response.code):
-        return False, "[Rapidvideo] Este conector solo funciona a partir de Kodi 17"
+        from core import config
+        if config.is_xbmc():
+            return False, "[Rapidvideo] Este conector solo funciona a partir de Kodi 17"
+        elif config.get_platform() == "plex":
+            return False, "[Rapidvideo] Este conector no funciona con tu versión de Plex, intenta actualizarla"
+        elif config.get_platform() == "mediaserver":
+            return False, "[Rapidvideo] Este conector requiere actualizar python a la versión 2.7.9 o superior"
     
     if "Object not found" in response.data:
         return False, "[Rapidvideo] El archivo no existe o ha sido borrado"

--- a/python/main-classic/servers/rapidvideo.py
+++ b/python/main-classic/servers/rapidvideo.py
@@ -13,11 +13,27 @@ from core import logger
 from core import scrapertools
 
 
+def test_video_exists(page_url):
+    logger.info("(page_url='%s')" % page_url)
+    try:
+        response = httptools.downloadpage(page_url)
+    except:
+        pass
+
+    if not response.data or "urlopen error [Errno 1]" in str(response.code):
+        return False, "[Rapidvideo] Este conector solo funciona a partir de Kodi 17"
+    
+    if "Object not found" in response.data:
+        return False, "[Rapidvideo] El archivo no existe o ha sido borrado"
+    
+    return True, ""
+
+
 def get_video_url(page_url, premium=False, user="", password="", video_password=""):
     logger.info("url=" + page_url)
     video_urls = []
 
-    data = get_data(page_url)
+    data = httptools.downloadpage(page_url).data
     urls = scrapertools.find_multiple_matches(data, '"file":"([^"]+)","label":"[^"]*","res":"([^"]+)"')
     for mediaurl, res in urls:
         ext = scrapertools.get_filename_from_url(mediaurl)[-4:]
@@ -48,26 +64,3 @@ def find_videos(text):
 
 
     return devuelve
-
-
-def get_data(url_orig):
-    try:
-        response = httptools.downloadpage(url_orig)
-        if not response.data or "urlopen error [Errno 1]" in str(response.code):
-            raise Exception
-    except:
-        import random
-        server_random = ['nl', 'de', 'us']
-        server = server_random[random.randint(0, 2)]
-        url = "https://%s.hideproxy.me/includes/process.php?action=update" % server
-        post = "u=%s&proxy_formdata_server=%s&allowCookies=1&encodeURL=0&encodePage=0&stripObjects=0&stripJS=0&go=" \
-               % (urllib.quote(url_orig), server)
-        while True:
-            response = httptools.downloadpage(url, post, follow_redirects=False)
-            if response.headers.get("location"):
-                url = response.headers["location"]
-                post = ""
-            else:
-                break
-
-    return response.data

--- a/python/main-classic/servers/rapidvideo.xml
+++ b/python/main-classic/servers/rapidvideo.xml
@@ -22,8 +22,8 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>rapidvideo.org/([A-Za-z0-9]+)/</pattern>
-			<url>http://www.rapidvideo.org/\1</url>
+			<pattern>rapidvideo.(?:org|com)/(?:\?v=|e/|embed/)([A-z0-9]+)</pattern>
+			<url>https://www.rapidvideo.com/e/\1</url>
 		</patterns>
 	</find_videos>
 	<free>true</free>

--- a/python/main-classic/servers/raptu.py
+++ b/python/main-classic/servers/raptu.py
@@ -20,7 +20,13 @@ def test_video_exists(page_url):
         pass
 
     if not response.data or "urlopen error [Errno 1]" in str(response.code):
-        return False, "[Raptu] Este conector solo funciona a partir de Kodi 17"
+        from core import config
+        if config.is_xbmc():
+            return False, "[Raptu] Este conector solo funciona a partir de Kodi 17"
+        elif config.get_platform() == "plex":
+            return False, "[Raptu] Este conector no funciona con tu versión de Plex, intenta actualizarla"
+        elif config.get_platform() == "mediaserver":
+            return False, "[Raptu] Este conector requiere actualizar python a la versión 2.7.9 o superior"
 
     if "Object not found" in response.data:
         return False, "[Raptu] El archivo no existe o ha sido borrado"

--- a/python/main-classic/servers/raptu.py
+++ b/python/main-classic/servers/raptu.py
@@ -14,9 +14,15 @@ from core import scrapertools
 
 def test_video_exists(page_url):
     logger.info("(page_url='%s')" % page_url)
-    data = httptools.downloadpage(page_url).data
+    try:
+        response = httptools.downloadpage(page_url)
+    except:
+        pass
 
-    if "Object not found" in data:
+    if not response.data or "urlopen error [Errno 1]" in str(response.code):
+        return False, "[Raptu] Este conector solo funciona a partir de Kodi 17"
+
+    if "Object not found" in response.data:
         return False, "[Raptu] El archivo no existe o ha sido borrado"
 
     return True, ""

--- a/python/main-classic/servers/tusfiles.py
+++ b/python/main-classic/servers/tusfiles.py
@@ -1,15 +1,31 @@
 # -*- coding: utf-8 -*-
 #------------------------------------------------------------
 # pelisalacarta - XBMC Plugin
-# Conector para adnstream
+# Conector para tusfiles.net/org
 # http://blog.tvalacarta.info/plugin-xbmc/pelisalacarta/
 #------------------------------------------------------------
 
 import re
 
+from core import httptools
 from core import logger
 from core import scrapertools
-from core import httptools
+
+
+
+def test_video_exists(page_url):
+    logger.info("(page_url='%s')" % page_url)
+
+    if "tusfiles.net" in page_url:
+        data = httptools.downloadpage(page_url).data
+        
+        if "File Not Found" in data:
+            return False, "[Tusfiles] El archivo no existe o ha sido borrado"
+        if "download is no longer available" in data:
+            return False, "[Tusfiles] El archivo ya no está disponible"
+    
+    return True, ""
+
 
 def get_video_url( page_url , premium = False , user="" , password="" , video_password="" ):
     logger.info("page_url='%s'" % page_url)
@@ -17,11 +33,27 @@ def get_video_url( page_url , premium = False , user="" , password="" , video_pa
     # Saca el código del vídeo
     data = httptools.downloadpage(page_url).data.replace("\\", "")
     video_urls = []
-    matches = scrapertools.find_multiple_matches(data, '"label"\s*:\s*(.*?),"type"\s*:\s*"([^"]+)","file"\s*:\s*"([^"]+)"')
-    for calidad, tipo, video_url in matches:
-        tipo = tipo.replace("video/", "")
-        video_urls.append([".%s %sp [tusfiles]" % (tipo, calidad), video_url])
-    
-    video_urls.sort(key=lambda it:int(it[0].split("p ", 1)[0].rsplit(" ")[1]))
-    
+
+    if "tusfiles.org" in page_url:
+        matches = scrapertools.find_multiple_matches(data, '"label"\s*:\s*(.*?),"type"\s*:\s*"([^"]+)","file"\s*:\s*"([^"]+)"')
+        for calidad, tipo, video_url in matches:
+            tipo = tipo.replace("video/", "")
+            video_urls.append([".%s %sp [tusfiles]" % (tipo, calidad), video_url])
+        
+        video_urls.sort(key=lambda it:int(it[0].split("p ", 1)[0].rsplit(" ")[1]))
+    else:
+        matches = scrapertools.find_multiple_matches(data, '<source src="([^"]+)" type="([^"]+)"')
+        for video_url, tipo in matches:
+            tipo = tipo.replace("video/", "")
+            video_urls.append([".%s [tusfiles]" % tipo, video_url])
+
+        id = scrapertools.find_single_match(data, 'name="id" value="([^"]+)"')
+        rand = scrapertools.find_single_match(data, 'name="rand" value="([^"]+)"')
+        if id and rand:
+            post = "op=download2&id=%s&rand=%s&referer=&method_free=&method_premium=" % (id, rand)
+            location = httptools.downloadpage(page_url, post, follow_redirects=False, only_headers=True).headers.get("location")
+            if location:
+                ext = location[-4:]
+                video_urls.append(["%s [tusfiles]" % ext, location])
+
     return video_urls

--- a/python/main-classic/servers/tusfiles.xml
+++ b/python/main-classic/servers/tusfiles.xml
@@ -15,6 +15,11 @@
 			<pattern>http://tusfiles.org/\?([A-z0-9]+)</pattern>
 			<url>http://tusfiles.org/?\1/</url>
 		</patterns>
+		<patterns>
+			<pattern>tusfiles.net/(?:embed-|)([A-z0-9]+)</pattern>
+			<url>http://tusfiles.net/\1</url>
+		</patterns>
+		
 	</find_videos>
 	<free>true</free>
 	<id>tusfiles</id>

--- a/python/main-classic/servers/watchers.py
+++ b/python/main-classic/servers/watchers.py
@@ -37,6 +37,7 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
         ext = scrapertools.get_filename_from_url(media_url)[-4:]
         if calidad:
             ext += " " + calidad + "p"
+        media_url += "|Referer=%s" % page_url
         video_urls.append([ext + ' [watchers]', media_url])
 
     return video_urls


### PR DESCRIPTION
- Reparado watchers
- Añadido servidor tusfiles.net a tusfiles (discriminando para no confundir con tusfiles.org)
- Regex de auroravid, datoporn, netutv, rapidvideo.
- Raptu y rapidvideo muestran aviso de que no funcionan por debajo de Kodi 17 debido a https


Opción buscar trailer en platformtools: Se cambia de lugar para que se añada al menu cuando el action es findvideos, antes solo se hacia si el item.context era str.