### PR TITLE
XMLs Servidores normalizados

### DIFF
--- a/python/main-classic/servers/adnstream.xml
+++ b/python/main-classic/servers/adnstream.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -30,18 +30,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<id>favorites_servers_list</id>
-		<type>list</type>
-		<label>Incluir en lista de favoritos</label>
 		<default>100</default>
 		<enabled>true</enabled>
-		<visible>false</visible>
+		<id>favorites_servers_list</id>
+		<label>Incluir en lista de favoritos</label>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_adnstream.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/allmyvideos.xml
+++ b/python/main-classic/servers/allmyvideos.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>04/06/2016</date>
 			<description>Reparado, utiliza proxy en caso que salte el geobloqueo</description>
 		</change>
@@ -64,14 +64,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_allmyvideos.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/auroravid.xml
+++ b/python/main-classic/servers/auroravid.xml
@@ -8,7 +8,7 @@
 			<description>Conector corregido</description>
 		</change>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -39,14 +39,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_auroravid.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/backin.xml
+++ b/python/main-classic/servers/backin.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_backin.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/bigfile.xml
+++ b/python/main-classic/servers/bigfile.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -35,14 +35,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_bigfile.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/bitshare.xml
+++ b/python/main-classic/servers/bitshare.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -44,14 +44,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_bitshare.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/bitvidsx.xml
+++ b/python/main-classic/servers/bitvidsx.xml
@@ -8,7 +8,7 @@
 			<description>Conector corregido</description>
 		</change>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -43,14 +43,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_bitvidsx.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/clicknupload.xml
