### PR TITLE
Fix #801, fix animeflv lista episodios

### DIFF
--- a/python/main-classic/channels/animeflv.py
+++ b/python/main-classic/channels/animeflv.py
@@ -223,27 +223,48 @@ def episodios(item):
     if item.plot == "":
         item.plot = scrapertools.find_single_match(data, 'Description[^>]+><p>(.*?)</p>')
 
-    data = scrapertools.find_single_match(data, '<ul class="ListCaps">(.*?)</ul>')
     matches = re.compile('href="([^"]+)"><figure><img class="[^"]+" data-original="([^"]+)".+?</h3>'
                          '<p>(.*?)</p>', re.DOTALL).findall(data)
 
-    for url, thumb, title in matches:
-        title = title.strip()
-        url = urlparse.urljoin(item.url, url)
-        # thumbnail = item.thumbnail
+    if matches:
+        for url, thumb, title in matches:
+            title = title.strip()
+            url = urlparse.urljoin(item.url, url)
+            # thumbnail = item.thumbnail
 
-        try:
-            episode = int(scrapertools.find_single_match(title, "^.+?\s(\d+)$"))
-        except ValueError:
-            season = 1
-            episode = 1
-        else:
-            season, episode = renumbertools.numbered_for_tratk(item.channel, item.show, 1, episode)
+            try:
+                episode = int(scrapertools.find_single_match(title, "^.+?\s(\d+)$"))
+            except ValueError:
+                season = 1
+                episode = 1
+            else:
+                season, episode = renumbertools.numbered_for_tratk(item.channel, item.show, 1, episode)
 
-        title = "%s: %sx%s" % (item.title, season, str(episode).zfill(2))
+            title = "%s: %sx%s" % (item.title, season, str(episode).zfill(2))
 
-        itemlist.append(item.clone(action="findvideos", title=title, url=url, thumbnail=thumb, fulltitle=title,
-                                   fanart=item.thumbnail, contentType="episode"))
+            itemlist.append(item.clone(action="findvideos", title=title, url=url, thumbnail=thumb, fulltitle=title,
+                                       fanart=item.thumbnail, contentType="episode"))
+    else:
+        # no hay thumbnail
+        matches = re.compile('<a href="(/ver/[^"]+)"[^>]+>(.*?)<', re.DOTALL).findall(data)
+
+        for url, title in matches:
+            title = title.strip()
+            url = urlparse.urljoin(item.url, url)
+            thumb = item.thumbnail
+
+            try:
+                episode = int(scrapertools.find_single_match(title, "^.+?\s(\d+)$"))
+            except ValueError:
+                season = 1
+                episode = 1
+            else:
+                season, episode = renumbertools.numbered_for_tratk(item.channel, item.show, 1, episode)
+
+            title = "%s: %sx%s" % (item.title, season, str(episode).zfill(2))
+
+            itemlist.append(item.clone(action="findvideos", title=title, url=url, thumbnail=thumb, fulltitle=title,
+                                       fanart=item.thumbnail, contentType="episode"))
 
     return itemlist
 

--- a/python/main-classic/channels/biblioteca.py
+++ b/python/main-classic/channels/biblioteca.py
@@ -534,8 +534,8 @@ def mark_season_as_watched(item):
     # logger.debug("item:\n" + item.tostring('\n'))
 
     # Obtener el diccionario de episodios marcados
-    tvshow_nfo_file = filetools.join(item.path, 'tvshow.nfo')
-    head_nfo, it = library.read_nfo(tvshow_nfo_file)
+    tvshow_path = filetools.join(item.path, 'tvshow.nfo')
+    head_nfo, it = library.read_nfo(tvshow_path)
     if not hasattr(it, 'library_playcounts'):
         it.library_playcounts = {}
 
@@ -568,7 +568,7 @@ def mark_season_as_watched(item):
             it = check_tvshow_playcount(it, item.contentSeason)
 
         # Guardamos los cambios en tvshow.nfo
-        filetools.write(tvshow_nfo_file, head_nfo + it.tojson())
+        filetools.write(tvshow_path, head_nfo + it.tojson())
         item.infoLabels['playcount'] = item.playcount
 
         if config.is_xbmc():

