### PR TITLE
Servertools: lista negra y favoritos

### DIFF
--- a/python/main-classic/channels/configuracion.py
+++ b/python/main-classic/channels/configuracion.py
@@ -153,7 +153,6 @@ def menu_servers(item):
 
     
     # Inicio - Servidores configurables
-    #from core import servertools
 
     server_list = servertools.get_debriders_list().keys()
     for server in server_list:
@@ -188,21 +187,17 @@ def server_config(item):
 
 
 def servers_blacklist(item):
-    #from core import servertools
     server_list = servertools.get_servers_list()
-
-    if config.get_setting('filter_servers'):
-        default = True
-    else:
-        default = False
+    dict_values = {}
 
     list_controls = [{'id': 'filter_servers',
                       'type': "bool",
                       'label': "@30068",
-                      'default': default,
+                      'default': False,
                       'enabled': True,
                       'visible': True}]
-    dict_values = {}
+    dict_values['filter_servers'] = config.get_setting('filter_servers')
+
     for i, server in enumerate(sorted(server_list.keys())):
         server_parameters = server_list[server]
         controls, defaults = servertools.get_server_controls_settings(server)
@@ -237,21 +232,17 @@ def cb_servers_blacklist(item, dict_values):
         config.set_setting('filter_servers', False)
 
 def servers_whitelist(item):
-    #from core import servertools
     server_list = servertools.get_servers_list()
-
-    if config.get_setting('sort_servers'):
-        default = True
-    else:
-        default = False
+    dict_values = {}
 
     list_controls = [{'id': 'sort_servers',
                       'type': "bool",
                       'label': "Ordenar servidores",
-                      'default': default,
+                      'default': False,
                       'enabled': True,
                       'visible': True}]
-    dict_values = {}
+    dict_values['sort_servers'] = config.get_setting('sort_servers')
+
     server_names = ['Ninguno']
 
     for server in sorted(server_list.keys()):
@@ -284,7 +275,6 @@ def servers_whitelist(item):
 
 
 def cb_servers_whitelist(server_names, dict_values):
-    #from core import servertools
     dict_name = {}
     for i, v in dict_values.items():
         if i == "sort_servers":

--- a/python/main-classic/channels/configuracion.py
+++ b/python/main-classic/channels/configuracion.py
@@ -260,7 +260,7 @@ def servers_favorites(item):
 
         orden = config.get_setting("favorites_servers_list", server=server)
 
-        if orden and orden < 100:
+        if orden > 0 and orden < 100:
             dict_values[orden] = len(server_names) - 1
 
 

--- a/python/main-classic/channels/configuracion.py
+++ b/python/main-classic/channels/configuracion.py
@@ -223,6 +223,7 @@ def servers_blacklist(item):
 
 
 def cb_servers_blacklist(item, dict_values):
+    f = False
     for k,v in dict_values.items():
         if k == 'filter_servers':
             config.set_setting('filter_servers', v)
@@ -230,7 +231,10 @@ def cb_servers_blacklist(item, dict_values):
             config.set_setting("black_list", v,server=k)
             if v: # Si el servidor esta en la lista negra no puede estar en la de favoritos
                 config.set_setting("white_list", 100, server=k)
+                f = True
 
+    if not f: # Si no hay ningun servidor en la lista, desactivarla
+        config.set_setting('filter_servers', False)
 
 def servers_whitelist(item):
     #from core import servertools
@@ -293,6 +297,9 @@ def cb_servers_whitelist(server_names, dict_values):
             config.set_setting("white_list", dict_name[server_parameters['name']], server=server)
         else:
             config.set_setting("white_list", 100, server=server)
+
+    if not dict_name: #Si no hay ningun servidor en lalista desactivarla
+        config.set_setting("sort_servers", False)
 
 
 def get_all_versions(item):

--- a/python/main-classic/channels/configuracion.py
+++ b/python/main-classic/channels/configuracion.py
@@ -230,7 +230,7 @@ def cb_servers_blacklist(item, dict_values):
             if v: # Si el servidor esta en la lista negra no puede estar en la de favoritos
                 config.set_setting("favorites_servers_list", 100, server=k)
                 f = True
-        progreso.update((i * 100) / n, "Guardando configuración...")
+                progreso.update((i * 100) / n, "Guardando configuración...%s" % k)
         i += 1
 
     if not f: # Si no hay ningun servidor en la lista, desactivarla
@@ -299,7 +299,7 @@ def cb_servers_favorites(server_names, dict_values):
             config.set_setting("favorites_servers_list", dict_name[server_parameters['name']], server=server)
         else:
             config.set_setting("favorites_servers_list", 100, server=server)
-        progreso.update((i * 100) / n, "Guardando configuración...")
+        progreso.update((i * 100) / n, "Guardando configuración...%s" % server_parameters['name'])
         i += 1
 
     if not dict_name: #Si no hay ningun servidor en lalista desactivarla