+++ b/python/main-classic/servers/clicknupload.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -35,14 +35,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_clicknupload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/cloudy.xml
+++ b/python/main-classic/servers/cloudy.xml
@@ -39,14 +39,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_cloudy.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/cnubis.xml
+++ b/python/main-classic/servers/cnubis.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_cnubis.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/copiapop.xml
+++ b/python/main-classic/servers/copiapop.xml
@@ -12,7 +12,7 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>((?:copiapop.com|diskokosmiko.mx)/[^\s'&quot;]+)</pattern>
+			<pattern>((?:copiapop.com|diskokosmiko.mx)/[^\s'"]+)</pattern>
 			<url>http://\1</url>
 		</patterns>
 	</find_videos>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/EjbfM7p.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/crunchyroll.xml
+++ b/python/main-classic/servers/crunchyroll.xml
@@ -8,7 +8,7 @@
 			<description>Se añade libreria jscrypto para que funcione en cualquier sistema y deteccion enlaces rtmpe</description>
 		</change>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>11/01/2017</date>
 			<description>Versión inicial</description>
 		</change>
@@ -39,14 +39,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<settings>
 		<default>false</default>
@@ -57,7 +57,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default/>
+		<default></default>
 		<enabled>eq(-1,true)</enabled>
 		<id>user</id>
 		<label>@30014</label>
@@ -65,7 +65,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default/>
+		<default></default>
 		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
 		<hidden>true</hidden>
 		<id>password</id>

--- a/python/main-classic/servers/cumlouder.xml
+++ b/python/main-classic/servers/cumlouder.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_cumlouder.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/dailymotion.xml
+++ b/python/main-classic/servers/dailymotion.xml
@@ -8,7 +8,7 @@
 			<description>Corregido para adaptarlo al uso de httptools ya que fallaba</description>
 		</change>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -41,14 +41,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_dailymotion.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/datoporn.xml
+++ b/python/main-classic/servers/datoporn.xml
@@ -44,14 +44,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/tBSWudd.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/depositfiles.xml
+++ b/python/main-classic/servers/depositfiles.xml
@@ -3,7 +3,7 @@
 	<active>false</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_depositfiles.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/directo.xml
+++ b/python/main-classic/servers/directo.xml
@@ -54,18 +54,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<id>favorites_servers_list</id>
-		<type>list</type>
-		<label>Incluir en lista de favoritos</label>
 		<default>100</default>
 		<enabled>true</enabled>
-		<visible>false</visible>
+		<id>favorites_servers_list</id>
+		<label>Incluir en lista de favoritos</label>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_directo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/divxstage.xml
+++ b/python/main-classic/servers/divxstage.xml
@@ -8,7 +8,7 @@
 			<description>Conector corregido</description>
 		</change>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -17,7 +17,7 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>(?:divxstage|cloudtime).[^/]+/video/([^&quot;' ]+)</pattern>
+			<pattern>(?:divxstage|cloudtime).[^/]+/video/([^"' ]+)</pattern>
 			<url>http://www.cloudtime.to/embed/?v=\1</url>
 		</patterns>
 	</find_videos>
@@ -39,14 +39,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_divxstage.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/documentary.xml
+++ b/python/main-classic/servers/documentary.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_documentary.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/eroshare.xml
+++ b/python/main-classic/servers/eroshare.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>27/02/2017</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>https://s31.postimg.org/cewftt397/eroshare.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/facebook.xml
+++ b/python/main-classic/servers/facebook.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -38,14 +38,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_facebook.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/fakingstv.xml
+++ b/python/main-classic/servers/fakingstv.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_fakingstv.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/fastplay.xml
+++ b/python/main-classic/servers/fastplay.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>6</version>
 	<changes>
 		<change>
 			<autor>Intel1</autor>
@@ -55,15 +54,16 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/vHDcd6Y.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>6</version>
 </server>

--- a/python/main-classic/servers/fastplay.xml
+++ b/python/main-classic/servers/fastplay.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
+	<version>6</version>
 	<changes>
+		<change>
+			<autor>Intel1</autor>
+			<date>14/06/2017</date>
+			<description>Patrón reparado</description>
+		</change>
 		<change>
 			<autor>Intel1</autor>
 			<date>07/06/2017</date>
@@ -27,7 +33,7 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>fastplay.(?:cc|sx)/(?:flash-|embed-|)([A-z0-9]+)</pattern>
+			<pattern>fastplay.(?:to|cc|sx)/(?:flash-|embed-|)([A-z0-9]+)</pattern>
 			<url>http://fastplay.cc/embed-\1.html</url>
 		</patterns>
 	</find_videos>
@@ -60,5 +66,4 @@
 	</settings>
 	<thumbnail>http://i.imgur.com/vHDcd6Y.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>5</version>
 </server>

--- a/python/main-classic/servers/filebox.xml
+++ b/python/main-classic/servers/filebox.xml
@@ -3,7 +3,7 @@
 	<active>false</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_filebox.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/filefactory.xml
+++ b/python/main-classic/servers/filefactory.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -36,14 +36,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_filefactory.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/fileflyer.xml
+++ b/python/main-classic/servers/fileflyer.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -36,14 +36,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_fileflyer.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/filescdn.py
+++ b/python/main-classic/servers/filescdn.py
@@ -22,7 +22,7 @@ def get_video_url(page_url, premium=False, user="", password="", video_password=
     logger.info("url=" + page_url)
     video_urls = []
     data = httptools.downloadpage(page_url).data
-    url = scrapertools.find_single_match(data, 'link:\s*"(https:\/\/.*?filescdn\.com.*?mp4)"')
+    url = scrapertools.find_single_match(data, '(?i)link:\s*"(https://.*?filescdn\.com.*?mp4)"')
     url = url.replace(':443', '')
     video_urls.append(['filescdn', url])
 

--- a/python/main-classic/servers/filescdn.xml
+++ b/python/main-classic/servers/filescdn.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
+	<version>3</version>
 	<changes>
+		<change>
+			<autor>Intel1<autor/>
+			<date>13/06/2017</date>
+			<description>Actualizado patrón del get_video()</description>
+		</change>
 		<change>
 			<autor/>
 			<date>15/02/2017</date>
@@ -45,5 +51,4 @@
 	</settings>
 	<thumbnail>https://s31.postimg.org/ijne6piij/filescdn.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
-	<version>2</version>
 </server>

--- a/python/main-classic/servers/filescdn.xml
+++ b/python/main-classic/servers/filescdn.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>3</version>
 	<changes>
 		<change>
-			<autor>Intel1<autor/>
+			<autor>Intel1</autor>
 			<date>13/06/2017</date>
 			<description>Actualizado patrón del get_video()</description>
 		</change>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>15/02/2017</date>
 			<description>Versión incial</description>
 		</change>
@@ -40,15 +39,16 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>https://s31.postimg.org/ijne6piij/filescdn.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>3</version>
 </server>

--- a/python/main-classic/servers/fileserve.xml
+++ b/python/main-classic/servers/fileserve.xml
@@ -3,7 +3,7 @@
 	<active>false</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_fileserve.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/filesmonster.xml
+++ b/python/main-classic/servers/filesmonster.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Version incial</description>
 		</change>
@@ -35,14 +35,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<settings>
 		<default>false</default>
@@ -53,7 +53,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default/>
+		<default></default>
 		<enabled>eq(-1,true)</enabled>
 		<id>user</id>
 		<label>@30014</label>
@@ -61,7 +61,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default/>
+		<default></default>
 		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
 		<hidden>true</hidden>
 		<id>password</id>

--- a/python/main-classic/servers/filez.xml
+++ b/python/main-classic/servers/filez.xml
@@ -39,14 +39,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/HasfjUH.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/flashx.xml
+++ b/python/main-classic/servers/flashx.xml
@@ -8,7 +8,7 @@
 			<description>Mejorado el test de video y uso de httptools</description>
 		</change>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>04/06/2016</date>
 			<description>Reparado por cambio en la url embebida</description>
 		</change>
@@ -39,14 +39,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_flashx.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/fourshared.xml
+++ b/python/main-classic/servers/fourshared.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -45,14 +45,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_fourshared.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/freakshare.xml
+++ b/python/main-classic/servers/freakshare.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -12,7 +12,7 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>(freakshare.com/files/[^/]+/[^&quot;'\n ]+)</pattern>
+			<pattern>(freakshare.com/files/[^/]+/[^"'\n ]+)</pattern>
 			<url>http://\1</url>
 		</patterns>
 	</find_videos>
@@ -36,14 +36,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_freakshare.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/gamovideo.xml
+++ b/python/main-classic/servers/gamovideo.xml
@@ -49,14 +49,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_gamovideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/gigasize.xml
+++ b/python/main-classic/servers/gigasize.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -40,14 +40,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_gigasize.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/googlevideo.xml
+++ b/python/main-classic/servers/googlevideo.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_googlevideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/hugefiles.xml
+++ b/python/main-classic/servers/hugefiles.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -35,14 +35,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_hugefiles.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/idowatch.xml
+++ b/python/main-classic/servers/idowatch.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_idowatch.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/kingvid.xml
+++ b/python/main-classic/servers/kingvid.xml
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/oq0tPhY.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/letwatch.xml
+++ b/python/main-classic/servers/letwatch.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>04/06/2016</date>
 			<description>Reparado porque a veces devuelve enlace directo al video y no ofuscado</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_letwatch.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/mailru.xml
+++ b/python/main-classic/servers/mailru.xml
@@ -8,7 +8,7 @@
 			<description>Reparado por cambios y corregidas expresiones regulares</description>
 		</change>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión inicial</description>
 		</change>
@@ -43,14 +43,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_mailru.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/mediafire.xml
+++ b/python/main-classic/servers/mediafire.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -36,14 +36,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_mediafire.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/mega.xml
+++ b/python/main-classic/servers/mega.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -47,14 +47,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_mega.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/movshare.xml
+++ b/python/main-classic/servers/movshare.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -38,14 +38,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_movshare.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/mp4upload.xml
+++ b/python/main-classic/servers/mp4upload.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -35,14 +35,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_mp4upload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/netutv.xml
+++ b/python/main-classic/servers/netutv.xml
@@ -62,14 +62,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_netutv.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/nosvideo.xml
+++ b/python/main-classic/servers/nosvideo.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -38,14 +38,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_nosvideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/nowdownload.xml
+++ b/python/main-classic/servers/nowdownload.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -35,14 +35,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_nowdownload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/nowvideo.xml
+++ b/python/main-classic/servers/nowvideo.xml
@@ -41,14 +41,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<settings>
 		<default>false</default>
@@ -59,7 +59,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default/>
+		<default></default>
 		<enabled>eq(-1,true)</enabled>
 		<id>user</id>
 		<label>@30014</label>
@@ -67,7 +67,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default/>
+		<default></default>
 		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
 		<hidden>true</hidden>
 		<id>password</id>

--- a/python/main-classic/servers/oboom.xml
+++ b/python/main-classic/servers/oboom.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -35,14 +35,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_oboom.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/okru.xml
+++ b/python/main-classic/servers/okru.xml
@@ -44,14 +44,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_okru.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/onefichier.xml
+++ b/python/main-classic/servers/onefichier.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -41,14 +41,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<settings>
 		<default>false</default>
@@ -59,7 +59,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default/>
+		<default></default>
 		<enabled>eq(-1,true)</enabled>
 		<id>user</id>
 		<label>@30014</label>
@@ -67,7 +67,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default/>
+		<default></default>
 		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
 		<hidden>true</hidden>
 		<id>password</id>

--- a/python/main-classic/servers/openload.xml
+++ b/python/main-classic/servers/openload.xml
@@ -45,14 +45,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_openload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/pcloud.xml
+++ b/python/main-classic/servers/pcloud.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>07/05/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_pcloud.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/playwatch.xml
+++ b/python/main-classic/servers/playwatch.xml
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/c7LwCTc.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/playwire.xml
+++ b/python/main-classic/servers/playwire.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>07/05/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_playwire.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/powvideo.py
+++ b/python/main-classic/servers/powvideo.py
@@ -117,7 +117,7 @@ def decrypt(h):
     for c in range(len(h)):
         sig += [ord(h[c])]
 
-    k = "powvideoembedz"
+    k = "powvideoembedc"
     sec = []
     for c in range(len(k)):
         sec += [ord(k[c])]

--- a/python/main-classic/servers/powvideo.xml
+++ b/python/main-classic/servers/powvideo.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>8</version>
 	<changes>
 		<change>
 			<autor>Intel1</autor>
@@ -60,15 +59,16 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_powvideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>8</version>
 </server>

--- a/python/main-classic/servers/powvideo.xml
+++ b/python/main-classic/servers/powvideo.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>7</version>
+	<version>8</version>
 	<changes>
+		<change>
+			<autor>Intel1</autor>
+			<date>14/06/2017</date>
+			<description>Reparado por robalo</description>
+		</change>
 		<change>
 			<autor>Intel1</autor>
 			<date>09/06/2017</date>

--- a/python/main-classic/servers/rapidgator.xml
+++ b/python/main-classic/servers/rapidgator.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -36,14 +36,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_rapidgator.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/rapidvideo.xml
+++ b/python/main-classic/servers/rapidvideo.xml
@@ -44,14 +44,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_rapidvideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/raptu.xml
+++ b/python/main-classic/servers/raptu.xml
@@ -39,14 +39,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/quVK1j0.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/redirects.xml
+++ b/python/main-classic/servers/redirects.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>26/05/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -46,14 +46,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_servers\redirects.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/rutube.xml
+++ b/python/main-classic/servers/rutube.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -35,14 +35,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_rutube.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/sendvid.xml
+++ b/python/main-classic/servers/sendvid.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_sendvid.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/speedvideo.xml
+++ b/python/main-classic/servers/speedvideo.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_speedvideo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/spruto.xml
+++ b/python/main-classic/servers/spruto.xml
@@ -44,14 +44,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_spruto.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/stagevu.xml
+++ b/python/main-classic/servers/stagevu.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -42,14 +42,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_stagevu.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/stormo.xml
+++ b/python/main-classic/servers/stormo.xml
@@ -39,14 +39,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/mTYCw5E.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/streamango.xml
+++ b/python/main-classic/servers/streamango.xml
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/o8XR8fL.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/streamcloud.xml
+++ b/python/main-classic/servers/streamcloud.xml
@@ -5,7 +5,7 @@
 		<change>
 			<autor>Intel1</autor>
 			<date>09/03/2017</date>
-			<description>No detectaba &quot;archivo no encontrado&quot;</description>
+			<description>No detectaba"archivo no encontrado"</description>
 		</change>
 		<change>
 			<date>25/03/2016</date>
@@ -51,14 +51,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_streamcloud.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/streame.xml
+++ b/python/main-classic/servers/streame.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_streame.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/streaminto.xml
+++ b/python/main-classic/servers/streaminto.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -49,14 +49,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_streaminto.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/streamixcloud.xml
+++ b/python/main-classic/servers/streamixcloud.xml
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/NuD85Py.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/streamplay.py
+++ b/python/main-classic/servers/streamplay.py
@@ -94,7 +94,7 @@ def decrypt(h):
     for c in range(len(h)):
         sig += [ord(h[c])]
 
-    k = "streamplayembedz"
+    k = "streamplayembedc"
     sec = []
     for c in range(len(k)):
         sec += [ord(k[c])]

--- a/python/main-classic/servers/streamplay.xml
+++ b/python/main-classic/servers/streamplay.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>9</version>
+	<version>10</version>
 	<changes>
+		<change>
+			<autor>Intel1</autor>
+			<date>14/06/2017</date>
+			<description>Reparado por robalo</description>
+		</change>
 		<change>
 			<autor>Intel1</autor>
 			<date>09/06/2017</date>

--- a/python/main-classic/servers/streamplay.xml
+++ b/python/main-classic/servers/streamplay.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" ?>
 <server>
 	<active>true</active>
-	<version>10</version>
 	<changes>
 		<change>
 			<autor>Intel1</autor>
@@ -65,15 +64,16 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_streamplay.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>
+	<version>10</version>
 </server>

--- a/python/main-classic/servers/thevideome.xml
+++ b/python/main-classic/servers/thevideome.xml
@@ -8,7 +8,7 @@
 			<description>Reparado conector</description>
 		</change>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Primera versión</description>
 		</change>
@@ -39,14 +39,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_thevideome.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/thevideos.xml
+++ b/python/main-classic/servers/thevideos.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_thevideos.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/torrent.xml
+++ b/python/main-classic/servers/torrent.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -16,7 +16,7 @@
 			<url>\1</url>
 		</patterns>
 		<patterns>
-			<pattern>(magnet:\?xt=urn:[^&quot;]+)</pattern>
+			<pattern>(magnet:\?xt=urn:[^"]+)</pattern>
 			<url>\1</url>
 		</patterns>
 	</find_videos>
@@ -38,14 +38,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_torrent.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/tunepk.xml
+++ b/python/main-classic/servers/tunepk.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_tunepk.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/turbobit.xml
+++ b/python/main-classic/servers/turbobit.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -36,14 +36,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_turbobit.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/turbovideos.xml
+++ b/python/main-classic/servers/turbovideos.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_turbovideos.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/tusfiles.xml
+++ b/python/main-classic/servers/tusfiles.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>16/03/2017</date>
 			<description>Versión incial</description>
 		</change>
@@ -38,14 +38,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_tusfiles.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/tutv.xml
+++ b/python/main-classic/servers/tutv.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -12,7 +12,7 @@
 		<ignore_urls>
 		</ignore_urls>
 		<patterns>
-			<pattern>(http://(?:www.)?tu.tv[^&quot;]+)</pattern>
+			<pattern>(http://(?:www.)?tu.tv[^"]+)</pattern>
 			<url>\1</url>
 		</patterns>
 		<patterns>
@@ -38,14 +38,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_tutv.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/uploadedto.xml
+++ b/python/main-classic/servers/uploadedto.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -45,14 +45,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<settings>
 		<default>false</default>
@@ -63,7 +63,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default/>
+		<default></default>
 		<enabled>eq(-1,true)</enabled>
 		<id>user</id>
 		<label>@30014</label>
@@ -71,7 +71,7 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<default/>
+		<default></default>
 		<enabled>eq(-2,true)+!eq(-1,'')</enabled>
 		<hidden>true</hidden>
 		<id>password</id>

--- a/python/main-classic/servers/uptobox.xml
+++ b/python/main-classic/servers/uptobox.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -40,14 +40,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_uptobox.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/userporn.xml
+++ b/python/main-classic/servers/userporn.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -48,14 +48,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_userporn.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/userscloud.xml
+++ b/python/main-classic/servers/userscloud.xml
@@ -36,14 +36,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/u4W2DgA.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/veehd.xml
+++ b/python/main-classic/servers/veehd.xml
@@ -3,7 +3,7 @@
 	<active>false</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_veehd.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/veoh.xml
+++ b/python/main-classic/servers/veoh.xml
@@ -34,18 +34,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<id>favorites_servers_list</id>
-		<type>list</type>
-		<label>Incluir en lista de favoritos</label>
 		<default>100</default>
 		<enabled>true</enabled>
-		<visible>false</visible>
+		<id>favorites_servers_list</id>
+		<label>Incluir en lista de favoritos</label>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_veoh.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidabc.xml
+++ b/python/main-classic/servers/vidabc.xml
@@ -3,13 +3,13 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<autor>Intel1</autor>
 			<date>05/06/17</date>
 			<description>Detectado que el archivo se está procesando</description>
 		</change>
 		<change>
-			<autor/>
+			<autor></autor>
 			<autor>Intel1</autor>
 			<date>10/05/17</date>
 			<description>Reparado por robalo, yo solo lo subí al github</description>
@@ -46,14 +46,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidabc.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/videowood.xml
+++ b/python/main-classic/servers/videowood.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_videowood.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidgg.xml
+++ b/python/main-classic/servers/vidgg.xml
@@ -39,14 +39,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidgg.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidgot.xml
+++ b/python/main-classic/servers/vidgot.xml
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/tAI34bF.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidoza.xml
+++ b/python/main-classic/servers/vidoza.xml
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/YefcBBY.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidspot.xml
+++ b/python/main-classic/servers/vidspot.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>04/06/2016</date>
 			<description>Reparado, utiliza proxy en caso que salte el geobloqueo</description>
 		</change>
@@ -64,14 +64,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidspot.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidtodo.xml
+++ b/python/main-classic/servers/vidtodo.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>24/12/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidtodo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidtome.xml
+++ b/python/main-classic/servers/vidtome.xml
@@ -8,7 +8,7 @@
 			<description>Conector corregido</description>
 		</change>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -43,14 +43,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidtome.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidup.xml
+++ b/python/main-classic/servers/vidup.xml
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/sZvy8IC.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vidzi.xml
+++ b/python/main-classic/servers/vidzi.xml
@@ -43,14 +43,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vidzi.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vimeo.xml
+++ b/python/main-classic/servers/vimeo.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -36,14 +36,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vimeo.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vimpleru.xml
+++ b/python/main-classic/servers/vimpleru.xml
@@ -8,7 +8,7 @@
 			<description>Reparado por cambios</description>
 		</change>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión inicial</description>
 		</change>
@@ -39,14 +39,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vimpleru.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/vk.xml
+++ b/python/main-classic/servers/vk.xml
@@ -34,18 +34,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<id>favorites_servers_list</id>
-		<type>list</type>
-		<label>Incluir en lista de favoritos</label>
 		<default>100</default>
 		<enabled>true</enabled>
-		<visible>false</visible>
+		<id>favorites_servers_list</id>
+		<label>Incluir en lista de favoritos</label>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_vk.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/watchers.xml
+++ b/python/main-classic/servers/watchers.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>09/01/2017</date>
 			<description>Versión inicial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/WApzSMn.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/watchvideo.xml
+++ b/python/main-classic/servers/watchvideo.xml
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/vDev2I6.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/wholecloud.xml
+++ b/python/main-classic/servers/wholecloud.xml
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/yIAQurm.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/xvideos.xml
+++ b/python/main-classic/servers/xvideos.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_xvideos.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/yourupload.xml
+++ b/python/main-classic/servers/yourupload.xml
@@ -13,7 +13,7 @@
 			<description>Reparado y adaptado al uso de httptools</description>
 		</change>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión inicial</description>
 		</change>
@@ -49,14 +49,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_yourupload.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/youtube.xml
+++ b/python/main-classic/servers/youtube.xml
@@ -45,18 +45,18 @@
 		<visible>true</visible>
 	</settings>
 	<settings>
-		<id>favorites_servers_list</id>
-		<type>list</type>
-		<label>Incluir en lista de favoritos</label>
 		<default>100</default>
 		<enabled>true</enabled>
-		<visible>false</visible>
+		<id>favorites_servers_list</id>
+		<label>Incluir en lista de favoritos</label>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_youtube.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/youwatch.xml
+++ b/python/main-classic/servers/youwatch.xml
@@ -8,7 +8,7 @@
 			<description>Corregido conector</description>
 		</change>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>25/03/2016</date>
 			<description>Versión incial</description>
 		</change>
@@ -40,14 +40,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_youwatch.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/zippyshare.xml
+++ b/python/main-classic/servers/zippyshare.xml
@@ -41,14 +41,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://media.tvalacarta.info/servers/server_zippyshare.png</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>

--- a/python/main-classic/servers/zstream.xml
+++ b/python/main-classic/servers/zstream.xml
@@ -3,7 +3,7 @@
 	<active>true</active>
 	<changes>
 		<change>
-			<autor/>
+			<autor></autor>
 			<date>09/01/2017</date>
 			<description>Versión inicial</description>
 		</change>
@@ -34,14 +34,14 @@
 		<enabled>true</enabled>
 		<id>favorites_servers_list</id>
 		<label>Incluir en lista de favoritos</label>
-		<type>list</type>
-		<visible>false</visible>
 		<lvalues>No</lvalues>
 		<lvalues>1</lvalues>
 		<lvalues>2</lvalues>
 		<lvalues>3</lvalues>
 		<lvalues>4</lvalues>
 		<lvalues>5</lvalues>
+		<type>list</type>
+		<visible>false</visible>
 	</settings>
 	<thumbnail>http://i.imgur.com/UJMfMZJ.png?1</thumbnail>
 	<update_url>https://raw.githubusercontent.com/tvalacarta/pelisalacarta/master/python/main-classic/servers/</update_url>


### PR DESCRIPTION
He pasado todos los xmls de los servidores por un script que tengo echo para 'normalizarlos' corregir errores y comprobar que los datos estén bien y ordenarlos, ya que se había introducido un error en el PR #795 con algunos caracteres.

He incorporado también en este PR el PR #797 para normalizar también los xmls subidos en ese pr sin conflictos ya que también había un error en filescdn.xml