--- a/python/main-classic/channels/biblioteca.py
+++ b/python/main-classic/channels/biblioteca.py
@@ -5,6 +5,7 @@
 # http://blog.tvalacarta.info/plugin-xbmc/pelisalacarta/
 # ------------------------------------------------------------
 
+import glob
 import os
 
 from core import config
@@ -39,55 +40,53 @@ def peliculas(item):
     logger.info()
     itemlist = []
 
-    for raiz, subcarpetas, ficheros in filetools.walk(library.MOVIES_PATH):
-        for f in ficheros:
-            if f.endswith(".nfo"):
-                nfo_path = filetools.join(raiz, f)
-                head_nfo, new_item = library.read_nfo(nfo_path)
+    for f in glob.glob(filetools.join(library.MOVIES_PATH, u'/*/*.nfo')):
+        nfo_path = f
+        head_nfo, new_item = library.read_nfo(nfo_path)
 
-                new_item.nfo = nfo_path
-                new_item.path = raiz
-                new_item.thumbnail = new_item.contentThumbnail
-                new_item.text_color = "blue"
+        new_item.nfo = nfo_path
+        # new_item.path = raiz
+        new_item.thumbnail = new_item.contentThumbnail
+        new_item.text_color = "blue"
 
-                if not filetools.exists(filetools.join(new_item.path, filetools.basename(new_item.strm_path))):
-                    # Si se ha eliminado el strm desde la bilbioteca de kodi, no mostrarlo
-                    continue
+        if not filetools.exists(filetools.join(library.MOVIES_PATH, new_item.strm_path)):
+            # Si se ha eliminado el strm desde la bilbioteca de kodi, no mostrarlo
+            continue
 
-                # Menu contextual: Marcar como visto/no visto
-                visto = new_item.library_playcounts.get(os.path.splitext(f)[0], 0)
-                new_item.infoLabels["playcount"] = visto
-                if visto > 0:
-                    texto_visto = "Marcar película como no vista"
-                    contador = 0
-                else:
-                    texto_visto = "Marcar película como vista"
-                    contador = 1
+        # Menu contextual: Marcar como visto/no visto
+        visto = new_item.library_playcounts.get(os.path.splitext(f)[0], 0)
+        new_item.infoLabels["playcount"] = visto
+        if visto > 0:
+            texto_visto = "Marcar película como no vista"
+            contador = 0
+        else:
+            texto_visto = "Marcar película como vista"
+            contador = 1
 
-                # Menu contextual: Eliminar serie/canal
-                num_canales = len(new_item.library_urls)
-                if "descargas" in new_item.library_urls:
-                    num_canales -= 1
-                if num_canales > 1:
-                    texto_eliminar = "Eliminar película/canal"
-                    multicanal = True
-                else:
-                    texto_eliminar = "Eliminar esta película"
-                    multicanal = False
+        # Menu contextual: Eliminar serie/canal
+        num_canales = len(new_item.library_urls)
+        if "descargas" in new_item.library_urls:
+            num_canales -= 1
+        if num_canales > 1:
+            texto_eliminar = "Eliminar película/canal"
+            multicanal = True
+        else:
+            texto_eliminar = "Eliminar esta película"
+            multicanal = False
 
-                new_item.context = [{"title": texto_visto,
-                                     "action": "mark_content_as_watched",
-                                     "channel": "biblioteca",
-                                     "playcount": contador},
-                                    {"title": texto_eliminar,
-                                     "action": "eliminar",
-                                     "channel": "biblioteca",
-                                     "multicanal": multicanal}]
-                # ,{"title": "Cambiar contenido (PENDIENTE)",
-                # "action": "",
-                # "channel": "biblioteca"}]
-                # logger.debug("new_item: " + new_item.tostring('\n'))
-                itemlist.append(new_item)
+        new_item.context = [{"title": texto_visto,
+                             "action": "mark_content_as_watched",
+                             "channel": "biblioteca",
+                             "playcount": contador},
+                            {"title": texto_eliminar,
+                             "action": "eliminar",
+                             "channel": "biblioteca",
+                             "multicanal": multicanal}]
+        # ,{"title": "Cambiar contenido (PENDIENTE)",
+        # "action": "",
+        # "channel": "biblioteca"}]
+        # logger.debug("new_item: " + new_item.tostring('\n'))
+        itemlist.append(new_item)
 
     return sorted(itemlist, key=lambda it: it.title.lower())
 