--- a/python/main-classic/core/servertools.py
+++ b/python/main-classic/core/servertools.py
@@ -696,7 +696,7 @@ def sort_servers(servers_list):
     u objetos Item. En cuyo caso es necesario q tengan un atributo item.server del tipo str.
     :return: Lista del mismo tipo de objetos que servers_list ordenada en funcion de los servidores favoritos.
     """
-    if servers_list:
+    if servers_list and config.get_setting('sort_servers'):
         if isinstance(servers_list[0],Item):
             servers_list = sorted(servers_list, key = lambda x: config.get_setting("white_list",server=x.server) or 100)
         else:
@@ -713,7 +713,7 @@ def filter_servers(servers_list):
     :return: Lista del mismo tipo de objetos que servers_list filtrada en funcion de la Lista Negra.
     """
     servers_list_filter = []
-    if servers_list:
+    if servers_list and config.get_setting('filter_servers'):
         if isinstance(servers_list[0],Item):
             servers_list_filter = filter(lambda x: not config.get_setting("black_list",server=x.server), servers_list)
         else:

--- a/python/main-classic/core/servertools.py
+++ b/python/main-classic/core/servertools.py
@@ -700,11 +700,11 @@ def sort_servers(servers_list):
     u objetos Item. En cuyo caso es necesario q tengan un atributo item.server del tipo str.
     :return: Lista del mismo tipo de objetos que servers_list ordenada en funcion de los servidores favoritos.
     """
-    if servers_list and config.get_setting('sort_servers'):
+    if servers_list and config.get_setting('favorites_servers'):
         if isinstance(servers_list[0],Item):
-            servers_list = sorted(servers_list, key = lambda x: config.get_setting("white_list",server=x.server) or 100)
+            servers_list = sorted(servers_list, key = lambda x: config.get_setting("favorites_servers_list",server=x.server) or 100)
         else:
-            servers_list = sorted(servers_list, key = lambda x: config.get_setting("white_list",server=x) or 100)
+            servers_list = sorted(servers_list, key = lambda x: config.get_setting("favorites_servers_list",server=x) or 100)
     return servers_list
 
     

--- a/python/main-classic/core/servertools.py
+++ b/python/main-classic/core/servertools.py
@@ -92,6 +92,8 @@ def get_servers_itemlist(itemlist, fnc=None, sort=False):
     @type itemlist: list
     @param fnc: función para ejecutar con cada item (para asignar el titulo)
     @type fnc: function
+    @param sort: indica si el listado resultante se ha de ordenar en funcion de la lista de servidores favoritos
+    @type sort: bool
     """
     server_stats = {}
     #Recorre los servidores
@@ -140,6 +142,7 @@ def get_servers_itemlist(itemlist, fnc=None, sort=False):
         itemlist = sort_servers(itemlist)
     
     return itemlist
+
 
 def findvideos(data, skip=False):
     """
@@ -691,7 +694,8 @@ def get_debriders_list():
 
 def sort_servers(servers_list):
     """
-    Si existe un listado de servidores favoritos en la configuracion lo utiliza para ordenar la lista servers_list
+    Si esta activada la opcion "Ordenar servidores" en la configuracion de servidores y existe un listado de servidores 
+    favoritos en la configuracion lo utiliza para ordenar la lista servers_list
     :param servers_list: Listado de servidores para ordenar. Los elementos de la lista servers_list pueden ser strings
     u objetos Item. En cuyo caso es necesario q tengan un atributo item.server del tipo str.
     :return: Lista del mismo tipo de objetos que servers_list ordenada en funcion de los servidores favoritos.
@@ -706,8 +710,8 @@ def sort_servers(servers_list):
     
 def filter_servers(servers_list):
     """
-    Si esta activada la opcion "Filtrar servidores (Lista Negra)" en la configuracion, elimina de la lista de entrada los
-    servidores incluidos en la Lista Negra.
+    Si esta activada la opcion "Filtrar por servidores" en la configuracion de servidores, elimina de la lista 
+    de entrada los servidores incluidos en la Lista Negra.
     :param servers_list: Listado de servidores para filtrar. Los elementos de la lista servers_list pueden ser strings
     u objetos Item. En cuyo caso es necesario q tengan un atributo item.server del tipo str.
     :return: Lista del mismo tipo de objetos que servers_list filtrada en funcion de la Lista Negra.

--- a/python/main-classic/core/servertools.py
+++ b/python/main-classic/core/servertools.py
@@ -724,11 +724,12 @@ def filter_servers(servers_list):
             servers_list_filter = filter(lambda x: not config.get_setting("black_list",server=x), servers_list)
             
         # Si no hay enlaces despues de filtrarlos
-        if not servers_list_filter and platformtools.dialog_yesno("Filtrar servidores (Lista Negra)",
+        if servers_list_filter or not platformtools.dialog_yesno("Filtrar servidores (Lista Negra)",
                                                                   "Todos los enlaces disponibles pertenecen a servidores incluidos en su Lista Negra.",
                                                                   "¿Desea mostrar estos enlaces?"):
-            return servers_list
-    return servers_list_filter
+            servers_list = servers_list_filter
+
+    return servers_list
 
 
 def xml2dict(file = None, xmldata = None):

--- a/python/main-classic/servers/adnstream.xml
+++ b/python/main-classic/servers/adnstream.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/adnstream.xml
+++ b/python/main-classic/servers/adnstream.xml
@@ -42,12 +42,6 @@
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
-		<lvalues>No</lvalues>
-		<lvalues>1</lvalues>
-		<lvalues>2</lvalues>
-		<lvalues>3</lvalues>
-		<lvalues>4</lvalues>
-		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_adnstream.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/adnstream.xml
+++ b/python/main-classic/servers/adnstream.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,24 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
-		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
+		<type>list</type>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<default>100</default>
+		<enabled>true</enabled>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_adnstream.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/allmyvideos.xml
+++ b/python/main-classic/servers/allmyvideos.xml
@@ -62,7 +62,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/allmyvideos.xml
+++ b/python/main-classic/servers/allmyvideos.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>04/06/2016</date>
 			<description>Reparado, utiliza proxy en caso que salte el geobloqueo</description>
 		</change>
@@ -60,12 +60,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_allmyvideos.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/auroravid.xml
+++ b/python/main-classic/servers/auroravid.xml
@@ -8,7 +8,7 @@
 			<description>Conector corregido</description>
 		</change>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -35,12 +35,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_auroravid.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/auroravid.xml
+++ b/python/main-classic/servers/auroravid.xml
@@ -37,7 +37,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/backin.xml
+++ b/python/main-classic/servers/backin.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_backin.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/backin.xml
+++ b/python/main-classic/servers/backin.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/bigfile.xml
+++ b/python/main-classic/servers/bigfile.xml
@@ -33,7 +33,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/bigfile.xml
+++ b/python/main-classic/servers/bigfile.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -31,12 +31,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_bigfile.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/bitshare.xml
+++ b/python/main-classic/servers/bitshare.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -40,12 +40,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_bitshare.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/bitshare.xml
+++ b/python/main-classic/servers/bitshare.xml
@@ -42,7 +42,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/bitvidsx.xml
+++ b/python/main-classic/servers/bitvidsx.xml
@@ -41,7 +41,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/bitvidsx.xml
+++ b/python/main-classic/servers/bitvidsx.xml
@@ -8,7 +8,7 @@
 			<description>Conector corregido</description>
 		</change>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -39,12 +39,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_bitvidsx.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/clicknupload.xml
+++ b/python/main-classic/servers/clicknupload.xml
@@ -33,7 +33,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/clicknupload.xml
+++ b/python/main-classic/servers/clicknupload.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -31,12 +31,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_clicknupload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/cloudy.xml
+++ b/python/main-classic/servers/cloudy.xml
@@ -37,7 +37,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/cloudy.xml
+++ b/python/main-classic/servers/cloudy.xml
@@ -35,12 +35,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_cloudy.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/cnubis.xml
+++ b/python/main-classic/servers/cnubis.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_cnubis.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/cnubis.xml
+++ b/python/main-classic/servers/cnubis.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/copiapop.xml
+++ b/python/main-classic/servers/copiapop.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/copiapop.xml
+++ b/python/main-classic/servers/copiapop.xml
@@ -12,7 +12,7 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>((?:copiapop.com|diskokosmiko.mx)/[^\s'"]+)</pattern>
+			<pattern>((?:copiapop.com|diskokosmiko.mx)/[^\s'&quot;]+)</pattern>
 			<url>http://\1</url>
 		</patterns>
 	</find_videos>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/EjbfM7p.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/crunchyroll.xml
+++ b/python/main-classic/servers/crunchyroll.xml
@@ -8,7 +8,7 @@
 			<description>Se añade libreria jscrypto para que funcione en cualquier sistema y deteccion enlaces rtmpe</description>
 		</change>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>11/01/2017</date>
 			<description>Versión inicial</description>
 		</change>
@@ -35,12 +35,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<settings>
 		<default>false</default>
@@ -51,7 +57,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default></default>
+		<default/>
 		<enabled>eq(-1,true)</enabled>
 		<id>user</id>
 		<label>@30014</label>
@@ -59,7 +65,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default></default>
+		<default/>
 		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
 		<hidden>true</hidden>
 		<id>password</id>

--- a/python/main-classic/servers/crunchyroll.xml
+++ b/python/main-classic/servers/crunchyroll.xml
@@ -37,7 +37,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/cumlouder.xml
+++ b/python/main-classic/servers/cumlouder.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/cumlouder.xml
+++ b/python/main-classic/servers/cumlouder.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_cumlouder.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/dailymotion.xml
+++ b/python/main-classic/servers/dailymotion.xml
@@ -39,7 +39,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/dailymotion.xml
+++ b/python/main-classic/servers/dailymotion.xml
@@ -8,7 +8,7 @@
 			<description>Corregido para adaptarlo al uso de httptools ya que fallaba</description>
 		</change>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -37,12 +37,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_dailymotion.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/datoporn.xml
+++ b/python/main-classic/servers/datoporn.xml
@@ -40,12 +40,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/tBSWudd.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/datoporn.xml
+++ b/python/main-classic/servers/datoporn.xml
@@ -42,7 +42,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/depositfiles.xml
+++ b/python/main-classic/servers/depositfiles.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/depositfiles.xml
+++ b/python/main-classic/servers/depositfiles.xml
@@ -3,7 +3,7 @@
 	<active>false</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_depositfiles.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/directo.xml
+++ b/python/main-classic/servers/directo.xml
@@ -54,12 +54,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
-		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
+		<type>list</type>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<default>100</default>
+		<enabled>true</enabled>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_directo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/directo.xml
+++ b/python/main-classic/servers/directo.xml
@@ -56,7 +56,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/divxstage.xml
+++ b/python/main-classic/servers/divxstage.xml
@@ -37,7 +37,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/divxstage.xml
+++ b/python/main-classic/servers/divxstage.xml
@@ -8,7 +8,7 @@
 			<description>Conector corregido</description>
 		</change>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -17,7 +17,7 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>(?:divxstage|cloudtime).[^/]+/video/([^"' ]+)</pattern>
+			<pattern>(?:divxstage|cloudtime).[^/]+/video/([^&quot;' ]+)</pattern>
 			<url>http://www.cloudtime.to/embed/?v=\1</url>
 		</patterns>
 	</find_videos>
@@ -35,12 +35,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_divxstage.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/documentary.xml
+++ b/python/main-classic/servers/documentary.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_documentary.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/documentary.xml
+++ b/python/main-classic/servers/documentary.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/eroshare.xml
+++ b/python/main-classic/servers/eroshare.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/eroshare.xml
+++ b/python/main-classic/servers/eroshare.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>27/02/2017</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>https://s31.postimg.org/cewftt397/eroshare.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/facebook.xml
+++ b/python/main-classic/servers/facebook.xml
@@ -36,7 +36,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/facebook.xml
+++ b/python/main-classic/servers/facebook.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,12 +34,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_facebook.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/fakingstv.xml
+++ b/python/main-classic/servers/fakingstv.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/fakingstv.xml
+++ b/python/main-classic/servers/fakingstv.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_fakingstv.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/fastplay.xml
+++ b/python/main-classic/servers/fastplay.xml
@@ -40,12 +40,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/vHDcd6Y.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/fastplay.xml
+++ b/python/main-classic/servers/fastplay.xml
@@ -42,7 +42,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/filebox.xml
+++ b/python/main-classic/servers/filebox.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/filebox.xml
+++ b/python/main-classic/servers/filebox.xml
@@ -3,7 +3,7 @@
 	<active>false</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_filebox.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/filefactory.xml
+++ b/python/main-classic/servers/filefactory.xml
@@ -34,7 +34,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/filefactory.xml
+++ b/python/main-classic/servers/filefactory.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -32,12 +32,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_filefactory.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/fileflyer.xml
+++ b/python/main-classic/servers/fileflyer.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -32,12 +32,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_fileflyer.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/fileflyer.xml
+++ b/python/main-classic/servers/fileflyer.xml
@@ -34,7 +34,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/filescdn.xml
+++ b/python/main-classic/servers/filescdn.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/filescdn.xml
+++ b/python/main-classic/servers/filescdn.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>15/02/2017</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>https://s31.postimg.org/ijne6piij/filescdn.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/fileserve.xml
+++ b/python/main-classic/servers/fileserve.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/fileserve.xml
+++ b/python/main-classic/servers/fileserve.xml
@@ -3,7 +3,7 @@
 	<active>false</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_fileserve.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/filesmonster.xml
+++ b/python/main-classic/servers/filesmonster.xml
@@ -33,7 +33,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/filesmonster.xml
+++ b/python/main-classic/servers/filesmonster.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Version incial</description>
 		</change>
@@ -31,12 +31,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<settings>
 		<default>false</default>
@@ -47,7 +53,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default></default>
+		<default/>
 		<enabled>eq(-1,true)</enabled>
 		<id>user</id>
 		<label>@30014</label>
@@ -55,7 +61,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default></default>
+		<default/>
 		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
 		<hidden>true</hidden>
 		<id>password</id>

--- a/python/main-classic/servers/filez.xml
+++ b/python/main-classic/servers/filez.xml
@@ -37,7 +37,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/filez.xml
+++ b/python/main-classic/servers/filez.xml
@@ -35,12 +35,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/HasfjUH.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/flashx.xml
+++ b/python/main-classic/servers/flashx.xml
@@ -8,7 +8,7 @@
 			<description>Mejorado el test de video y uso de httptools</description>
 		</change>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>04/06/2016</date>
 			<description>Reparado por cambio en la url embebida</description>
 		</change>
@@ -35,12 +35,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_flashx.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/flashx.xml
+++ b/python/main-classic/servers/flashx.xml
@@ -37,7 +37,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/fourshared.xml
+++ b/python/main-classic/servers/fourshared.xml
@@ -43,7 +43,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/fourshared.xml
+++ b/python/main-classic/servers/fourshared.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -41,12 +41,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_fourshared.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/freakshare.xml
+++ b/python/main-classic/servers/freakshare.xml
@@ -34,7 +34,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/freakshare.xml
+++ b/python/main-classic/servers/freakshare.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -12,7 +12,7 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>(freakshare.com/files/[^/]+/[^"'\n ]+)</pattern>
+			<pattern>(freakshare.com/files/[^/]+/[^&quot;'\n ]+)</pattern>
 			<url>http://\1</url>
 		</patterns>
 	</find_videos>
@@ -32,12 +32,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_freakshare.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/gamovideo.xml
+++ b/python/main-classic/servers/gamovideo.xml
@@ -45,12 +45,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_gamovideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/gamovideo.xml
+++ b/python/main-classic/servers/gamovideo.xml
@@ -47,7 +47,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/gigasize.xml
+++ b/python/main-classic/servers/gigasize.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -36,12 +36,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_gigasize.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/gigasize.xml
+++ b/python/main-classic/servers/gigasize.xml
@@ -38,7 +38,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/googlevideo.xml
+++ b/python/main-classic/servers/googlevideo.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/googlevideo.xml
+++ b/python/main-classic/servers/googlevideo.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_googlevideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/hugefiles.xml
+++ b/python/main-classic/servers/hugefiles.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -31,12 +31,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_hugefiles.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/hugefiles.xml
+++ b/python/main-classic/servers/hugefiles.xml
@@ -33,7 +33,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/idowatch.xml
+++ b/python/main-classic/servers/idowatch.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/idowatch.xml
+++ b/python/main-classic/servers/idowatch.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_idowatch.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/kingvid.xml
+++ b/python/main-classic/servers/kingvid.xml
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/oq0tPhY.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/kingvid.xml
+++ b/python/main-classic/servers/kingvid.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/letwatch.xml
+++ b/python/main-classic/servers/letwatch.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/letwatch.xml
+++ b/python/main-classic/servers/letwatch.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>04/06/2016</date>
 			<description>Reparado porque a veces devuelve enlace directo al video y no ofuscado</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_letwatch.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/mailru.xml
+++ b/python/main-classic/servers/mailru.xml
@@ -8,7 +8,7 @@
 			<description>Reparado por cambios y corregidas expresiones regulares</description>
 		</change>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión inicial</description>
 		</change>
@@ -39,12 +39,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_mailru.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/mailru.xml
+++ b/python/main-classic/servers/mailru.xml
@@ -41,7 +41,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/mediafire.xml
+++ b/python/main-classic/servers/mediafire.xml
@@ -34,7 +34,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/mediafire.xml
+++ b/python/main-classic/servers/mediafire.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -32,12 +32,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_mediafire.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/mega.xml
+++ b/python/main-classic/servers/mega.xml
@@ -45,7 +45,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/mega.xml
+++ b/python/main-classic/servers/mega.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -43,12 +43,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_mega.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/movshare.xml
+++ b/python/main-classic/servers/movshare.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,12 +34,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_movshare.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/movshare.xml
+++ b/python/main-classic/servers/movshare.xml
@@ -36,7 +36,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/mp4upload.xml
+++ b/python/main-classic/servers/mp4upload.xml
@@ -33,7 +33,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/mp4upload.xml
+++ b/python/main-classic/servers/mp4upload.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -31,12 +31,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_mp4upload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/netutv.xml
+++ b/python/main-classic/servers/netutv.xml
@@ -60,7 +60,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/netutv.xml
+++ b/python/main-classic/servers/netutv.xml
@@ -58,12 +58,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_netutv.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/nosvideo.xml
+++ b/python/main-classic/servers/nosvideo.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,12 +34,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_nosvideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/nosvideo.xml
+++ b/python/main-classic/servers/nosvideo.xml
@@ -36,7 +36,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/nowdownload.xml
+++ b/python/main-classic/servers/nowdownload.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -31,12 +31,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_nowdownload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/nowdownload.xml
+++ b/python/main-classic/servers/nowdownload.xml
@@ -33,7 +33,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/nowvideo.xml
+++ b/python/main-classic/servers/nowvideo.xml
@@ -39,7 +39,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/nowvideo.xml
+++ b/python/main-classic/servers/nowvideo.xml
@@ -37,12 +37,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<settings>
 		<default>false</default>
@@ -53,7 +59,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default></default>
+		<default/>
 		<enabled>eq(-1,true)</enabled>
 		<id>user</id>
 		<label>@30014</label>
@@ -61,7 +67,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default></default>
+		<default/>
 		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
 		<hidden>true</hidden>
 		<id>password</id>

--- a/python/main-classic/servers/oboom.xml
+++ b/python/main-classic/servers/oboom.xml
@@ -33,7 +33,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/oboom.xml
+++ b/python/main-classic/servers/oboom.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -31,12 +31,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_oboom.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/okru.xml
+++ b/python/main-classic/servers/okru.xml
@@ -42,7 +42,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/okru.xml
+++ b/python/main-classic/servers/okru.xml
@@ -40,12 +40,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_okru.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/onefichier.xml
+++ b/python/main-classic/servers/onefichier.xml
@@ -39,7 +39,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/onefichier.xml
+++ b/python/main-classic/servers/onefichier.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -37,12 +37,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<settings>
 		<default>false</default>
@@ -53,7 +59,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default></default>
+		<default/>
 		<enabled>eq(-1,true)</enabled>
 		<id>user</id>
 		<label>@30014</label>
@@ -61,7 +67,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default></default>
+		<default/>
 		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
 		<hidden>true</hidden>
 		<id>password</id>

--- a/python/main-classic/servers/openload.xml
+++ b/python/main-classic/servers/openload.xml
@@ -43,7 +43,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/openload.xml
+++ b/python/main-classic/servers/openload.xml
@@ -41,12 +41,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_openload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/pcloud.xml
+++ b/python/main-classic/servers/pcloud.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/pcloud.xml
+++ b/python/main-classic/servers/pcloud.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>07/05/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_pcloud.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/playwatch.xml
+++ b/python/main-classic/servers/playwatch.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/playwatch.xml
+++ b/python/main-classic/servers/playwatch.xml
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/c7LwCTc.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/playwire.xml
+++ b/python/main-classic/servers/playwire.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/playwire.xml
+++ b/python/main-classic/servers/playwire.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>07/05/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_playwire.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/powvideo.xml
+++ b/python/main-classic/servers/powvideo.xml
@@ -45,12 +45,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_powvideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/powvideo.xml
+++ b/python/main-classic/servers/powvideo.xml
@@ -47,7 +47,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/rapidgator.xml
+++ b/python/main-classic/servers/rapidgator.xml
@@ -34,7 +34,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/rapidgator.xml
+++ b/python/main-classic/servers/rapidgator.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -32,12 +32,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_rapidgator.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/rapidvideo.xml
+++ b/python/main-classic/servers/rapidvideo.xml
@@ -40,12 +40,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_rapidvideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/rapidvideo.xml
+++ b/python/main-classic/servers/rapidvideo.xml
@@ -42,7 +42,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/raptu.xml
+++ b/python/main-classic/servers/raptu.xml
@@ -37,7 +37,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/raptu.xml
+++ b/python/main-classic/servers/raptu.xml
@@ -35,12 +35,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/quVK1j0.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/redirects.xml
+++ b/python/main-classic/servers/redirects.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>26/05/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -42,12 +42,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_servers\redirects.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/redirects.xml
+++ b/python/main-classic/servers/redirects.xml
@@ -44,7 +44,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/rutube.xml
+++ b/python/main-classic/servers/rutube.xml
@@ -33,7 +33,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/rutube.xml
+++ b/python/main-classic/servers/rutube.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -31,12 +31,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_rutube.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/sendvid.xml
+++ b/python/main-classic/servers/sendvid.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/sendvid.xml
+++ b/python/main-classic/servers/sendvid.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_sendvid.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/speedvideo.xml
+++ b/python/main-classic/servers/speedvideo.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/speedvideo.xml
+++ b/python/main-classic/servers/speedvideo.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_speedvideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/spruto.xml
+++ b/python/main-classic/servers/spruto.xml
@@ -40,12 +40,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_spruto.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/spruto.xml
+++ b/python/main-classic/servers/spruto.xml
@@ -42,7 +42,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/stagevu.xml
+++ b/python/main-classic/servers/stagevu.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -38,12 +38,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_stagevu.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/stagevu.xml
+++ b/python/main-classic/servers/stagevu.xml
@@ -40,7 +40,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/stormo.xml
+++ b/python/main-classic/servers/stormo.xml
@@ -37,7 +37,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/stormo.xml
+++ b/python/main-classic/servers/stormo.xml
@@ -35,12 +35,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/mTYCw5E.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/streamango.xml
+++ b/python/main-classic/servers/streamango.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/streamango.xml
+++ b/python/main-classic/servers/streamango.xml
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/o8XR8fL.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/streamcloud.xml
+++ b/python/main-classic/servers/streamcloud.xml
@@ -49,7 +49,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/streamcloud.xml
+++ b/python/main-classic/servers/streamcloud.xml
@@ -5,7 +5,7 @@
 		<change>
 			<autor>Intel1</autor>
 			<date>09/03/2017</date>
-			<description>No detectaba "archivo no encontrado"</description>
+			<description>No detectaba &quot;archivo no encontrado&quot;</description>
 		</change>
 		<change>
 			<date>25/03/2016</date>
@@ -47,12 +47,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_streamcloud.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/streame.xml
+++ b/python/main-classic/servers/streame.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/streame.xml
+++ b/python/main-classic/servers/streame.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_streame.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/streaminto.xml
+++ b/python/main-classic/servers/streaminto.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -45,12 +45,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_streaminto.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/streaminto.xml
+++ b/python/main-classic/servers/streaminto.xml
@@ -47,7 +47,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/streamixcloud.xml
+++ b/python/main-classic/servers/streamixcloud.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/streamixcloud.xml
+++ b/python/main-classic/servers/streamixcloud.xml
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/NuD85Py.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/streamplay.xml
+++ b/python/main-classic/servers/streamplay.xml
@@ -50,12 +50,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_streamplay.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/streamplay.xml
+++ b/python/main-classic/servers/streamplay.xml
@@ -52,7 +52,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/thevideome.xml
+++ b/python/main-classic/servers/thevideome.xml
@@ -8,7 +8,7 @@
 			<description>Reparado conector</description>
 		</change>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Primera versión</description>
 		</change>
@@ -35,12 +35,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_thevideome.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/thevideome.xml
+++ b/python/main-classic/servers/thevideome.xml
@@ -37,7 +37,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/thevideos.xml
+++ b/python/main-classic/servers/thevideos.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/thevideos.xml
+++ b/python/main-classic/servers/thevideos.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_thevideos.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/torrent.xml
+++ b/python/main-classic/servers/torrent.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -16,7 +16,7 @@
 			<url>\1</url>
 		</patterns>
 		<patterns>
-			<pattern>(magnet:\?xt=urn:[^"]+)</pattern>
+			<pattern>(magnet:\?xt=urn:[^&quot;]+)</pattern>
 			<url>\1</url>
 		</patterns>
 	</find_videos>
@@ -34,12 +34,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_torrent.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/torrent.xml
+++ b/python/main-classic/servers/torrent.xml
@@ -36,7 +36,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/tunepk.xml
+++ b/python/main-classic/servers/tunepk.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/tunepk.xml
+++ b/python/main-classic/servers/tunepk.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_tunepk.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/turbobit.xml
+++ b/python/main-classic/servers/turbobit.xml
@@ -34,7 +34,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/turbobit.xml
+++ b/python/main-classic/servers/turbobit.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -32,12 +32,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_turbobit.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/turbovideos.xml
+++ b/python/main-classic/servers/turbovideos.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/turbovideos.xml
+++ b/python/main-classic/servers/turbovideos.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_turbovideos.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/tusfiles.xml
+++ b/python/main-classic/servers/tusfiles.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>16/03/2017</date>
 			<description>Versión incial</description>
 		</change>
@@ -19,7 +19,6 @@
 			<pattern>tusfiles.net/(?:embed-|)([A-z0-9]+)</pattern>
 			<url>http://tusfiles.net/\1</url>
 		</patterns>
-		
 	</find_videos>
 	<free>true</free>
 	<id>tusfiles</id>
@@ -35,12 +34,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_tusfiles.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/tusfiles.xml
+++ b/python/main-classic/servers/tusfiles.xml
@@ -37,7 +37,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/tutv.xml
+++ b/python/main-classic/servers/tutv.xml
@@ -36,7 +36,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/tutv.xml
+++ b/python/main-classic/servers/tutv.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -12,7 +12,7 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>(http://(?:www.)?tu.tv[^"]+)</pattern>
+			<pattern>(http://(?:www.)?tu.tv[^&quot;]+)</pattern>
 			<url>\1</url>
 		</patterns>
 		<patterns>
@@ -34,12 +34,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_tutv.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/uploadedto.xml
+++ b/python/main-classic/servers/uploadedto.xml
@@ -43,7 +43,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/uploadedto.xml
+++ b/python/main-classic/servers/uploadedto.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -41,12 +41,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<settings>
 		<default>false</default>
@@ -57,7 +63,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default></default>
+		<default/>
 		<enabled>eq(-1,true)</enabled>
 		<id>user</id>
 		<label>@30014</label>
@@ -65,7 +71,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default></default>
+		<default/>
 		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
 		<hidden>true</hidden>
 		<id>password</id>

--- a/python/main-classic/servers/uptobox.xml
+++ b/python/main-classic/servers/uptobox.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -36,12 +36,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_uptobox.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/uptobox.xml
+++ b/python/main-classic/servers/uptobox.xml
@@ -38,7 +38,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/userporn.xml
+++ b/python/main-classic/servers/userporn.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -44,12 +44,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_userporn.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/userporn.xml
+++ b/python/main-classic/servers/userporn.xml
@@ -46,7 +46,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/userscloud.xml
+++ b/python/main-classic/servers/userscloud.xml
@@ -34,7 +34,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/userscloud.xml
+++ b/python/main-classic/servers/userscloud.xml
@@ -32,12 +32,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/u4W2DgA.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/veehd.xml
+++ b/python/main-classic/servers/veehd.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/veehd.xml
+++ b/python/main-classic/servers/veehd.xml
@@ -3,7 +3,7 @@
 	<active>false</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_veehd.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/veoh.xml
+++ b/python/main-classic/servers/veoh.xml
@@ -34,12 +34,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
-		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
+		<type>list</type>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<default>100</default>
+		<enabled>true</enabled>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_veoh.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/veoh.xml
+++ b/python/main-classic/servers/veoh.xml
@@ -36,7 +36,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/version.xml
+++ b/python/main-classic/servers/version.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" ?>
 <version>
 	<version>20170510</version>
 	<date>10/05/2017</date>

--- a/python/main-classic/servers/vidabc.xml
+++ b/python/main-classic/servers/vidabc.xml
@@ -3,13 +3,13 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<autor>Intel1</autor>
 			<date>05/06/17</date>
 			<description>Detectado que el archivo se está procesando</description>
 		</change>
 		<change>
-			<autor></autor>
+			<autor/>
 			<autor>Intel1</autor>
 			<date>10/05/17</date>
 			<description>Reparado por robalo, yo solo lo subí al github</description>
@@ -42,12 +42,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidabc.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidabc.xml
+++ b/python/main-classic/servers/vidabc.xml
@@ -44,7 +44,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/videowood.xml
+++ b/python/main-classic/servers/videowood.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/videowood.xml
+++ b/python/main-classic/servers/videowood.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_videowood.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidgg.xml
+++ b/python/main-classic/servers/vidgg.xml
@@ -35,12 +35,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidgg.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidgg.xml
+++ b/python/main-classic/servers/vidgg.xml
@@ -37,7 +37,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/vidgot.xml
+++ b/python/main-classic/servers/vidgot.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/vidgot.xml
+++ b/python/main-classic/servers/vidgot.xml
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/tAI34bF.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidoza.xml
+++ b/python/main-classic/servers/vidoza.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/vidoza.xml
+++ b/python/main-classic/servers/vidoza.xml
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/YefcBBY.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidspot.xml
+++ b/python/main-classic/servers/vidspot.xml
@@ -62,7 +62,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/vidspot.xml
+++ b/python/main-classic/servers/vidspot.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>04/06/2016</date>
 			<description>Reparado, utiliza proxy en caso que salte el geobloqueo</description>
 		</change>
@@ -60,12 +60,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidspot.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidtodo.xml
+++ b/python/main-classic/servers/vidtodo.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/vidtodo.xml
+++ b/python/main-classic/servers/vidtodo.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>24/12/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidtodo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidtome.xml
+++ b/python/main-classic/servers/vidtome.xml
@@ -41,7 +41,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/vidtome.xml
+++ b/python/main-classic/servers/vidtome.xml
@@ -8,7 +8,7 @@
 			<description>Conector corregido</description>
 		</change>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -39,12 +39,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidtome.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidup.xml
+++ b/python/main-classic/servers/vidup.xml
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/sZvy8IC.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidup.xml
+++ b/python/main-classic/servers/vidup.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/vidzi.xml
+++ b/python/main-classic/servers/vidzi.xml
@@ -39,12 +39,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidzi.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidzi.xml
+++ b/python/main-classic/servers/vidzi.xml
@@ -41,7 +41,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/vimeo.xml
+++ b/python/main-classic/servers/vimeo.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -32,12 +32,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vimeo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vimeo.xml
+++ b/python/main-classic/servers/vimeo.xml
@@ -34,7 +34,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/vimpleru.xml
+++ b/python/main-classic/servers/vimpleru.xml
@@ -37,7 +37,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/vimpleru.xml
+++ b/python/main-classic/servers/vimpleru.xml
@@ -8,7 +8,7 @@
 			<description>Reparado por cambios</description>
 		</change>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión inicial</description>
 		</change>
@@ -35,12 +35,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vimpleru.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vk.xml
+++ b/python/main-classic/servers/vk.xml
@@ -36,7 +36,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/vk.xml
+++ b/python/main-classic/servers/vk.xml
@@ -34,12 +34,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
-		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
+		<type>list</type>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<default>100</default>
+		<enabled>true</enabled>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vk.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/watchers.xml
+++ b/python/main-classic/servers/watchers.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/watchers.xml
+++ b/python/main-classic/servers/watchers.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>09/01/2017</date>
 			<description>Versión inicial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/WApzSMn.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/watchvideo.xml
+++ b/python/main-classic/servers/watchvideo.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/watchvideo.xml
+++ b/python/main-classic/servers/watchvideo.xml
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/vDev2I6.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/wholecloud.xml
+++ b/python/main-classic/servers/wholecloud.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/wholecloud.xml
+++ b/python/main-classic/servers/wholecloud.xml
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/yIAQurm.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/xvideos.xml
+++ b/python/main-classic/servers/xvideos.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/xvideos.xml
+++ b/python/main-classic/servers/xvideos.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_xvideos.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/yourupload.xml
+++ b/python/main-classic/servers/yourupload.xml
@@ -47,7 +47,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/yourupload.xml
+++ b/python/main-classic/servers/yourupload.xml
@@ -13,7 +13,7 @@
 			<description>Reparado y adaptado al uso de httptools</description>
 		</change>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión inicial</description>
 		</change>
@@ -45,12 +45,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_yourupload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/youtube.xml
+++ b/python/main-classic/servers/youtube.xml
@@ -45,12 +45,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
-		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
+		<type>list</type>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<default>100</default>
+		<enabled>true</enabled>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_youtube.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/youtube.xml
+++ b/python/main-classic/servers/youtube.xml
@@ -47,7 +47,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/youwatch.xml
+++ b/python/main-classic/servers/youwatch.xml
@@ -8,7 +8,7 @@
 			<description>Corregido conector</description>
 		</change>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -36,12 +36,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_youwatch.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/youwatch.xml
+++ b/python/main-classic/servers/youwatch.xml
@@ -38,7 +38,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/zippyshare.xml
+++ b/python/main-classic/servers/zippyshare.xml
@@ -37,12 +37,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_zippyshare.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/zippyshare.xml
+++ b/python/main-classic/servers/zippyshare.xml
@@ -39,7 +39,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/zstream.xml
+++ b/python/main-classic/servers/zstream.xml
@@ -32,7 +32,7 @@
 	<settings>
 		<default>false</default>
 		<enabled>true</enabled>
-		<id>white_list</id>
+		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
 		<type>bool</type>
 		<visible>false</visible>

--- a/python/main-classic/servers/zstream.xml
+++ b/python/main-classic/servers/zstream.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor></autor>
+			<autor/>
 			<date>09/01/2017</date>
 			<description>Versión inicial</description>
 		</change>
@@ -30,12 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default>false</default>
+		<default>100</default>
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>bool</type>
+		<type>list</type>
 		<visible>false</visible>
+		<lvalues>No</lvalues>
+		<lvalues>1</lvalues>
+		<lvalues>2</lvalues>
+		<lvalues>3</lvalues>
+		<lvalues>4</lvalues>
+		<lvalues>5</lvalues>
 	</settings>
 	<thumbnail>http://i.imgur.com/UJMfMZJ.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>


### PR DESCRIPTION
Pequeños cambios en la lista de servidores bloqueados y en la lista de los 5 servidores favoritos.
El cuadro de seleccion de cada uno de esta listas permite ahora activar o desactivar la funcion, sin perder los servidores seleccionados.