@@ -97,74 +96,73 @@ def series(item):
     itemlist = []
 
     # Obtenemos todos los tvshow.nfo de la biblioteca de SERIES recursivamente
-    for raiz, subcarpetas, ficheros in filetools.walk(library.TVSHOWS_PATH):
-        for f in ficheros:
-            if f == "tvshow.nfo":
-                tvshow_path = filetools.join(raiz, f)
-                # logger.debug(tvshow_path)
-                head_nfo, item_tvshow = library.read_nfo(tvshow_path)
-                item_tvshow.title = item_tvshow.contentTitle
-                item_tvshow.path = raiz
-                item_tvshow.nfo = tvshow_path
+    for f in glob.glob(filetools.join(library.TVSHOWS_PATH, u'/*/tvshow.nfo')):
+        # logger.debug("file es %s" % f)
 
-                # Menu contextual: Marcar como visto/no visto
-                visto = item_tvshow.library_playcounts.get(item_tvshow.contentTitle, 0)
-                item_tvshow.infoLabels["playcount"] = visto
-                if visto > 0:
-                    texto_visto = "Marcar serie como no vista"
-                    contador = 0
-                else:
-                    texto_visto = "Marcar serie como vista"
-                    contador = 1
+        head_nfo, item_tvshow = library.read_nfo(f)
+        item_tvshow.title = item_tvshow.contentTitle
+        item_tvshow.path = filetools.join(library.TVSHOWS_PATH, item_tvshow.path)
+        item_tvshow.nfo = f
 
-                # Menu contextual: Buscar automáticamente nuevos episodios o no
-                if item_tvshow.active and int(item_tvshow.active) > 0:
-                    texto_update = "Buscar automáticamente nuevos episodios: Desactivar"
-                    value = 0
-                    item_tvshow.text_color = "green"
-                else:
-                    texto_update = "Buscar automáticamente nuevos episodios: Activar"
-                    value = 1
-                    item_tvshow.text_color = "0xFFDF7401"
+        # Menu contextual: Marcar como visto/no visto
+        visto = item_tvshow.library_playcounts.get(item_tvshow.contentTitle, 0)
+        item_tvshow.infoLabels["playcount"] = visto
+        if visto > 0:
+            texto_visto = "Marcar serie como no vista"
+            contador = 0
+        else:
+            texto_visto = "Marcar serie como vista"
+            contador = 1
 
-                # Menu contextual: Eliminar serie/canal
-                num_canales = len(item_tvshow.library_urls)
-                if "descargas" in item_tvshow.library_urls:
-                    num_canales -= 1
-                if num_canales > 1:
-                    texto_eliminar = "Eliminar serie/canal"
-                    multicanal = True
-                else:
-                    texto_eliminar = "Eliminar esta serie"
-                    multicanal = False
+        # Menu contextual: Buscar automáticamente nuevos episodios o no
+        if item_tvshow.active and int(item_tvshow.active) > 0:
+            texto_update = "Buscar automáticamente nuevos episodios: Desactivar"
+            value = 0
+            item_tvshow.text_color = "green"
+        else:
+            texto_update = "Buscar automáticamente nuevos episodios: Activar"
+            value = 1
+            item_tvshow.text_color = "0xFFDF7401"
 
-                item_tvshow.context = [{"title": texto_visto,
-                                        "action": "mark_content_as_watched",
-                                        "channel": "biblioteca",
-                                        "playcount": contador},
-                                       {"title": texto_update,
-                                        "action": "mark_tvshow_as_updatable",
-                                        "channel": "biblioteca",
-                                        "active": value},
-                                       {"title": texto_eliminar,
-                                        "action": "eliminar",
-                                        "channel": "biblioteca",
-                                        "multicanal": multicanal},
-                                       {"title": "Buscar nuevos episodios ahora",
-                                        "action": "update_serie",
-                                        "channel": "biblioteca"}]
-                # ,{"title": "Cambiar contenido (PENDIENTE)",
-                # "action": "",
-                # "channel": "biblioteca"}]
+        # Menu contextual: Eliminar serie/canal
+        num_canales = len(item_tvshow.library_urls)
+        if "descargas" in item_tvshow.library_urls:
+            num_canales -= 1
+        if num_canales > 1:
+            texto_eliminar = "Eliminar serie/canal"
+            multicanal = True
+        else:
+            texto_eliminar = "Eliminar esta serie"
+            multicanal = False
 
-                # logger.debug("item_tvshow:\n" + item_tvshow.tostring('\n'))
-                itemlist.append(item_tvshow)
+        item_tvshow.context = [{"title": texto_visto,
+                                "action": "mark_content_as_watched",
+                                "channel": "biblioteca",
+                                "playcount": contador},
+                               {"title": texto_update,
+                                "action": "mark_tvshow_as_updatable",
+                                "channel": "biblioteca",
+                                "active": value},
+                               {"title": texto_eliminar,
+                                "action": "eliminar",
+                                "channel": "biblioteca",
+                                "multicanal": multicanal},
+                               {"title": "Buscar nuevos episodios ahora",
+                                "action": "update_serie",
+                                "channel": "biblioteca"}]
+        # ,{"title": "Cambiar contenido (PENDIENTE)",
+        # "action": "",
+        # "channel": "biblioteca"}]
+
+        # logger.debug("item_tvshow:\n" + item_tvshow.tostring('\n'))
+        itemlist.append(item_tvshow)
 
     if itemlist:
         itemlist = sorted(itemlist, key=lambda it: it.title.lower())
 
         itemlist.append(Item(channel=item.channel, action="update_biblio", thumbnail=item.thumbnail,
                              title="Buscar nuevos episodios y actualizar biblioteca", folder=False))
+
     return itemlist
 
 
@@ -174,22 +172,31 @@ def get_temporadas(item):
     itemlist = []
     dict_temp = {}
 
-    raiz, carpetas_series, ficheros = filetools.walk(item.path).next()
-
     # Menu contextual: Releer tvshow.nfo
     head_nfo, item_nfo = library.read_nfo(item.nfo)
+
+    # Miramos las temporadas que estén marcadas como vistas
+    if not hasattr(item_nfo, 'library_playcounts'):
+        item_nfo.library_playcounts = {}
 
     if config.get_setting("no_pile_on_seasons", "biblioteca") == 2:  # Siempre
         return get_episodios(item)
 
-    for f in ficheros:
-        if f.endswith('.json'):
-            season = f.split('x')[0]
-            dict_temp[season] = "Temporada %s" % season
+    for f in glob.glob1(item.path, u'*.json'):
+        season = f.split('x')[0]
+        dict_temp[season] = "Temporada %s" % season
 
     if config.get_setting("no_pile_on_seasons", "biblioteca") == 1 and len(dict_temp) == 1:  # Sólo si hay una temporada
         return get_episodios(item)
     else:
+
+        # TODO mostrar los episodios de la unica temporada "no vista", en vez de mostrar el Item "temporada X" previo
+        # si está marcado "ocultar los vistos" en el skin, se ejecutaria esto
+        #     se comprueba cada temporada en dict_temp si está visto.
+        #          si hay una sola temporada y no_pile_on_seasons == 1, se devuelve get(episodios)
+        #          si está todo visto, hacemos como actualmente <-- el else no se hace nada.. CREO
+        # if config.get_setting("no_pile_on_seasons", "biblioteca") == 1 and len(dict_temp_Visible) == 1:  # Sólo si hay una temporada
+
         # Creamos un item por cada temporada
         for season, title in dict_temp.items():
             new_item = item.clone(action="get_episodios", title=title, contentSeason=season,
@@ -228,58 +235,54 @@ def get_episodios(item):
     # logger.debug("item:\n" + item.tostring('\n'))
     itemlist = []
 
-    # Obtenemos los archivos de los episodios
-    raiz, carpetas_series, ficheros = filetools.walk(item.path).next()
-
     # Menu contextual: Releer tvshow.nfo
     head_nfo, item_nfo = library.read_nfo(item.nfo)
 
     # Crear un item en la lista para cada strm encontrado
-    for i in ficheros:
-        if i.endswith('.strm'):
-            season_episode = scrapertools.get_season_and_episode(i)
-            if not season_episode:
-                # El fichero no incluye el numero de temporada y episodio
-                continue
-            season, episode = season_episode.split("x")
-            # Si hay q filtrar por temporada, ignoramos los capitulos de otras temporadas
-            if item.filtrar_season and int(season) != int(item.contentSeason):
-                continue
+    for f in glob.glob1(item.path, u'*.strm'):
+        season_episode = scrapertools.get_season_and_episode(f)
+        if not season_episode:
+            # El fichero no incluye el numero de temporada y episodio
+            continue
+        season, episode = season_episode.split("x")
+        # Si hay q filtrar por temporada, ignoramos los capitulos de otras temporadas
+        if item.filtrar_season and int(season) != int(item.contentSeason):
+            continue
 
-            # Obtener los datos del season_episode.nfo
-            nfo_path = filetools.join(raiz, i).replace('.strm', '.nfo')
-            head_nfo, epi = library.read_nfo(nfo_path)
+        # Obtener los datos del season_episode.nfo
+        nfo_path = filetools.join(item.path, f).replace('.strm', '.nfo')
+        head_nfo, epi = library.read_nfo(nfo_path)
 
-            # Fijar el titulo del capitulo si es posible
-            if epi.contentTitle:
-                title_episodie = epi.contentTitle.strip()
-            else:
-                title_episodie = "Temporada %s Episodio %s" % \
-                                 (epi.contentSeason, str(epi.contentEpisodeNumber).zfill(2))
+        # Fijar el titulo del capitulo si es posible
+        if epi.contentTitle:
+            title_episodie = epi.contentTitle.strip()
+        else:
+            title_episodie = "Temporada %s Episodio %s" % \
+                             (epi.contentSeason, str(epi.contentEpisodeNumber).zfill(2))
 
-            epi.contentTitle = "%sx%s" % (epi.contentSeason, str(epi.contentEpisodeNumber).zfill(2))
-            epi.title = "%sx%s - %s" % (epi.contentSeason, str(epi.contentEpisodeNumber).zfill(2), title_episodie)
+        epi.contentTitle = "%sx%s" % (epi.contentSeason, str(epi.contentEpisodeNumber).zfill(2))
+        epi.title = "%sx%s - %s" % (epi.contentSeason, str(epi.contentEpisodeNumber).zfill(2), title_episodie)
 
-            if item_nfo.library_filter_show:
-                epi.library_filter_show = item_nfo.library_filter_show
+        if item_nfo.library_filter_show:
+            epi.library_filter_show = item_nfo.library_filter_show
 
-            # Menu contextual: Marcar episodio como visto o no
-            visto = item_nfo.library_playcounts.get(season_episode, 0)
-            epi.infoLabels["playcount"] = visto
-            if visto > 0:
-                texto = "Marcar episodio como no visto"
-                value = 0
-            else:
-                texto = "Marcar episodio como visto"
-                value = 1
-            epi.context = [{"title": texto,
-                            "action": "mark_content_as_watched",
-                            "channel": "biblioteca",
-                            "playcount": value,
-                            "nfo": item.nfo}]
+        # Menu contextual: Marcar episodio como visto o no
+        visto = item_nfo.library_playcounts.get(season_episode, 0)
+        epi.infoLabels["playcount"] = visto
+        if visto > 0:
+            texto = "Marcar episodio como no visto"
+            value = 0
+        else:
+            texto = "Marcar episodio como visto"
+            value = 1
+        epi.context = [{"title": texto,
+                        "action": "mark_content_as_watched",
+                        "channel": "biblioteca",
+                        "playcount": value,
+                        "nfo": item.nfo}]
 
-            # logger.debug("epi:\n" + epi.tostring('\n'))
-            itemlist.append(epi)
+        # logger.debug("epi:\n" + epi.tostring('\n'))
+        itemlist.append(epi)
 
     return sorted(itemlist, key=lambda it: (int(it.contentSeason), int(it.contentEpisodeNumber)))
 
@@ -296,7 +299,7 @@ def findvideos(item):
         logger.debug("No se pueden buscar videos por falta de parametros")
         return []
 
-    content_title = filter(lambda c: c not in ":*?<>|\/", item.contentTitle).strip().lower()
+    content_title = filter(lambda c: c not in ":*?<>|\/", item.contentTitle.strip().lower())
 
     if item.contentType == 'movie':
         item.strm_path = filetools.join(library.MOVIES_PATH, item.strm_path)
@@ -334,7 +337,7 @@ def findvideos(item):
             num_canales -= 1
 
     filtro_canal = ''
-    if num_canales > 1 and config.get_setting("ask_channel", "biblioteca") == True:
+    if num_canales > 1 and config.get_setting("ask_channel", "biblioteca"):
         opciones = ["Mostrar solo los enlaces de %s" % k.capitalize() for k in list_canales.keys()]
         opciones.insert(0, "Mostrar todos los enlaces")
         if item_local:
@@ -376,15 +379,16 @@ def findvideos(item):
 
             # Ejecutamos find_videos, del canal o común
             if hasattr(channel, 'findvideos'):
+                from core import servertools
                 list_servers = getattr(channel, 'findvideos')(item_json)
                 list_servers = servertools.filter_servers(list_servers)
             else:
                 from core import servertools
                 list_servers = servertools.find_video_items(item_json)
-        except Exception as ex:
+        except Exception, ex:
             logger.error("Ha fallado la funcion findvideos para el canal %s" % nom_canal)
-            template = "An exception of type {0} occured. Arguments:\n{1!r}"
-            message = template.format(type(ex).__name__, ex.args)
+            template = "An exception of type %s occured. Arguments:\n{1!r}"
+            message = template % (type(ex).__name__, ex.args)
             logger.error(message)
 
         # Cambiarle el titulo a los servers añadiendoles el nombre del canal delante y
@@ -530,28 +534,25 @@ def mark_season_as_watched(item):
     # logger.debug("item:\n" + item.tostring('\n'))
 
     # Obtener el diccionario de episodios marcados
-    f = filetools.join(item.path, 'tvshow.nfo')
-    head_nfo, it = library.read_nfo(f)
+    tvshow_nfo_file = filetools.join(item.path, 'tvshow.nfo')
+    head_nfo, it = library.read_nfo(tvshow_nfo_file)
     if not hasattr(it, 'library_playcounts'):
         it.library_playcounts = {}
 
-    # Obtenemos los archivos de los episodios
-    raiz, carpetas_series, ficheros = filetools.walk(item.path).next()
-
     # Marcamos cada uno de los episodios encontrados de esta temporada
     episodios_marcados = 0
-    for i in ficheros:
-        if i.endswith(".strm"):
-            season_episode = scrapertools.get_season_and_episode(i)
-            if not season_episode:
-                # El fichero no incluye el numero de temporada y episodio
-                continue
-            season, episode = season_episode.split("x")
+    for f in glob.glob1(item.path, u'*.strm'):
+        # if f.endswith(".strm"):
+        season_episode = scrapertools.get_season_and_episode(f)
+        if not season_episode:
+            # El fichero no incluye el numero de temporada y episodio
+            continue
+        season, episode = season_episode.split("x")
 
-            if int(item.contentSeason) == -1 or int(season) == int(item.contentSeason):
-                name_file = os.path.splitext(os.path.basename(i))[0]
-                it.library_playcounts[name_file] = item.playcount
-                episodios_marcados += 1
+        if int(item.contentSeason) == -1 or int(season) == int(item.contentSeason):
+            name_file = os.path.splitext(os.path.basename(f))[0]
+            it.library_playcounts[name_file] = item.playcount
+            episodios_marcados += 1
 
     if episodios_marcados:
         if int(item.contentSeason) == -1:
@@ -567,7 +568,7 @@ def mark_season_as_watched(item):
             it = check_tvshow_playcount(it, item.contentSeason)
 
         # Guardamos los cambios en tvshow.nfo
-        filetools.write(f, head_nfo + it.tojson())
+        filetools.write(tvshow_nfo_file, head_nfo + it.tojson())
         item.infoLabels['playcount'] = item.playcount
 
         if config.is_xbmc():

--- a/python/main-classic/channels/configuracion.py
+++ b/python/main-classic/channels/configuracion.py
@@ -868,10 +868,9 @@ def overwrite_tools(item):
         heading = 'Sobrescribiendo biblioteca....'
         p_dialog = platformtools.dialog_progress_bg('pelisalacarta', heading)
         p_dialog.update(0, '')
-        show_list = []
 
-        for path, folders, files in filetools.walk(library.TVSHOWS_PATH):
-            show_list.extend([filetools.join(path, f) for f in files if f == "tvshow.nfo"])
+        import glob
+        show_list = glob.glob(filetools.join(library.TVSHOWS_PATH, u'/*/tvshow.nfo'))
 
         if show_list:
             t = float(100) / len(show_list)

--- a/python/main-classic/core/library.py
+++ b/python/main-classic/core/library.py
@@ -27,15 +27,15 @@
 
 import errno
 import math
+import os
 
 from core import config
 from core import filetools
 from core import logger
-from core import scrapertools
 from core import scraper
+from core import scrapertools
 from core.item import Item
 from platformcode import platformtools
-
 
 FOLDER_MOVIES = config.get_setting("folder_movies")
 FOLDER_TVSHOWS = config.get_setting("folder_tvshows")
@@ -149,13 +149,14 @@ def save_library_movie(item):
 
     base_name = unicode(filetools.validate_path(base_name.replace('/', '-')), "utf8").lower().encode("utf8")
 
-    for raiz, subcarpetas, ficheros in filetools.walk(MOVIES_PATH):
-        for c in subcarpetas:
-            code = scrapertools.find_single_match(c, '\[(.*?)\]')
-            if code and code in item.infoLabels['code']:
-                path = filetools.join(raiz, c)
-                _id = code
-                break
+    subcarpetas = os.listdir(MOVIES_PATH)
+
+    for c in subcarpetas:
+        code = scrapertools.find_single_match(c, '\[(.*?)\]')
+        if code and code in item.infoLabels['code']:
+            path = c
+            _id = code
+            break
 
     if not path:
         # Crear carpeta
@@ -269,13 +270,14 @@ def save_library_tvshow(item, episodelist):
 
     base_name = unicode(filetools.validate_path(base_name.replace('/', '-')), "utf8").lower().encode("utf8")
 
-    for raiz, subcarpetas, ficheros in filetools.walk(TVSHOWS_PATH):
-        for c in subcarpetas:
-            code = scrapertools.find_single_match(c, '\[(.*?)\]')
-            if code and code in item.infoLabels['code']:
-                path = filetools.join(raiz, c)
-                _id = code
-                break
+    subcarpetas = os.listdir(TVSHOWS_PATH)
+
+    for c in subcarpetas:
+        code = scrapertools.find_single_match(c, '\[(.*?)\]')
+        if code and code in item.infoLabels['code']:
+            path = c
+            _id = code
+            break
 
     if not path:
         path = filetools.join(TVSHOWS_PATH, ("%s [%s]" % (base_name, _id)).strip())
@@ -285,7 +287,6 @@ def save_library_tvshow(item, episodelist):
         except OSError, exception:
             if exception.errno != errno.EEXIST:
                 raise
-
 
     tvshow_path = filetools.join(path, "tvshow.nfo")
     if not filetools.exists(tvshow_path):

--- a/python/main-classic/core/library.py
+++ b/python/main-classic/core/library.py
@@ -371,7 +371,7 @@ def save_library_episodes(path, episodelist, serie, silent=False, overwrite=True
     news_in_playcounts = {}
 
     # Listamos todos los ficheros de la serie, asi evitamos tener que comprobar si existe uno por uno
-    raiz, carpetas_series, ficheros = filetools.walk(path).next()
+    ficheros = os.listdir(path)
     ficheros = [filetools.join(path, f) for f in ficheros]
 
     # Silent es para no mostrar progreso (para library_service)
@@ -403,7 +403,6 @@ def save_library_episodes(path, episodelist, serie, silent=False, overwrite=True
     for i, e in enumerate(scraper.sort_episode_list(new_episodelist)):
         if not silent:
             p_dialog.update(int(math.ceil((i + 1) * t)), 'Añadiendo episodio...', e.title)
-
 
         season_episode = "%sx%s" % (e.contentSeason, str(e.contentEpisodeNumber).zfill(2))
         strm_path = filetools.join(path, "%s.strm" % season_episode)


### PR DESCRIPTION
# Fix #801
Revisada velocidad en lo referente a obtener archivos, carpetas de la biblioteca, tanto para películas como series.

Como se sabe la estructura de datos, no hace falta usar el método walk, de hecho no hace falta búsqueda recursiva, solo listados de un directorio o subdirectorio, por lo que se ha mejorado bastante el tiempo de obtención de estos datos.
# Fix animeflv
Corrección en el listado de episodios para algunos casos.